### PR TITLE
fix: :bug: 支持更大的 SSE event 并正确上报流式错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 data
 build
 static/out
-.cache
-AGENTS.md


### PR DESCRIPTION
**原因说明**

- 之前 go-sse 默认单 event 大小约 64KB，遇到超长 data: 会报 token too long。
- relay 在流式场景下遇到该错误会 break 后正常返回，导致统计被记录为成功且 token/cost 都为 0，同时客户端收到不完整 stream 报错。

**进行的修改**

- 修复上游 SSE 单条事件过大时触发 `bufio.Scanner: token too long` 导致断流的问题。
- 流式读取 event 出错时不再吞错，向上返回 error，避免出现 success=true 但 input/output token=0、客户端却报错的情况。
- 新增环境变量 `OCTOPUS_RELAY_MAX_SSE_EVENT_SIZE`（bytes，默认 2MB）用于调整 SSE 单事件最大长度。