### PR TITLE
fix: :bug: 修复设置值更新时的 SQL 语句格式

### DIFF
--- a/internal/op/setting.go
+++ b/internal/op/setting.go
@@ -39,7 +39,7 @@ func SettingSetString(key model.SettingKey, value string) error {
 	if valueCache == value {
 		return nil
 	}
-	result := db.GetDB().Model(&model.Setting{}).Where("key = ?", key).Update("value", value)
+	result := db.GetDB().Model(&model.Setting{}).Where("`key` = ?", key).Update("`value`", value)
 	if result.Error != nil {
 		return fmt.Errorf("failed to set setting: %w", result.Error)
 	}
@@ -78,7 +78,7 @@ func SettingSetInt(key model.SettingKey, value int) error {
 	if valueCacheNum == value {
 		return nil
 	}
-	result := db.GetDB().Model(&model.Setting{}).Where("key = ?", key).Update("value", value)
+	result := db.GetDB().Model(&model.Setting{}).Where("`key` = ?", key).Update("`value`", value)
 	if result.Error != nil {
 		return fmt.Errorf("failed to set setting: %w", result.Error)
 	}


### PR DESCRIPTION
使用 MariaDB 时，更新系统设置(cros/proxy)时报错，错误信息如下：
```json
{
    "code":500,
    "message":"failed to set setting: Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'key = ?' at line 1"}
```
根因是key是SQL保留字，需要用反引号`包裹起来