### PR TITLE
fix: preserve responses input array shape in openai responses #151

### DIFF
--- a/internal/transformer/inbound/openai/response.go
+++ b/internal/transformer/inbound/openai/response.go
@@ -953,6 +953,10 @@ func convertToInternalRequest(req *ResponsesRequest) (*model.InternalLLMRequest,
 		TransformerMetadata: map[string]string{},
 	}
 
+	if req.Input.Text == nil && len(req.Input.Items) > 0 {
+		chatReq.TransformOptions.ArrayInputs = lo.ToPtr(true)
+	}
+
 	// Convert reasoning
 	if req.Reasoning != nil {
 		if req.Reasoning.Effort != "" {

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -225,6 +225,10 @@ type InternalLLMRequest struct {
 	// This is a help field and will not be sent to the llm service.
 	TransformerMetadata map[string]string `json:"-"`
 
+	// TransformOptions stores transformer-specific options for preserving request format.
+	// This is a help field and will not be sent to the llm service.
+	TransformOptions TransformOptions `json:"-"`
+
 	// Include specifies additional output data to include in the model response.
 	// This is a help field and will not be sent to the llm service.
 	// e.g., "file_search_call.results", "message.input_image.image_url", "reasoning.encrypted_content"
@@ -290,6 +294,12 @@ func (r *InternalLLMRequest) ClearHelpFields() {
 func (r *InternalLLMRequest) IsImageGenerationRequest() bool {
 	return len(r.Modalities) > 0 && slices.Contains(r.Modalities, "image")
 }
+
+type TransformOptions struct {
+	// ArrayInputs specifies whether the original input was an array.
+	ArrayInputs *bool `json:"-"`
+}
+
 
 type StreamOptions struct {
 	// If set, an additional chunk will be streamed before the data: [DONE] message.

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -457,7 +457,7 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 	result.Instructions = convertInstructionsFromMessages(req.Messages)
 
 	// Convert input from messages
-	result.Input = convertInputFromMessages(req.Messages)
+	result.Input = convertInputFromMessages(req.Messages, req.TransformOptions)
 
 	// Convert tools
 	if len(req.Tools) > 0 {
@@ -516,10 +516,12 @@ func convertInstructionsFromMessages(msgs []model.Message) string {
 	return strings.Join(instructions, "\n")
 }
 
-func convertInputFromMessages(msgs []model.Message) ResponsesInput {
+func convertInputFromMessages(msgs []model.Message, transformOptions model.TransformOptions) ResponsesInput {
 	if len(msgs) == 0 {
 		return ResponsesInput{}
 	}
+
+	wasArrayFormat := transformOptions.ArrayInputs != nil && *transformOptions.ArrayInputs
 
 	// Check for simple single user message
 	nonSystemMsgs := make([]model.Message, 0)
@@ -529,7 +531,7 @@ func convertInputFromMessages(msgs []model.Message) ResponsesInput {
 		}
 	}
 
-	if len(nonSystemMsgs) == 1 && nonSystemMsgs[0].Content.Content != nil && nonSystemMsgs[0].Role == "user" {
+	if !wasArrayFormat && len(nonSystemMsgs) == 1 && nonSystemMsgs[0].Content.Content != nil && nonSystemMsgs[0].Role == "user" {
 		return ResponsesInput{Text: nonSystemMsgs[0].Content.Content}
 	}
 


### PR DESCRIPTION
在openai response下保持入站和出站input格式一致, 提高兼容性
#151 #152 