### PR TITLE
style: :art: 格式化 docker-compose.yml 文件中的缩进

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: bestrui/octopus
     ports:
        - '8080:8080'
-    volumes:      
+    volumes:
        - '/path/to/data:/app/data'
     container_name: octopus
     restart: unless-stopped


### PR DESCRIPTION
删除了 `docker-compose.yml` 文件中 `volumes:` 行末尾的多余空格，同时在这个文件的末尾添加空行