### PR TITLE
[Fix] 修复Gemini渠道缺失的图像类型image_url内容的转换

### DIFF
--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -158,9 +158,11 @@ func convertLLMToGeminiRequest(request *model.InternalLLMRequest) *model.GeminiG
 				for _, part := range msg.Content.MultipleContent {
 					switch part.Type {
 					case "text":
-						content.Parts = append(content.Parts, &model.GeminiPart{
-							Text: *part.Text,
-						})
+						if part.Text != nil {
+							content.Parts = append(content.Parts, &model.GeminiPart{
+								Text: *part.Text,
+							})
+						}
 					case "image_url":
 						// get mime type from url extension
 						dataurl := xurl.ParseDataURL(part.ImageURL.URL)


### PR DESCRIPTION
抱歉之前的PR忘记了对图像输入的转换，现在补上了

- 添加了对MultipleContent的转化
- 改进Gemini使用量元数据到内部使用量结构的映射，现在`completion_tokens_details`这个属性能正常显示信息了


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Gemini support for multimodal user inputs (text + image_url via inline base64), maps response format/modalities and safety settings, and enriches usage token details.
> 
> - **Gemini transformer (`internal/transformer/outbound/gemini/messages.go`)**:
>   - **Multimodal inputs**:
>     - Parse `user` message `MultipleContent`, handling `text` and `image_url` (data URLs -> `InlineData` with inferred `MimeType` and base64 `Data`).
>   - **Generation config mapping**:
>     - Map `ResponseFormat` to `GenerationConfig.ResponseMimeType` (json/text) and pass through `Modalities` to `ResponseModalities`.
>     - Load `SafetySettings` from `TransformerMetadata["gemini_safety_settings"]`.
>   - **Usage details**:
>     - Populate `usage.PromptTokensDetails.CachedTokens` from `CachedContentTokenCount`.
>     - Populate `usage.CompletionTokensDetails.ReasoningTokens` from `ThoughtsTokenCount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f66e8f85f814d72c83fdbf07ddc95cdd498da9ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->