### PR TITLE
feat: 添加火山引擎(Volcengine)渠道支持

### DIFF
--- a/internal/client/fetch.go
+++ b/internal/client/fetch.go
@@ -18,7 +18,7 @@ func FetchLLMName(ctx context.Context, request model.Channel) ([]string, error) 
 	}
 
 	switch request.Type {
-	case outbound.OutboundTypeOpenAIChat, outbound.OutboundTypeOpenAIResponse:
+	case outbound.OutboundTypeOpenAIChat, outbound.OutboundTypeOpenAIResponse, outbound.OutboundTypeVolcengine:
 		return fetchOpenAIModels(client, ctx, request)
 	case outbound.OutboundTypeAnthropic:
 		return fetchAnthropicModels(client, ctx, request)

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -30,7 +30,7 @@ func (o *ResponseOutbound) TransformRequest(ctx context.Context, request *model.
 	}
 
 	// Convert to Responses API request format
-	responsesReq := convertToResponsesRequest(request)
+	responsesReq := ConvertToResponsesRequest(request)
 
 	body, err := json.Marshal(responsesReq)
 	if err != nil {
@@ -438,7 +438,7 @@ type ResponsesStreamEvent struct {
 
 // Conversion functions
 
-func convertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest {
+func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest {
 	result := &ResponsesRequest{
 		Model:             req.Model,
 		Temperature:       req.Temperature,

--- a/internal/transformer/outbound/register.go
+++ b/internal/transformer/outbound/register.go
@@ -5,6 +5,7 @@ import (
 	"github.com/bestruirui/octopus/internal/transformer/outbound/authropic"
 	"github.com/bestruirui/octopus/internal/transformer/outbound/gemini"
 	"github.com/bestruirui/octopus/internal/transformer/outbound/openai"
+	"github.com/bestruirui/octopus/internal/transformer/outbound/volcengine"
 )
 
 type OutboundType int
@@ -14,6 +15,7 @@ const (
 	OutboundTypeOpenAIResponse
 	OutboundTypeAnthropic
 	OutboundTypeGemini
+	OutboundTypeVolcengine
 )
 
 var outboundFactories = map[OutboundType]func() model.Outbound{
@@ -21,6 +23,7 @@ var outboundFactories = map[OutboundType]func() model.Outbound{
 	OutboundTypeOpenAIResponse: func() model.Outbound { return &openai.ResponseOutbound{} },
 	OutboundTypeAnthropic:      func() model.Outbound { return &authropic.MessageOutbound{} },
 	OutboundTypeGemini:         func() model.Outbound { return &gemini.MessagesOutbound{} },
+	OutboundTypeVolcengine:     func() model.Outbound { return &volcengine.ResponseOutbound{} },
 }
 
 func Get(outboundType OutboundType) model.Outbound {

--- a/internal/transformer/outbound/volcengine/response.go
+++ b/internal/transformer/outbound/volcengine/response.go
@@ -1,0 +1,98 @@
+package volcengine
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/bestruirui/octopus/internal/transformer/model"
+	"github.com/bestruirui/octopus/internal/transformer/outbound/openai"
+)
+
+var supportedReasoningEffortModel = map[string]bool{
+	"doubao-seed-1-6-lite-251015":true,
+	"doubao-seed-1-6-251015":true,
+}
+
+type ResponseOutbound struct {
+	inner openai.ResponseOutbound
+}
+
+func (o *ResponseOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	// Convert to Responses API request format
+	openaiReq := openai.ConvertToResponsesRequest(request)
+	if _, ok := supportedReasoningEffortModel[request.Model]; !ok {
+		openaiReq.Reasoning = nil
+	}
+	responsesReq := ResponsesRequest{
+		ResponsesRequest: openaiReq,
+	}
+	switch request.ReasoningEffort {
+	case "minimal":
+		responsesReq.Thinking.Type = ThinkingTypeDisabled
+	case "low", "medium", "high":
+		responsesReq.Thinking.Type = ThinkingTypeEnabled
+	default:
+	}
+
+	body, err := json.Marshal(responsesReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal responses api request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	// Parse and set URL
+	parsedUrl, err := url.Parse(strings.TrimSuffix(baseUrl, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base url: %w", err)
+	}
+	parsedUrl.Path = parsedUrl.Path + "/responses"
+	req.URL = parsedUrl
+	req.Method = http.MethodPost
+
+	return req, nil
+
+}
+func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http.Response) (*model.InternalLLMResponse, error) {
+	return o.inner.TransformResponse(ctx, response)
+}
+
+func (o *ResponseOutbound) TransformStream(ctx context.Context, eventData []byte) (*model.InternalLLMResponse, error) {
+	return o.inner.TransformStream(ctx, eventData)
+}
+
+
+
+type ResponsesRequest struct {
+	*openai.ResponsesRequest
+	Thinking Thinking `json:"thinking,omitzero"`
+}
+
+type ThinkingType string
+
+const (
+	ThinkingTypeAuto ThinkingType = "auto"
+	ThinkingTypeDisabled ThinkingType = "disabled"
+	ThinkingTypeEnabled ThinkingType = "enabled"
+)
+
+type Thinking struct {
+	Type ThinkingType `json:"type"`
+}

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -451,6 +451,7 @@
             "typeOpenAIResponse": "OpenAI Response",
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
+            "typeVolcengine": "Volcengine",
             "autoSync": "Auto Sync",
             "autoGroup": "Auto Group",
             "autoGroupNone": "None",

--- a/web/public/locale/zh.json
+++ b/web/public/locale/zh.json
@@ -451,6 +451,7 @@
             "typeOpenAIResponse": "OpenAI Response",
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
+            "typeVolcengine": "火山引擎",
             "autoSync": "自动同步",
             "autoGroup": "自动分组",
             "autoGroupNone": "不自动分组",

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -11,6 +11,7 @@ export enum ChannelType {
     OpenAIResponse = 1,
     Anthropic = 2,
     Gemini = 3,
+    Volcengine = 4,
 }
 
 /**

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -156,6 +156,7 @@ export function ChannelForm({
                         <SelectItem className='rounded-xl' value={String(ChannelType.OpenAIResponse)}>{t('typeOpenAIResponse')}</SelectItem>
                         <SelectItem className='rounded-xl' value={String(ChannelType.Anthropic)}>{t('typeAnthropic')}</SelectItem>
                         <SelectItem className='rounded-xl' value={String(ChannelType.Gemini)}>{t('typeGemini')}</SelectItem>
+                        <SelectItem className='rounded-xl' value={String(ChannelType.Volcengine)}>{t('typeVolcengine')}</SelectItem>
                     </SelectContent>
                 </Select>
             </div>


### PR DESCRIPTION
由于火山引擎对 thinking 的控制与 openai 不完全一致，因此增加一个独立渠道进行兼容
参考文档：https://www.volcengine.com/docs/82379/1569618
<img width="1596" height="1070" alt="image" src="https://github.com/user-attachments/assets/a1481edf-d2c6-46b0-a5a5-813c65d13dd7" />
