### PR TITLE
fix: 修复设置页面下拉框文字显示不全问题

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *, html.dark *));
 
 :root {
   --background: oklch(0.9331 0.0081 98.8844);
@@ -58,7 +58,7 @@
   --spacing: 0.25rem;
 }
 
-.dark {
+html.dark, .dark {
   --background: oklch(0.2809 0.0264 153.4040);
   --foreground: oklch(0.9200 0.0104 81.7947);
   --card: oklch(0.3196 0.0217 150.3385);

--- a/web/src/components/modules/setting/Appearance.tsx
+++ b/web/src/components/modules/setting/Appearance.tsx
@@ -25,27 +25,21 @@ export function SettingAppearance() {
                     <span className="text-sm font-medium">{t('theme.label')}</span>
                 </div>
                 <Select value={theme} onValueChange={setTheme}>
-                    <SelectTrigger className="w-28 rounded-xl">
+                    <SelectTrigger className="w-36 rounded-xl">
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
                         <SelectItem value="light">
-                            <div className="flex items-center gap-2">
-                                <Sun className="h-4 w-4" />
-                                {t('theme.light')}
-                            </div>
+                            <Sun className="h-4 w-4" />
+                            {t('theme.light')}
                         </SelectItem>
                         <SelectItem value="dark">
-                            <div className="flex items-center gap-2">
-                                <Moon className="h-4 w-4" />
-                                {t('theme.dark')}
-                            </div>
+                            <Moon className="h-4 w-4" />
+                            {t('theme.dark')}
                         </SelectItem>
                         <SelectItem value="system">
-                            <div className="flex items-center gap-2">
-                                <Monitor className="h-4 w-4" />
-                                {t('theme.system')}
-                            </div>
+                            <Monitor className="h-4 w-4" />
+                            {t('theme.system')}
                         </SelectItem>
                     </SelectContent>
                 </Select>
@@ -58,7 +52,7 @@ export function SettingAppearance() {
                     <span className="text-sm font-medium">{t('language.label')}</span>
                 </div>
                 <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
-                    <SelectTrigger className="w-28 rounded-xl">
+                    <SelectTrigger className="w-36 rounded-xl">
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
- 加宽主题和语言选择器宽度
<img width="427" height="168" alt="image" src="https://github.com/user-attachments/assets/416015cd-3e95-4571-bb4a-4d54901d41c3" />

<img width="448" height="195" alt="image" src="https://github.com/user-attachments/assets/d6c29769-7541-46f7-9f6f-cad245f84ed6" />

- 修复深色模式下 Portal 弹出层样式继承问题
- 简化 SelectItem 内部结构
