### PR TITLE
bugfix: :bug: add ChannelKeys export/import in backup

### DIFF
--- a/internal/model/backup.go
+++ b/internal/model/backup.go
@@ -10,8 +10,9 @@ type DBDump struct {
 	IncludeLogs  bool      `json:"include_logs"`
 	IncludeStats bool      `json:"include_stats"`
 
-	Channels   []Channel   `json:"channels,omitempty"`
-	Groups     []Group     `json:"groups,omitempty"`
+	Channels    []Channel    `json:"channels,omitempty"`
+	ChannelKeys []ChannelKey `json:"channel_keys,omitempty"`
+	Groups      []Group      `json:"groups,omitempty"`
 	GroupItems []GroupItem `json:"group_items,omitempty"`
 	LLMInfos   []LLMInfo   `json:"llm_infos,omitempty"`
 	APIKeys    []APIKey    `json:"api_keys,omitempty"`

--- a/internal/op/backup.go
+++ b/internal/op/backup.go
@@ -26,6 +26,9 @@ func DBExportAll(ctx context.Context, includeLogs, includeStats bool) (*model.DB
 	if err := conn.Find(&d.Channels).Error; err != nil {
 		return nil, fmt.Errorf("export channels: %w", err)
 	}
+	if err := conn.Find(&d.ChannelKeys).Error; err != nil {
+		return nil, fmt.Errorf("export channel_keys: %w", err)
+	}
 	if err := conn.Find(&d.Groups).Error; err != nil {
 		return nil, fmt.Errorf("export groups: %w", err)
 	}
@@ -90,6 +93,11 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 			return fmt.Errorf("import channels: %w", err)
 		} else {
 			res.RowsAffected["channels"] = n
+		}
+		if n, err := createDoNothing(tx, dump.ChannelKeys); err != nil {
+			return fmt.Errorf("import channel_keys: %w", err)
+		} else {
+			res.RowsAffected["channel_keys"] = n
 		}
 		if n, err := createDoNothing(tx, dump.Groups); err != nil {
 			return fmt.Errorf("import groups: %w", err)


### PR DESCRIPTION
## 问题描述        
   备份导出功能未导出渠道密钥(ChannelKeys)，导致恢复备份后所有渠道的密钥丢失。解决 #109 

 ## 修改内容
   - `DBDump` 结构体新增 `ChannelKeys` 字段
   - `DBExportAll` 导出时查询 `channel_keys` 表
   - `DBImportIncremental` 导入时插入 `channel_keys` 数据

  ## 兼容性
   - **向后兼容**：旧版本备份文件（无 `channel_keys` 字段）可正常导入
   - **向前兼容**：新版本导出的 JSON 在旧版本导入时，`channel_keys` 字段会被忽略