### PR TITLE
feat: support reasoning field passthrough for thinking models

### DIFF
--- a/internal/transformer/inbound/openai/chat.go
+++ b/internal/transformer/inbound/openai/chat.go
@@ -117,12 +117,12 @@ func (i *ChatInbound) GetInternalResponse(ctx context.Context) (*model.InternalL
 					*existingChoice.Message.Content.Content += *delta.Content.Content
 				}
 
-				// Append reasoning content
-				if delta.ReasoningContent != nil {
+				// Append reasoning content (supports both reasoning_content and reasoning fields)
+				if delta.GetReasoningContent() != "" {
 					if existingChoice.Message.ReasoningContent == nil {
 						existingChoice.Message.ReasoningContent = new(string)
 					}
-					*existingChoice.Message.ReasoningContent += *delta.ReasoningContent
+					*existingChoice.Message.ReasoningContent += delta.GetReasoningContent()
 				}
 
 				// Aggregate tool calls

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -164,6 +164,9 @@ type InternalLLMRequest struct {
 	// Help fields， will not be sent to the llm service.
 	ReasoningBudget *int64 `json:"-"`
 
+	// EnableThinking is used by Alibaba Qwen models to enable thinking/reasoning output.
+	EnableThinking *bool `json:"enable_thinking,omitempty"`
+
 	// Specifies the processing type used for serving the request.
 	ServiceTier *string `json:"service_tier,omitempty"`
 
@@ -316,6 +319,10 @@ type Message struct {
 	// - https://api-docs.deepseek.com/api/create-chat-completion#responses
 	ReasoningContent *string `json:"reasoning_content,omitempty"`
 
+	// Reasoning is used by some providers (e.g., OpenRouter, Ollama cloud) as an alternative to ReasoningContent.
+	// Both fields serve the same purpose, use GetReasoningContent() to get the value.
+	Reasoning *string `json:"reasoning,omitempty"`
+
 	// Help field, will not be sent to the llm service, to adapt the anthropic think signature.
 	ReasoningSignature *string `json:"reasoning_signature,omitempty"`
 
@@ -326,7 +333,25 @@ type Message struct {
 
 func (m *Message) ClearHelpFields() {
 	m.ReasoningContent = nil
+	m.Reasoning = nil
 	m.ReasoningSignature = nil
+}
+
+// GetReasoningContent returns the reasoning content from either ReasoningContent or Reasoning field.
+// Different providers use different field names for the same purpose.
+func (m *Message) GetReasoningContent() string {
+	if m.ReasoningContent != nil {
+		return *m.ReasoningContent
+	}
+	if m.Reasoning != nil {
+		return *m.Reasoning
+	}
+	return ""
+}
+
+// SetReasoningContent sets the reasoning content to the ReasoningContent field.
+func (m *Message) SetReasoningContent(s string) {
+	m.ReasoningContent = &s
 }
 
 type MessageContent struct {


### PR DESCRIPTION
 ## 问题描述
     当前 octopus 在中转某些渠道的思考模型（如阿里云、cerebras、Ollama cloud）时，不会显示思考内容。这是因为：
     1. 不同供应商使用不同的字段名返回思考内容（`reasoning_content`、`reasoning`）
     2. 缺少 `enable_thinking` 请求参数的透传支持

## 修改内容

### 1. `internal/transformer/model/model.go`

     **请求字段新增：**
     - `EnableThinking` - 阿里云等渠道的思考模型启用思考输出

     **响应字段新增：**
     - `Reasoning` - OpenRouter、Ollama cloud 等供应商使用的字段

     **新增方法：**
     - `GetReasoningContent()` - 统一从 `reasoning_content`、`reasoning` 字段获取思考内容
     - `SetReasoningContent()` - 设置思考内容

     **更新方法：**
     - `ClearHelpFields()` - 清理时包含新增字段

### 2. `internal/transformer/inbound/openai/chat.go`

     - 使用 `GetReasoningContent()` 方法聚合流式响应中的思考内容，支持多种字段名

## 测试结果
使用ollama cloud glm-4.7 模型测试，响应正确返回 `reasoning_content` 字段内容。
使用阿里云 glm-4.7 模型测试，请求带 `enable_thinking=true` 时，响应正确返回 `reasoning_content` 字段内容。