### PR TITLE
fix: :bug: 修复流式请求 Accept 头并校验上游 SSE 响应

### DIFF
--- a/internal/transformer/outbound/authropic/messages.go
+++ b/internal/transformer/outbound/authropic/messages.go
@@ -47,7 +47,12 @@ func (o *MessageOutbound) TransformRequest(ctx context.Context, request *model.I
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
+	// For streaming requests, Anthropic returns Server-Sent Events.
+	if request.Stream != nil && *request.Stream {
+		req.Header.Set("Accept", "text/event-stream")
+	} else {
+		req.Header.Set("Accept", "application/json")
+	}
 	req.Header.Set("Anthropic-Version", "2023-06-01")
 	req.Header.Set("X-API-Key", key)
 


### PR DESCRIPTION
**原因说明**

- 起因是于 https://linux.do/t/topic/1316708/591 中提到 AnyRouter，“虽然octopus有协议转换,但是他检测很严格,只能在cc使用”，在 Codex 中无法使用。检查后台发现：channel Any Router failed: failed to read stream event: go-sse: unexpected end of input，同时CC侧能够正常调用。
- 排查发现，由于流式请求仍使用 Accept: application/json，导致部分上游在流式场景返回的响应类型不符合预期，relay 侧按流式协议处理时出现兼容性问题且排查成本较高。

**进行的修改**

Anthropic 出站请求：当 stream=true 时将 Accept 调整为 text/event-stream，非流式请求保持 application/json。

**测试结果**

Codex/Claude Code 中均可以正常调用 Anyrouter 等 Anthropic 格式的 API，使用过程中未见明显异常。也许需要进行进一步测试以确保更多工具/上游的兼容性。

    