### PR TITLE
feat(web,server): 日志按时间段分割展示 + 本地开发 CORS 兼容

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -367,7 +367,8 @@
     },
     "log": {
         "list": {
-            "noMore": "No more logs"
+            "noMore": "No more logs",
+            "timeGap": "Older logs: {time}"
         },
         "card": {
             "error": "Error",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -367,7 +367,8 @@
     },
     "log": {
         "list": {
-            "noMore": "没有更多日志了"
+            "noMore": "没有更多日志了",
+            "timeGap": "更早日志 · {time}"
         },
         "card": {
             "error": "错误",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -367,7 +367,8 @@
     },
     "log": {
         "list": {
-            "noMore": "沒有更多日誌了"
+            "noMore": "沒有更多日誌了",
+            "timeGap": "較早日誌 · {time}"
         },
         "card": {
             "error": "錯誤",


### PR DESCRIPTION
## 背景
日志列表在连续时间段边界不明显.加入了一个视觉提醒.方便排查日志.

## 变更内容
- 日志页新增时间段分割机制：当相邻日志时间差 >= 3 分钟时插入分割线
- 分割线文案支持多语言，并将中文文案统一为：`更早日志 · {time}`
- 修复分割线文案 key 未命中时显示 `log.list.timeGap` 的问题，增加兜底文案
- 优化分割线布局，使其与上下日志卡片间距一致、视觉垂直居中
  
## 影响文件
- `web/src/components/modules/log/index.tsx`
- `web/public/locale/zh_hans.json`
- `web/public/locale/zh_hant.json`
- `web/public/locale/en.json`
- `internal/server/middleware/cors.go`

## 跨域
- 顺手把本地localhost:3000加入了 CORS 白名单 方便调试,如果觉得不妥可以不合并.

<img width="2062" height="1028" alt="image" src="https://github.com/user-attachments/assets/5d3e5eae-8416-4a9f-97b4-560645e32fa1" />
