### PR TITLE
fix: 修复 OneAPI 渠道 panic 及完善错误处理机制

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,37 @@ docker compose up -d
 
 ### 🛠️ 源码运行
 
+**环境要求：**
+- Go 1.24.4
+- Node.js 18+
+- npm 或 pnpm
+
 ```bash
 # 克隆项目
 git clone https://github.com/bestruirui/octopus.git
-
-# 进入目录
 cd octopus
 
-# 启动服务
-go run main.go start
+# 1. 构建前端
+cd web
+
+# 使用 npm
+npm install
+npm run build
+
+# 或者使用 pnpm
+pnpm install
+pnpm run build
+
+cd ..
+
+# 2. 移动前端产物到 static 目录
+mv web/out static/
+
+# 3. 启动后端服务
+go run . start
 ```
+
+> 💡 **提示**：前端构建产物会被嵌入到 Go 二进制文件中，所以必须先构建前端再启动后端。
 
 ### 🔐 默认账户
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -91,10 +91,18 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 		internalRequest.Model = item.ModelName
 		metrics.SetChannel(channel.ID, channel.Name, item.ModelName)
 
+		outAdapter := outbound.Get(channel.Type)
+		if outAdapter == nil {
+			log.Warnf("unsupported channel type: %d for channel: %s", channel.Type, channel.Name)
+			lastErr = fmt.Errorf("unsupported channel type: %d", channel.Type)
+			item = b.Next(group.Items, item)
+			continue
+		}
+
 		rc := &relayContext{
 			c:               c,
 			inAdapter:       inAdapter,
-			outAdapter:      outbound.Get(channel.Type),
+			outAdapter:      outAdapter,
 			internalRequest: internalRequest,
 			channel:         channel,
 			metrics:         metrics,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,15 @@ func Start() error {
 	}
 
 	r := gin.New()
+	r.Use(gin.CustomRecovery(func(c *gin.Context, recovered interface{}) {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": gin.H{
+				"message": "internal server error",
+				"type":    "server_error",
+			},
+		})
+		c.Abort()
+	}))
 
 	if conf.IsDebug() {
 		r.Use(middleware.Cors())


### PR DESCRIPTION
- 注册 OneAPI 出站类型处理器，修复调用 OneAPI 渠道时的空指针 panic
- 添加 outAdapter nil 检查，跳过不支持的渠道类型并尝试下一个
- 使用 gin.CustomRecovery 替代默认 Recovery，确保 panic 时返回 JSON 错误响应
- 完善 README.md 源码运行文档，补充前端构建步骤