### PR TITLE
feat: :sparkles: 支持OpenAI Embedding 接口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ data
 build
 static/out/*
 !static/out/README.md
+.vscode

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -95,6 +95,21 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 				continue
 			}
 
+			// 验证 channel 类型与请求类型匹配
+			if internalRequest.IsEmbeddingRequest() && !outbound.IsEmbeddingChannelType(channel.Type) {
+				log.Warnf("channel type %d is not compatible with embedding request for channel: %s", channel.Type, channel.Name)
+				lastErr = fmt.Errorf("channel type %d not compatible with embedding request", channel.Type)
+				item = b.Next(group.Items, item)
+				continue
+			}
+
+			if internalRequest.IsChatRequest() && !outbound.IsChatChannelType(channel.Type) {
+				log.Warnf("channel type %d is not compatible with chat request for channel: %s", channel.Type, channel.Name)
+				lastErr = fmt.Errorf("channel type %d not compatible with chat request", channel.Type)
+				item = b.Next(group.Items, item)
+				continue
+			}
+
 			rc := &relayContext{
 				c:                    c,
 				inAdapter:            inAdapter,

--- a/internal/server/handlers/relay.go
+++ b/internal/server/handlers/relay.go
@@ -25,6 +25,10 @@ func init() {
 		AddRoute(
 			router.NewRoute("/messages", http.MethodPost).
 				Handle(message),
+		).
+		AddRoute(
+			router.NewRoute("/embeddings", http.MethodPost).
+				Handle(embedding),
 		)
 }
 
@@ -36,4 +40,7 @@ func response(c *gin.Context) {
 }
 func message(c *gin.Context) {
 	relay.Handler(inbound.InboundTypeAnthropic, c)
+}
+func embedding(c *gin.Context) {
+	relay.Handler(inbound.InboundTypeOpenAIEmbedding, c)
 }

--- a/internal/transformer/inbound/openai/embedding.go
+++ b/internal/transformer/inbound/openai/embedding.go
@@ -1,0 +1,82 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/bestruirui/octopus/internal/transformer/model"
+)
+
+type EmbeddingInbound struct {
+	// storedResponse stores the non-stream response
+	storedResponse *model.InternalLLMResponse
+}
+
+// OpenAIEmbeddingRequest 是 OpenAI 标准的 embedding 请求格式
+type OpenAIEmbeddingRequest struct {
+	Model          string               `json:"model"`
+	Input          model.EmbeddingInput `json:"input"` // 客户端使用 "input"
+	Dimensions     *int64               `json:"dimensions,omitempty"`
+	EncodingFormat *string              `json:"encoding_format,omitempty"`
+	User           *string              `json:"user,omitempty"`
+}
+
+// OpenAIEmbeddingResponse 是 OpenAI 标准的 embedding 响应格式
+type OpenAIEmbeddingResponse struct {
+	ID      string                  `json:"id"`
+	Object  string                  `json:"object"`
+	Created int64                   `json:"created"`
+	Model   string                  `json:"model"`
+	Data    []model.EmbeddingObject `json:"data"` // 客户端期望 "data"
+	Usage   *model.Usage            `json:"usage,omitempty"`
+}
+
+func (i *EmbeddingInbound) TransformRequest(ctx context.Context, body []byte) (*model.InternalLLMRequest, error) {
+	var openAIReq OpenAIEmbeddingRequest
+	if err := json.Unmarshal(body, &openAIReq); err != nil {
+		return nil, err
+	}
+
+	// 转换为内部格式
+	var request model.InternalLLMRequest
+	request.Model = openAIReq.Model
+	request.EmbeddingInput = &openAIReq.Input
+	request.EmbeddingDimensions = openAIReq.Dimensions
+	request.EmbeddingEncodingFormat = openAIReq.EncodingFormat
+	request.User = openAIReq.User
+	request.RawAPIFormat = model.APIFormatOpenAIEmbedding
+
+	return &request, nil
+}
+
+func (i *EmbeddingInbound) TransformResponse(ctx context.Context, response *model.InternalLLMResponse) ([]byte, error) {
+	// Store the response for later retrieval
+	i.storedResponse = response
+
+	// 转换为 OpenAI 标准格式
+	openAIResp := OpenAIEmbeddingResponse{
+		ID:      response.ID,
+		Object:  response.Object,
+		Created: response.Created,
+		Model:   response.Model,
+		Data:    response.EmbeddingData, // 使用 "data" 返回给客户端
+		Usage:   response.Usage,
+	}
+
+	body, err := json.Marshal(openAIResp)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (i *EmbeddingInbound) TransformStream(ctx context.Context, stream *model.InternalLLMResponse) ([]byte, error) {
+	// Embedding API does not support streaming
+	return nil, errors.New("streaming is not supported for embedding API")
+}
+
+// GetInternalResponse returns the complete internal response for logging, statistics, etc.
+func (i *EmbeddingInbound) GetInternalResponse(ctx context.Context) (*model.InternalLLMResponse, error) {
+	return i.storedResponse, nil
+}

--- a/internal/transformer/inbound/register.go
+++ b/internal/transformer/inbound/register.go
@@ -13,15 +13,17 @@ const (
 	InboundTypeOpenAIResponse
 	InboundTypeAnthropic
 	InboundTypeGemini
+	InboundTypeOpenAIEmbedding
 
 	// Compatibility alias for legacy naming
 	InboundTypeOpenAI = InboundTypeOpenAIChat
 )
 
 var inboundFactories = map[InboundType]func() model.Inbound{
-	InboundTypeOpenAIChat:     func() model.Inbound { return &openai.ChatInbound{} },
-	InboundTypeOpenAIResponse: func() model.Inbound { return &openai.ResponseInbound{} },
-	InboundTypeAnthropic:      func() model.Inbound { return &anthropic.MessagesInbound{} },
+	InboundTypeOpenAIChat:      func() model.Inbound { return &openai.ChatInbound{} },
+	InboundTypeOpenAIResponse:  func() model.Inbound { return &openai.ResponseInbound{} },
+	InboundTypeOpenAIEmbedding: func() model.Inbound { return &openai.EmbeddingInbound{} },
+	InboundTypeAnthropic:       func() model.Inbound { return &anthropic.MessagesInbound{} },
 }
 
 func Get(inboundType InboundType) model.Inbound {

--- a/internal/transformer/model/embedding_test.go
+++ b/internal/transformer/model/embedding_test.go
@@ -1,0 +1,255 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEmbeddingInput_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    EmbeddingInput
+		expected string
+	}{
+		{
+			name:     "single string",
+			input:    EmbeddingInput{Single: strPtr("hello world")},
+			expected: `"hello world"`,
+		},
+		{
+			name:     "multiple strings",
+			input:    EmbeddingInput{Multiple: []string{"hello", "world"}},
+			expected: `["hello","world"]`,
+		},
+		{
+			name:     "empty",
+			input:    EmbeddingInput{},
+			expected: `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, string(data))
+			}
+		})
+	}
+}
+
+func TestEmbeddingInput_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected EmbeddingInput
+	}{
+		{
+			name:     "single string",
+			input:    `"hello world"`,
+			expected: EmbeddingInput{Single: strPtr("hello world")},
+		},
+		{
+			name:     "multiple strings",
+			input:    `["hello","world"]`,
+			expected: EmbeddingInput{Multiple: []string{"hello", "world"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var input EmbeddingInput
+			err := json.Unmarshal([]byte(tt.input), &input)
+			if err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if input.Single != nil && tt.expected.Single != nil {
+				if *input.Single != *tt.expected.Single {
+					t.Errorf("expected %s, got %s", *tt.expected.Single, *input.Single)
+				}
+			}
+
+			if len(input.Multiple) != len(tt.expected.Multiple) {
+				t.Errorf("expected %d items, got %d", len(tt.expected.Multiple), len(input.Multiple))
+			}
+		})
+	}
+}
+
+func TestEmbedding_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		emb      Embedding
+		expected string
+	}{
+		{
+			name:     "float array",
+			emb:      Embedding{FloatArray: []float64{0.1, 0.2, 0.3}},
+			expected: `[0.1,0.2,0.3]`,
+		},
+		{
+			name:     "base64 string",
+			emb:      Embedding{Base64String: strPtr("YWJjZGVm")},
+			expected: `"YWJjZGVm"`,
+		},
+		{
+			name:     "empty",
+			emb:      Embedding{},
+			expected: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.emb)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+			if string(data) != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, string(data))
+			}
+		})
+	}
+}
+
+func TestInternalLLMRequest_IsEmbeddingRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  InternalLLMRequest
+		expected bool
+	}{
+		{
+			name: "embedding request",
+			request: InternalLLMRequest{
+				Model:          "text-embedding-ada-002",
+				EmbeddingInput: &EmbeddingInput{Single: strPtr("hello")},
+			},
+			expected: true,
+		},
+		{
+			name: "chat request",
+			request: InternalLLMRequest{
+				Model:    "gpt-4",
+				Messages: []Message{{Role: "user"}},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.request.IsEmbeddingRequest()
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestInternalLLMRequest_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		request   InternalLLMRequest
+		expectErr bool
+	}{
+		{
+			name: "valid embedding request",
+			request: InternalLLMRequest{
+				Model:          "text-embedding-ada-002",
+				EmbeddingInput: &EmbeddingInput{Single: strPtr("hello")},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid chat request",
+			request: InternalLLMRequest{
+				Model:    "gpt-4",
+				Messages: []Message{{Role: "user"}},
+			},
+			expectErr: false,
+		},
+		{
+			name: "both messages and input",
+			request: InternalLLMRequest{
+				Model:          "gpt-4",
+				Messages:       []Message{{Role: "user"}},
+				EmbeddingInput: &EmbeddingInput{Single: strPtr("hello")},
+			},
+			expectErr: true,
+		},
+		{
+			name: "neither messages nor input",
+			request: InternalLLMRequest{
+				Model: "gpt-4",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty input",
+			request: InternalLLMRequest{
+				Model:          "text-embedding-ada-002",
+				EmbeddingInput: &EmbeddingInput{},
+			},
+			expectErr: true,
+		},
+		{
+			name:      "missing model",
+			request:   InternalLLMRequest{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if tt.expectErr && err == nil {
+				t.Error("expected error but got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestInternalLLMResponse_IsEmbeddingResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response InternalLLMResponse
+		expected bool
+	}{
+		{
+			name: "embedding response",
+			response: InternalLLMResponse{
+				Object:        "list",
+				EmbeddingData: []EmbeddingObject{{Object: "embedding", Index: 0}},
+			},
+			expected: true,
+		},
+		{
+			name: "chat response",
+			response: InternalLLMResponse{
+				Object:  "chat.completion",
+				Choices: []Choice{{Index: 0}},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.response.IsEmbeddingResponse()
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -16,6 +16,7 @@ const (
 	APIFormatOpenAIChatCompletion  APIFormat = "openai/chat_completions"
 	APIFormatOpenAIResponse        APIFormat = "openai/responses"
 	APIFormatOpenAIImageGeneration APIFormat = "openai/image_generation"
+	APIFormatOpenAIEmbedding       APIFormat = "openai/embeddings"
 	APIFormatGeminiContents        APIFormat = "gemini/contents"
 	APIFormatAnthropicMessage      APIFormat = "anthropic/messages"
 	APIFormatAiSDKText             APIFormat = "aisdk/text"
@@ -26,7 +27,21 @@ const (
 // It choose to base on the OpenAI chat completion request, but add some extra fields to support more features.
 type InternalLLMRequest struct {
 	// Messages is a list of messages to send to the llm model.
-	Messages []Message `json:"messages" validator:"required,min=1"`
+	// For chat completion requests, this field is required.
+	// For embedding requests, this field should be empty and Input should be used instead.
+	Messages []Message `json:"messages,omitempty" validator:"required,min=1"`
+
+	// Embedding API 参数（与 Messages 互斥）
+	// EmbeddingInput is the text or texts to get embeddings for.
+	// For embedding requests, this field is required.
+	// For chat completion requests, this field should be empty.
+	EmbeddingInput *EmbeddingInput `json:"embedding_input,omitempty"` // string or string[]
+	// EmbeddingDimensions is the number of dimensions for the embedding output.
+	// Only supported for certain embedding models.
+	EmbeddingDimensions *int64 `json:"embedding_dimensions,omitempty"`
+	// EmbeddingEncodingFormat is the format of the embedding output.
+	// Can be "float" or "base64". Defaults to "float".
+	EmbeddingEncodingFormat *string `json:"embedding_encoding_format,omitempty"`
 
 	// Model is the model ID used to generate the response.
 	Model string `json:"model" validator:"required"`
@@ -224,10 +239,42 @@ func (r *InternalLLMRequest) Validate() error {
 	if r.Model == "" {
 		return errors.New("model is required")
 	}
-	if len(r.Messages) == 0 {
+
+	// 检查是否是 embedding 请求
+	isEmbeddingRequest := r.EmbeddingInput != nil
+	isChatRequest := len(r.Messages) > 0
+
+	if isEmbeddingRequest && isChatRequest {
+		return errors.New("cannot specify both messages and input")
+	}
+
+	if !isEmbeddingRequest && !isChatRequest {
+		return errors.New("either messages or input is required")
+	}
+
+	// 验证 embedding 请求
+	if isEmbeddingRequest {
+		if r.EmbeddingInput.Single == nil && len(r.EmbeddingInput.Multiple) == 0 {
+			return errors.New("input cannot be empty")
+		}
+	}
+
+	// 验证 chat 请求
+	if isChatRequest && len(r.Messages) == 0 {
 		return errors.New("messages are required")
 	}
+
 	return nil
+}
+
+// IsEmbeddingRequest returns true if this is an embedding request.
+func (r *InternalLLMRequest) IsEmbeddingRequest() bool {
+	return r.EmbeddingInput != nil
+}
+
+// IsChatRequest returns true if this is a chat completion request.
+func (r *InternalLLMRequest) IsChatRequest() bool {
+	return len(r.Messages) > 0
 }
 
 func (r *InternalLLMRequest) ClearHelpFields() {
@@ -459,10 +506,18 @@ type InternalLLMResponse struct {
 
 	// A list of chat completion choices. Can be more than one if `n` is greater
 	// than 1.
-	Choices []Choice `json:"choices"`
+	// For chat completion responses, this field is required.
+	// For embedding responses, this field should be empty and EmbeddingData should be used instead.
+	Choices []Choice `json:"choices,omitempty"`
+
+	// Embedding API 响应（与 Choices 互斥）
+	// EmbeddingData is the list of embedding objects.
+	// For embedding responses, this field is required.
+	// For chat completion responses, this field should be empty.
+	EmbeddingData []EmbeddingObject `json:"embedding_data,omitempty"`
 
 	// Object is the type of the response.
-	// e.g. "chat.completion", "chat.completion.chunk"
+	// e.g. "chat.completion", "chat.completion.chunk", "list"
 	Object string `json:"object"`
 
 	// Created is the timestamp of when the response was created.
@@ -502,6 +557,16 @@ func (r *InternalLLMResponse) ClearHelpFields() {
 
 		r.Choices[i] = choice
 	}
+}
+
+// IsEmbeddingResponse returns true if this is an embedding response.
+func (r *InternalLLMResponse) IsEmbeddingResponse() bool {
+	return len(r.EmbeddingData) > 0
+}
+
+// IsChatResponse returns true if this is a chat completion response.
+func (r *InternalLLMResponse) IsChatResponse() bool {
+	return len(r.Choices) > 0
 }
 
 // Choice represents a choice in the response.
@@ -549,6 +614,7 @@ type ResponseMeta struct {
 }
 
 // Usage Represents the total token usage per request to OpenAI.
+// For embedding requests, CompletionTokens is always 0.
 type Usage struct {
 	PromptTokens            int64                    `json:"prompt_tokens"`
 	CompletionTokens        int64                    `json:"completion_tokens"`
@@ -788,4 +854,92 @@ type ImageGeneration struct {
 	// Whether to add a watermark to the generated image. Default: false.
 	// It only works for the models support watermark, it will be ignored otherwise.
 	Watermark bool `json:"watermark,omitempty"`
+}
+
+// EmbeddingInput represents the input for embedding requests.
+// It can be a single string or an array of strings.
+type EmbeddingInput struct {
+	Single   *string
+	Multiple []string
+}
+
+func (i EmbeddingInput) MarshalJSON() ([]byte, error) {
+	if i.Single != nil {
+		return json.Marshal(i.Single)
+	}
+
+	if len(i.Multiple) > 0 {
+		return json.Marshal(i.Multiple)
+	}
+
+	return []byte("null"), nil
+}
+
+func (i *EmbeddingInput) UnmarshalJSON(data []byte) error {
+	var str string
+
+	err := json.Unmarshal(data, &str)
+	if err == nil {
+		i.Single = &str
+		return nil
+	}
+
+	var strs []string
+
+	err = json.Unmarshal(data, &strs)
+	if err == nil {
+		i.Multiple = strs
+		return nil
+	}
+
+	return errors.New("invalid input type")
+}
+
+// EmbeddingObject represents a single embedding object in the response.
+type EmbeddingObject struct {
+	// The object type, always "embedding".
+	Object string `json:"object"`
+	// The index of this embedding in the list.
+	Index int `json:"index"`
+	// The embedding vector.
+	Embedding Embedding `json:"embedding"`
+}
+
+// Embedding represents an embedding vector.
+// It can be a float array or a base64-encoded string.
+type Embedding struct {
+	FloatArray   []float64
+	Base64String *string
+}
+
+func (e Embedding) MarshalJSON() ([]byte, error) {
+	if e.Base64String != nil {
+		return json.Marshal(e.Base64String)
+	}
+
+	if len(e.FloatArray) > 0 {
+		return json.Marshal(e.FloatArray)
+	}
+
+	return []byte("[]"), nil
+}
+
+func (e *Embedding) UnmarshalJSON(data []byte) error {
+	var str string
+
+	err := json.Unmarshal(data, &str)
+	if err == nil {
+		e.Base64String = &str
+		return nil
+	}
+
+	var floats []float64
+
+	err = json.Unmarshal(data, &floats)
+	if err == nil {
+		e.FloatArray = floats
+		return nil
+	}
+
+	return errors.New("invalid embedding type")
 }

--- a/internal/transformer/outbound/openai/embedding.go
+++ b/internal/transformer/outbound/openai/embedding.go
@@ -1,0 +1,119 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/bestruirui/octopus/internal/transformer/model"
+)
+
+type EmbeddingOutbound struct{}
+
+// OpenAIEmbeddingRequest 是 OpenAI 标准的请求格式（发送给上游）
+type OpenAIEmbeddingRequest struct {
+	Model          string               `json:"model"`
+	Input          model.EmbeddingInput `json:"input"` // 上游期望 "input"
+	Dimensions     *int64               `json:"dimensions,omitempty"`
+	EncodingFormat *string              `json:"encoding_format,omitempty"`
+	User           *string              `json:"user,omitempty"`
+}
+
+// OpenAIEmbeddingResponse 是 OpenAI 标准的响应格式（上游返回）
+type OpenAIEmbeddingResponse struct {
+	ID      string                  `json:"id"`
+	Object  string                  `json:"object"`
+	Created int64                   `json:"created"`
+	Model   string                  `json:"model"`
+	Data    []model.EmbeddingObject `json:"data"` // 上游返回 "data"
+	Usage   *model.Usage            `json:"usage,omitempty"`
+}
+
+func (o *EmbeddingOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
+	// 验证这是一个 embedding 请求
+	if !request.IsEmbeddingRequest() {
+		return nil, errors.New("not an embedding request")
+	}
+
+	// 构建 embedding 请求体（使用 OpenAI 标准字段名）
+	embeddingRequest := map[string]any{
+		"model": request.Model,
+		"input": request.EmbeddingInput, // 上游期望 "input"
+	}
+
+	// 添加可选参数
+	if request.EmbeddingDimensions != nil {
+		embeddingRequest["dimensions"] = *request.EmbeddingDimensions
+	}
+
+	if request.EmbeddingEncodingFormat != nil {
+		embeddingRequest["encoding_format"] = *request.EmbeddingEncodingFormat
+	}
+
+	if request.User != nil {
+		embeddingRequest["user"] = *request.User
+	}
+
+	body, err := json.Marshal(embeddingRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	parsedUrl, err := url.Parse(strings.TrimSuffix(baseUrl, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base url: %w", err)
+	}
+	parsedUrl.Path = parsedUrl.Path + "/embeddings"
+	req.URL = parsedUrl
+	req.Method = http.MethodPost
+	return req, nil
+}
+
+func (o *EmbeddingOutbound) TransformResponse(ctx context.Context, response *http.Response) (*model.InternalLLMResponse, error) {
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("response body is empty")
+	}
+
+	// 先解析为 OpenAI 标准格式
+	var openAIResp OpenAIEmbeddingResponse
+	if err := json.Unmarshal(body, &openAIResp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	// 转换为内部格式
+	resp := &model.InternalLLMResponse{
+		ID:            openAIResp.ID,
+		Object:        openAIResp.Object,
+		Created:       openAIResp.Created,
+		Model:         openAIResp.Model,
+		EmbeddingData: openAIResp.Data, // 上游返回 "data"，映射到内部字段
+		Usage:         openAIResp.Usage,
+	}
+
+	return resp, nil
+}
+
+func (o *EmbeddingOutbound) TransformStream(ctx context.Context, eventData []byte) (*model.InternalLLMResponse, error) {
+	// Embedding API does not support streaming
+	return nil, errors.New("streaming is not supported for embedding API")
+}

--- a/internal/transformer/outbound/register.go
+++ b/internal/transformer/outbound/register.go
@@ -16,14 +16,40 @@ const (
 	OutboundTypeAnthropic
 	OutboundTypeGemini
 	OutboundTypeVolcengine
+	OutboundTypeOpenAIEmbedding
 )
 
+// EmbeddingChannelTypes 定义支持 embedding 请求的 channel 类型集合
+var EmbeddingChannelTypes = map[OutboundType]bool{
+	OutboundTypeOpenAIEmbedding: true,
+}
+
+// ChatChannelTypes 定义支持 chat 请求的 channel 类型集合
+var ChatChannelTypes = map[OutboundType]bool{
+	OutboundTypeOpenAIChat:     true,
+	OutboundTypeOpenAIResponse: true,
+	OutboundTypeAnthropic:      true,
+	OutboundTypeGemini:         true,
+	OutboundTypeVolcengine:     true,
+}
+
+// IsEmbeddingChannelType 判断 channel 类型是否支持 embedding 请求
+func IsEmbeddingChannelType(channelType OutboundType) bool {
+	return EmbeddingChannelTypes[channelType]
+}
+
+// IsChatChannelType 判断 channel 类型是否支持 chat 请求
+func IsChatChannelType(channelType OutboundType) bool {
+	return ChatChannelTypes[channelType]
+}
+
 var outboundFactories = map[OutboundType]func() model.Outbound{
-	OutboundTypeOpenAIChat:     func() model.Outbound { return &openai.ChatOutbound{} },
-	OutboundTypeOpenAIResponse: func() model.Outbound { return &openai.ResponseOutbound{} },
-	OutboundTypeAnthropic:      func() model.Outbound { return &authropic.MessageOutbound{} },
-	OutboundTypeGemini:         func() model.Outbound { return &gemini.MessagesOutbound{} },
-	OutboundTypeVolcengine:     func() model.Outbound { return &volcengine.ResponseOutbound{} },
+	OutboundTypeOpenAIChat:      func() model.Outbound { return &openai.ChatOutbound{} },
+	OutboundTypeOpenAIResponse:  func() model.Outbound { return &openai.ResponseOutbound{} },
+	OutboundTypeOpenAIEmbedding: func() model.Outbound { return &openai.EmbeddingOutbound{} },
+	OutboundTypeAnthropic:       func() model.Outbound { return &authropic.MessageOutbound{} },
+	OutboundTypeGemini:          func() model.Outbound { return &gemini.MessagesOutbound{} },
+	OutboundTypeVolcengine:      func() model.Outbound { return &volcengine.ResponseOutbound{} },
 }
 
 func Get(outboundType OutboundType) model.Outbound {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -464,6 +464,7 @@
             "modelClearAll": "Clear All",
             "typeOpenAIChat": "OpenAI Chat",
             "typeOpenAIResponse": "OpenAI Response",
+            "typeOpenAIEmbedding": "OpenAI Embedding",
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
             "typeVolcengine": "Volcengine",

--- a/web/public/locale/zh.json
+++ b/web/public/locale/zh.json
@@ -464,6 +464,7 @@
             "modelClearAll": "清除全部",
             "typeOpenAIChat": "OpenAI Chat",
             "typeOpenAIResponse": "OpenAI Response",
+            "typeOpenAIEmbedding": "OpenAI Embedding",
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
             "typeVolcengine": "火山引擎",

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -12,6 +12,7 @@ export enum ChannelType {
     Anthropic = 2,
     Gemini = 3,
     Volcengine = 4,
+    OpenAIEmbedding = 5,
 }
 
 /**

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -250,6 +250,7 @@ export function ChannelForm({
                             <SelectItem className='rounded-xl' value={String(ChannelType.Anthropic)}>{t('typeAnthropic')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.Gemini)}>{t('typeGemini')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.Volcengine)}>{t('typeVolcengine')}</SelectItem>
+                            <SelectItem className='rounded-xl' value={String(ChannelType.OpenAIEmbedding)}>{t('typeOpenAIEmbedding')}</SelectItem>
                         </SelectContent>
                     </Select>
                 </div>


### PR DESCRIPTION
Add full support for OpenAI Embedding API:

- Add EmbeddingInbound and EmbeddingOutbound transformers with field name mapping
  - Internal format uses embedding_input/embedding_dimensions/embedding_encoding_format
  - External format maintains OpenAI standard (input/dimensions/encoding_format/data)
- Add EmbeddingInput and related model structures
- Add embedding endpoint handler (/embeddings)
- Add channel type validation (embedding vs chat requests)
- Add EmbeddingChannelTypes and ChatChannelTypes for type filtering
- Update frontend UI with OpenAI Embedding channel option

fix #20 