### PR TITLE
fix: 修复ChannelProxy、ParamOverride、MatchRegex 字段更新为空时无法保存的问题

### DIFF
--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -97,19 +97,22 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         const nextChannelProxy = formData.channel_proxy.trim();
         const curChannelProxy = channel.channel_proxy ?? '';
         if (nextChannelProxy !== curChannelProxy) {
-            req.channel_proxy = nextChannelProxy ? nextChannelProxy : null;
+            // Empty string means "clear" for patch semantics; backend maps it to NULL.
+            req.channel_proxy = nextChannelProxy;
         }
 
         const nextParamOverride = formData.param_override.trim();
         const curParamOverride = channel.param_override ?? '';
         if (nextParamOverride !== curParamOverride) {
-            req.param_override = nextParamOverride ? nextParamOverride : null;
+            // Empty string means "clear" for patch semantics; backend maps it to NULL.
+            req.param_override = nextParamOverride;
         }
 
         const nextMatchRegex = formData.match_regex.trim();
         const curMatchRegex = channel.match_regex ?? '';
         if (nextMatchRegex !== curMatchRegex) {
-            req.match_regex = nextMatchRegex ? nextMatchRegex : null;
+            // Empty string means "clear" for patch semantics; backend maps it to NULL.
+            req.match_regex = nextMatchRegex;
         }
 
         const originalKeys = channel.keys;


### PR DESCRIPTION
- 新增 normalizeOptionalString 辅助函数统一处理空字符串转 nil 逻辑
- 修复 ChannelProxy、ParamOverride、MatchRegex 字段清除时的行为
- 前端发送空字符串表示清除，后端统一转换为 NULL 存储
- 新增单元测试覆盖三个字段的清除场景
#149 