### PR TITLE
fix(task): 修复定时任务间隔为0时panic的问题

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -25,6 +25,12 @@ var (
 // Register 注册一个定时任务
 // runOnStart: 是否在启动时立即执行一次
 func Register(name string, interval time.Duration, runOnStart bool, fn func()) {
+	// 如果间隔为0或负数，跳过注册（禁用该任务）
+	if interval <= 0 {
+		log.Infof("task %s disabled (interval: %v)", name, interval)
+		return
+	}
+
 	tasksMu.Lock()
 	defer tasksMu.Unlock()
 
@@ -77,6 +83,12 @@ func RUN() {
 }
 
 func runTask(entry *taskEntry) {
+	// 防御性检查：间隔必须大于0
+	if entry.interval <= 0 {
+		log.Warnf("task %s has non-positive interval, skipping", entry.name)
+		return
+	}
+
 	// 根据配置决定是否在启动时立即执行
 	if entry.runOnStart {
 		go entry.fn()


### PR DESCRIPTION
当在页面上设置自动更新价格等任务的间隔时间为0，或者 model_info_update_interval 或 sync_llm_interval 设置为 0 时， time.NewTicker(0) 会触发 panic: non-positive interval for NewTicker

修复方案：
- 在 Register 函数中添加检查，间隔 ≤ 0 时跳过任务注册并记录日志
- 在 runTask 函数中添加防御性检查，避免无效间隔的任务被执行

这也将允许用户通过将更新间隔设置为 0 来禁用自动更新任务。