### PR TITLE
feat: 全局熔断策略与分组页面交互优化

### DIFF
--- a/internal/db/migrate/003.go
+++ b/internal/db/migrate/003.go
@@ -1,0 +1,28 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 3,
+		Up:      ensureCircuitBreakerColumns,
+	})
+}
+
+func ensureCircuitBreakerColumns(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+
+	if !db.Migrator().HasColumn(&model.RelayLog{}, "cb_log_level_max") {
+		if err := db.Migrator().AddColumn(&model.RelayLog{}, "cb_log_level_max"); err != nil {
+			return fmt.Errorf("failed to add relay_logs.cb_log_level_max: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/db/migrate/004.go
+++ b/internal/db/migrate/004.go
@@ -1,0 +1,29 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 4,
+		Up:      ensureGroupItemCircuitBreakerColumn,
+	})
+}
+
+func ensureGroupItemCircuitBreakerColumn(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	if db.Migrator().HasColumn(&model.GroupItem{}, "cb_enabled") {
+		return nil
+	}
+	if err := db.Migrator().AddColumn(&model.GroupItem{}, "cb_enabled"); err != nil {
+		return fmt.Errorf("failed to add group_items.cb_enabled: %w", err)
+	}
+	return nil
+}
+

--- a/internal/db/migrate/005.go
+++ b/internal/db/migrate/005.go
@@ -1,0 +1,41 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 5,
+		Up:      upgradeCircuitBreakerDefaultSettings,
+	})
+}
+
+// upgradeCircuitBreakerDefaultSettings upgrades legacy default values only.
+// It keeps user-customized values untouched.
+func upgradeCircuitBreakerDefaultSettings(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+
+	legacyToNew := map[model.SettingKey]struct {
+		oldVal string
+		newVal string
+	}{
+		model.SettingKeyCBFailureThreshold: {oldVal: "5", newVal: "3"},
+		model.SettingKeyCBBaseCooldownMS:   {oldVal: "30000", newVal: "60000"},
+		model.SettingKeyCBMaxCooldownMS:    {oldVal: "300000", newVal: "3600000"},
+	}
+
+	for key, pair := range legacyToNew {
+		if err := db.Model(&model.Setting{}).
+			Where("key = ? AND value = ?", key, pair.oldVal).
+			Update("value", pair.newVal).Error; err != nil {
+			return fmt.Errorf("failed to upgrade setting %s: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/internal/db/migrate/006.go
+++ b/internal/db/migrate/006.go
@@ -1,0 +1,29 @@
+package migrate
+
+import (
+	"fmt"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"gorm.io/gorm"
+)
+
+func init() {
+	RegisterAfterAutoMigration(Migration{
+		Version: 6,
+		Up:      upgradeCircuitBreakerBaseCooldownDefaultTo180s,
+	})
+}
+
+// upgradeCircuitBreakerBaseCooldownDefaultTo180s upgrades legacy default 60s to 180s.
+// User customized values are preserved.
+func upgradeCircuitBreakerBaseCooldownDefaultTo180s(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	if err := db.Model(&model.Setting{}).
+		Where("key = ? AND value = ?", model.SettingKeyCBBaseCooldownMS, "60000").
+		Update("value", "180000").Error; err != nil {
+		return fmt.Errorf("failed to upgrade setting %s: %w", model.SettingKeyCBBaseCooldownMS, err)
+	}
+	return nil
+}

--- a/internal/model/circuit_breaker.go
+++ b/internal/model/circuit_breaker.go
@@ -1,0 +1,62 @@
+package model
+
+type CircuitBreakerConfig struct {
+	Enabled          bool    `json:"enabled"`
+	FailureThreshold int     `json:"failure_threshold"`
+	BaseCooldownMS   int     `json:"base_cooldown_ms"`
+	MaxCooldownMS    int     `json:"max_cooldown_ms"`
+	BackoffFactor    float64 `json:"backoff_factor"`
+	JitterMin        float64 `json:"jitter_min"`
+	JitterMax        float64 `json:"jitter_max"`
+	DecayWindowMS    int     `json:"decay_window_ms"`
+}
+
+type CircuitBreakerState string
+
+const (
+	CircuitBreakerStateClosed   CircuitBreakerState = "CLOSED"
+	CircuitBreakerStateOpen     CircuitBreakerState = "OPEN"
+	CircuitBreakerStateHalfOpen CircuitBreakerState = "HALF_OPEN"
+)
+
+type GroupCircuitBreakerItemState struct {
+	GroupID             int                 `json:"group_id"`
+	GroupName           string              `json:"group_name"`
+	ChannelID           int                 `json:"channel_id"`
+	ChannelName         string              `json:"channel_name"`
+	ModelName           string              `json:"model_name"`
+	BreakerKey          string              `json:"breaker_key"`
+	State               CircuitBreakerState `json:"state"`
+	ConsecutiveFailures int                 `json:"consecutive_failures"`
+	TripCount           int                 `json:"trip_count"`
+	LastFailureAt       string              `json:"last_failure_at,omitempty"`
+	LastFailureReason   string              `json:"last_failure_reason,omitempty"`
+	LastTripAt          string              `json:"last_trip_at,omitempty"`
+	OpenUntil           string              `json:"open_until,omitempty"`
+	OpenRemainingSecond int                 `json:"open_remaining_second,omitempty"`
+	ProbeInFlight       bool                `json:"probe_in_flight"`
+}
+
+type GroupCircuitBreakerStatesResponse struct {
+	GroupID   int                            `json:"group_id"`
+	GroupName string                         `json:"group_name"`
+	Items     []GroupCircuitBreakerItemState `json:"items"`
+}
+
+type CircuitBreakerResetResponse struct {
+	ChannelID        int      `json:"channel_id"`
+	AffectedBreakers int      `json:"affected_breakers"`
+	BreakerKeys      []string `json:"breaker_keys,omitempty"`
+}
+
+type CircuitBreakerAllOpenScope struct {
+	GroupID   int    `json:"group_id"`
+	ModelName string `json:"model_name"`
+}
+
+type CircuitBreakerAllOpenData struct {
+	Reason            string                     `json:"reason"`
+	EarliestRetryAt   string                     `json:"earliest_retry_at"`
+	RetryAfterSeconds int                        `json:"retry_after_seconds"`
+	Scope             CircuitBreakerAllOpenScope `json:"scope"`
+}

--- a/internal/model/group.go
+++ b/internal/model/group.go
@@ -10,12 +10,13 @@ const (
 )
 
 type Group struct {
-	ID                int         `json:"id" gorm:"primaryKey"`
-	Name              string      `json:"name" gorm:"unique;not null"`
-	Mode              GroupMode   `json:"mode" gorm:"not null"`
-	MatchRegex        string      `json:"match_regex"`
-	FirstTokenTimeOut int         `json:"first_token_time_out"` // 单个渠道首个Token响应超时时间(秒)
-	Items             []GroupItem `json:"items,omitempty" gorm:"foreignKey:GroupID"`
+	ID                int       `json:"id" gorm:"primaryKey"`
+	Name              string    `json:"name" gorm:"unique;not null"`
+	Mode              GroupMode `json:"mode" gorm:"not null"`
+	MatchRegex        string    `json:"match_regex"`
+	FirstTokenTimeOut int       `json:"first_token_time_out"` // 单个渠道首个Token响应超时时间(秒)
+
+	Items []GroupItem `json:"items,omitempty" gorm:"foreignKey:GroupID"`
 }
 
 type GroupItem struct {
@@ -25,6 +26,7 @@ type GroupItem struct {
 	ModelName string `json:"model_name" gorm:"not null;index:idx_group_channel_model,unique"`
 	Priority  int    `json:"priority"`
 	Weight    int    `json:"weight"`
+	CBEnabled bool   `json:"-" gorm:"default:false"`
 }
 
 // GroupUpdateRequest 分组更新请求 - 仅包含变更的数据

--- a/internal/model/log.go
+++ b/internal/model/log.go
@@ -10,24 +10,40 @@ type ChannelAttempt struct {
 	Success     bool   `json:"success"`
 	Error       string `json:"error,omitempty"`
 	Duration    int    `json:"duration"` // 耗时(毫秒)
+
+	RelayStatusCode  int    `json:"relay_status_code,omitempty"`
+	RelayErrorSource string `json:"relay_error_source,omitempty"`
+	RelayRetryable   bool   `json:"relay_retryable,omitempty"`
+	RelayTrippable   bool   `json:"relay_trippable,omitempty"`
+
+	BreakerKey        string `json:"breaker_key,omitempty"`
+	CBDecision        string `json:"cb_decision,omitempty"`
+	CBStateBefore     string `json:"cb_state_before,omitempty"`
+	CBStateAfter      string `json:"cb_state_after,omitempty"`
+	CBTripCount       int    `json:"cb_trip_count,omitempty"`
+	CBOpenUntil       string `json:"cb_open_until,omitempty"`
+	ProbeInFlight     bool   `json:"probe_in_flight,omitempty"`
+	EarliestRetryAt   string `json:"earliest_retry_at,omitempty"`
+	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
 }
 
 type RelayLog struct {
-	ID               int64             `json:"id" gorm:"primaryKey;autoIncrement:false"` // Snowflake ID
-	Time             int64             `json:"time"`                                     // 时间戳（秒）
-	RequestModelName string            `json:"request_model_name"`                       // 请求模型名称
-	ChannelId        int               `json:"channel"`                                  // 实际使用的渠道ID
-	ChannelName      string            `json:"channel_name"`                             // 渠道名称
-	ActualModelName  string            `json:"actual_model_name"`                        // 实际使用模型名称
-	InputTokens      int               `json:"input_tokens"`                             // 输入Token
-	OutputTokens     int               `json:"output_tokens"`                            // 输出 Token
-	Ftut             int               `json:"ftut"`                                     // 首字时间(毫秒)
-	UseTime          int               `json:"use_time"`                                 // 总用时(毫秒)
-	Cost             float64           `json:"cost"`                                     // 消耗费用
-	RequestContent   string            `json:"request_content"`                          // 请求内容
-	ResponseContent  string            `json:"response_content"`                         // 响应内容
-	Error            string            `json:"error"`                                    // 错误信息
-	Attempts         []ChannelAttempt  `json:"attempts" gorm:"serializer:json"`          // 所有尝试记录
-	TotalAttempts    int               `json:"total_attempts"`                           // 总尝试次数
-	SuccessfulRound  int               `json:"successful_round"`                         // 成功的轮次
+	ID               int64            `json:"id" gorm:"primaryKey;autoIncrement:false"` // Snowflake ID
+	Time             int64            `json:"time"`                                     // 时间戳（秒）
+	RequestModelName string           `json:"request_model_name"`                       // 请求模型名称
+	ChannelId        int              `json:"channel"`                                  // 实际使用的渠道ID
+	ChannelName      string           `json:"channel_name"`                             // 渠道名称
+	ActualModelName  string           `json:"actual_model_name"`                        // 实际使用模型名称
+	InputTokens      int              `json:"input_tokens"`                             // 输入Token
+	OutputTokens     int              `json:"output_tokens"`                            // 输出 Token
+	Ftut             int              `json:"ftut"`                                     // 首字时间(毫秒)
+	UseTime          int              `json:"use_time"`                                 // 总用时(毫秒)
+	Cost             float64          `json:"cost"`                                     // 消耗费用
+	RequestContent   string           `json:"request_content"`                          // 请求内容
+	ResponseContent  string           `json:"response_content"`                         // 响应内容
+	Error            string           `json:"error"`                                    // 错误信息
+	Attempts         []ChannelAttempt `json:"attempts" gorm:"serializer:json"`          // 所有尝试记录
+	TotalAttempts    int              `json:"total_attempts"`                           // 总尝试次数
+	SuccessfulRound  int              `json:"successful_round"`                         // 成功的轮次
+	CBLogLevelMax    int              `json:"cb_log_level_max"`                         // 熔断相关日志等级 (1~3)
 }

--- a/internal/op/group.go
+++ b/internal/op/group.go
@@ -117,12 +117,13 @@ func GroupUpdate(req *model.GroupUpdateRequest, ctx context.Context) (*model.Gro
 		priorityCase += " END"
 		weightCase += " END"
 
+		updateMap := map[string]interface{}{
+			"priority": gorm.Expr(priorityCase),
+			"weight":   gorm.Expr(weightCase),
+		}
 		if err := tx.Model(&model.GroupItem{}).
 			Where("id IN ? AND group_id = ?", ids, req.ID).
-			Updates(map[string]interface{}{
-				"priority": gorm.Expr(priorityCase),
-				"weight":   gorm.Expr(weightCase),
-			}).Error; err != nil {
+			Updates(updateMap).Error; err != nil {
 			tx.Rollback()
 			return nil, fmt.Errorf("failed to update items: %w", err)
 		}
@@ -248,6 +249,7 @@ func GroupItemBatchAdd(groupID int, items []model.GroupIDAndLLMName, ctx context
 			ModelName: it.ModelName,
 			Priority:  nextPriority,
 			Weight:    1,
+			CBEnabled: false,
 		})
 		nextPriority++
 	}

--- a/internal/op/setting.go
+++ b/internal/op/setting.go
@@ -66,6 +66,14 @@ func SettingGetBool(key model.SettingKey) (bool, error) {
 	return strconv.ParseBool(setting)
 }
 
+func SettingGetFloat(key model.SettingKey) (float64, error) {
+	setting, ok := settingCache.Get(key)
+	if !ok {
+		return 0, fmt.Errorf("setting not found")
+	}
+	return strconv.ParseFloat(setting, 64)
+}
+
 func SettingSetInt(key model.SettingKey, value int) error {
 	valueCache, ok := settingCache.Get(key)
 	if !ok {

--- a/internal/relay/breaker/breaker.go
+++ b/internal/relay/breaker/breaker.go
@@ -1,0 +1,401 @@
+package breaker
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/model"
+)
+
+const shardCount = 64
+
+type Decision string
+
+const (
+	DecisionDisabled    Decision = "disabled"
+	DecisionClosedAllow Decision = "closed_allow"
+	DecisionSkipOpen    Decision = "skip_open"
+	DecisionProbeAllow  Decision = "probe_allowed"
+	DecisionProbeDenied Decision = "probe_denied"
+	DecisionRecordFail  Decision = "record_failure"
+	DecisionProbeFailed Decision = "probe_failed"
+	DecisionAllOpen     Decision = "all_open"
+)
+
+type AttemptAcquire struct {
+	Key           string
+	Allowed       bool
+	Decision      Decision
+	StateBefore   model.CircuitBreakerState
+	StateAfter    model.CircuitBreakerState
+	TripCount     int
+	OpenUntil     time.Time
+	ProbeGranted  bool
+	ProbeInFlight bool
+}
+
+type RecordResult struct {
+	Decision      Decision
+	StateAfter    model.CircuitBreakerState
+	TripCount     int
+	OpenUntil     time.Time
+	ProbeInFlight bool
+}
+
+type Snapshot struct {
+	Key                 string
+	State               model.CircuitBreakerState
+	ConsecutiveFailures int
+	TripCount           int
+	OpenUntil           time.Time
+	LastFailureAt       time.Time
+	LastFailureReason   string
+	LastTripAt          time.Time
+	ProbeInFlight       bool
+}
+
+type breakerState struct {
+	mu sync.Mutex
+
+	state               model.CircuitBreakerState
+	consecutiveFailures int
+	tripCount           int
+	openUntil           time.Time
+	lastFailureAt       time.Time
+	lastFailureReason   string
+	lastTripAt          time.Time
+	probeInFlight       uint32
+}
+
+type shard struct {
+	mu sync.RWMutex
+	m  map[string]*breakerState
+}
+
+type Manager struct {
+	shards [shardCount]shard
+}
+
+var globalManager = NewManager()
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func NewManager() *Manager {
+	m := &Manager{}
+	for i := 0; i < shardCount; i++ {
+		m.shards[i].m = make(map[string]*breakerState)
+	}
+	return m
+}
+
+func GetManager() *Manager {
+	return globalManager
+}
+
+func BuildKey(channelID int, modelName string) string {
+	return fmt.Sprintf("%d:%s", channelID, strings.TrimSpace(modelName))
+}
+
+func (m *Manager) FilterAvailable(items []model.GroupItem, now time.Time, cfg model.CircuitBreakerConfig) ([]model.GroupItem, time.Time) {
+	filtered := make([]model.GroupItem, 0, len(items))
+	if !cfg.Enabled {
+		filtered = append(filtered, items...)
+		return filtered, time.Time{}
+	}
+
+	var earliest time.Time
+	for _, item := range items {
+		snap := m.Snapshot(BuildKey(item.ChannelID, item.ModelName))
+		switch snap.State {
+		case model.CircuitBreakerStateOpen:
+			if now.Before(snap.OpenUntil) {
+				if earliest.IsZero() || snap.OpenUntil.Before(earliest) {
+					earliest = snap.OpenUntil
+				}
+				continue
+			}
+		case model.CircuitBreakerStateHalfOpen:
+			if snap.ProbeInFlight {
+				retryAt := snap.OpenUntil
+				if retryAt.IsZero() || retryAt.Before(now) {
+					retryAt = now.Add(1 * time.Second)
+				}
+				if earliest.IsZero() || retryAt.Before(earliest) {
+					earliest = retryAt
+				}
+				continue
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered, earliest
+}
+
+func (m *Manager) Acquire(key string, now time.Time, cfg model.CircuitBreakerConfig) AttemptAcquire {
+	if !cfg.Enabled {
+		return AttemptAcquire{
+			Key:         key,
+			Allowed:     true,
+			Decision:    DecisionDisabled,
+			StateBefore: model.CircuitBreakerStateClosed,
+			StateAfter:  model.CircuitBreakerStateClosed,
+		}
+	}
+	s := m.getOrCreateState(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := AttemptAcquire{
+		Key:         key,
+		Allowed:     false,
+		Decision:    DecisionSkipOpen,
+		StateBefore: s.state,
+		StateAfter:  s.state,
+		TripCount:   s.tripCount,
+		OpenUntil:   s.openUntil,
+	}
+
+	switch s.state {
+	case model.CircuitBreakerStateClosed:
+		result.Allowed = true
+		result.Decision = DecisionClosedAllow
+		return result
+	case model.CircuitBreakerStateOpen:
+		if now.Before(s.openUntil) {
+			return result
+		}
+		if atomic.CompareAndSwapUint32(&s.probeInFlight, 0, 1) {
+			s.state = model.CircuitBreakerStateHalfOpen
+			result.Allowed = true
+			result.Decision = DecisionProbeAllow
+			result.StateAfter = s.state
+			result.ProbeGranted = true
+			result.ProbeInFlight = true
+			return result
+		}
+		result.Decision = DecisionProbeDenied
+		result.ProbeInFlight = true
+		return result
+	case model.CircuitBreakerStateHalfOpen:
+		if atomic.CompareAndSwapUint32(&s.probeInFlight, 0, 1) {
+			result.Allowed = true
+			result.Decision = DecisionProbeAllow
+			result.ProbeGranted = true
+			result.ProbeInFlight = true
+			return result
+		}
+		result.Decision = DecisionProbeDenied
+		result.ProbeInFlight = true
+		return result
+	default:
+		s.state = model.CircuitBreakerStateClosed
+		result.Allowed = true
+		result.Decision = DecisionClosedAllow
+		result.StateAfter = s.state
+		return result
+	}
+}
+
+func (m *Manager) RecordSuccess(key string, acquire AttemptAcquire, cfg model.CircuitBreakerConfig, now time.Time) RecordResult {
+	s := m.getOrCreateState(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !cfg.Enabled {
+		atomic.StoreUint32(&s.probeInFlight, 0)
+		return m.recordResultFromState(s, DecisionDisabled)
+	}
+
+	if acquire.ProbeGranted || s.state == model.CircuitBreakerStateHalfOpen {
+		s.state = model.CircuitBreakerStateClosed
+	}
+	s.consecutiveFailures = 0
+	atomic.StoreUint32(&s.probeInFlight, 0)
+	return m.recordResultFromState(s, acquire.Decision)
+}
+
+func (m *Manager) RecordFailure(key, reason string, acquire AttemptAcquire, cfg model.CircuitBreakerConfig, now time.Time) RecordResult {
+	s := m.getOrCreateState(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	applyDecay(s, now, time.Duration(cfg.DecayWindowMS)*time.Millisecond)
+	s.lastFailureAt = now
+	s.lastFailureReason = truncateReason(reason)
+	s.consecutiveFailures++
+
+	shouldTrip := s.consecutiveFailures >= cfg.FailureThreshold || acquire.ProbeGranted || s.state == model.CircuitBreakerStateHalfOpen
+	decision := DecisionRecordFail
+	if shouldTrip {
+		s.tripCount++
+		s.openUntil = now.Add(cooldownForTrip(s.tripCount, cfg))
+		s.state = model.CircuitBreakerStateOpen
+		s.lastTripAt = now
+		s.consecutiveFailures = 0
+		if acquire.ProbeGranted || acquire.StateBefore == model.CircuitBreakerStateHalfOpen {
+			decision = DecisionProbeFailed
+		}
+	}
+	atomic.StoreUint32(&s.probeInFlight, 0)
+	return m.recordResultFromState(s, decision)
+}
+
+func (m *Manager) RecordNonTrippable(key string, acquire AttemptAcquire, cfg model.CircuitBreakerConfig) RecordResult {
+	s := m.getOrCreateState(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	atomic.StoreUint32(&s.probeInFlight, 0)
+	if cfg.Enabled && (acquire.ProbeGranted || s.state == model.CircuitBreakerStateHalfOpen) {
+		s.state = model.CircuitBreakerStateClosed
+		s.consecutiveFailures = 0
+	}
+	return m.recordResultFromState(s, acquire.Decision)
+}
+
+func (m *Manager) Snapshot(key string) Snapshot {
+	s := m.getState(key)
+	if s == nil {
+		return Snapshot{
+			Key:   key,
+			State: model.CircuitBreakerStateClosed,
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Snapshot{
+		Key:                 key,
+		State:               s.state,
+		ConsecutiveFailures: s.consecutiveFailures,
+		TripCount:           s.tripCount,
+		OpenUntil:           s.openUntil,
+		LastFailureAt:       s.lastFailureAt,
+		LastFailureReason:   s.lastFailureReason,
+		LastTripAt:          s.lastTripAt,
+		ProbeInFlight:       atomic.LoadUint32(&s.probeInFlight) == 1,
+	}
+}
+
+func (m *Manager) ResetChannel(channelID int) (int, []string) {
+	prefix := fmt.Sprintf("%d:", channelID)
+	keys := make([]string, 0)
+	for i := 0; i < shardCount; i++ {
+		sh := &m.shards[i]
+		sh.mu.Lock()
+		for key := range sh.m {
+			if strings.HasPrefix(key, prefix) {
+				delete(sh.m, key)
+				keys = append(keys, key)
+			}
+		}
+		sh.mu.Unlock()
+	}
+	return len(keys), keys
+}
+
+func (m *Manager) ResetKey(key string) bool {
+	sh := &m.shards[hashKey(key)%shardCount]
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if _, ok := sh.m[key]; !ok {
+		return false
+	}
+	delete(sh.m, key)
+	return true
+}
+
+func (m *Manager) getState(key string) *breakerState {
+	sh := &m.shards[hashKey(key)%shardCount]
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	return sh.m[key]
+}
+
+func (m *Manager) getOrCreateState(key string) *breakerState {
+	sh := &m.shards[hashKey(key)%shardCount]
+	sh.mu.RLock()
+	state := sh.m[key]
+	sh.mu.RUnlock()
+	if state != nil {
+		return state
+	}
+
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if state = sh.m[key]; state != nil {
+		return state
+	}
+	state = &breakerState{
+		state: model.CircuitBreakerStateClosed,
+	}
+	sh.m[key] = state
+	return state
+}
+
+func (m *Manager) recordResultFromState(s *breakerState, decision Decision) RecordResult {
+	return RecordResult{
+		Decision:      decision,
+		StateAfter:    s.state,
+		TripCount:     s.tripCount,
+		OpenUntil:     s.openUntil,
+		ProbeInFlight: atomic.LoadUint32(&s.probeInFlight) == 1,
+	}
+}
+
+func applyDecay(s *breakerState, now time.Time, decayWindow time.Duration) {
+	if s.tripCount == 0 || s.lastTripAt.IsZero() || decayWindow <= 0 {
+		return
+	}
+	steps := int(now.Sub(s.lastTripAt) / decayWindow)
+	if steps <= 0 {
+		return
+	}
+	s.tripCount = max(0, s.tripCount-steps)
+}
+
+func cooldownForTrip(tripCount int, cfg model.CircuitBreakerConfig) time.Duration {
+	n := max(1, tripCount)
+	base := float64(cfg.BaseCooldownMS)
+	maxCD := float64(cfg.MaxCooldownMS)
+	backoff := math.Pow(cfg.BackoffFactor, float64(n-1))
+	cooldown := base * backoff
+	if cooldown > maxCD {
+		cooldown = maxCD
+	}
+	jitter := cfg.JitterMin + rand.Float64()*(cfg.JitterMax-cfg.JitterMin)
+	if jitter < 0 {
+		jitter = 0
+	}
+	cooldown *= jitter
+	if cooldown < 1 {
+		cooldown = 1
+	}
+	return time.Duration(cooldown) * time.Millisecond
+}
+
+func hashKey(key string) int {
+	var h uint32 = 2166136261
+	const prime32 = 16777619
+	for i := 0; i < len(key); i++ {
+		h ^= uint32(key[i])
+		h *= prime32
+	}
+	return int(h)
+}
+
+func truncateReason(reason string) string {
+	const maxLen = 512
+	reason = strings.TrimSpace(reason)
+	if len(reason) <= maxLen {
+		return reason
+	}
+	return reason[:maxLen]
+}

--- a/internal/relay/breaker/breaker_test.go
+++ b/internal/relay/breaker/breaker_test.go
@@ -1,0 +1,77 @@
+package breaker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/model"
+)
+
+func testConfig() model.CircuitBreakerConfig {
+	return model.CircuitBreakerConfig{
+		Enabled:          true,
+		FailureThreshold: 2,
+		BaseCooldownMS:   1000,
+		MaxCooldownMS:    10000,
+		BackoffFactor:    2,
+		JitterMin:        1,
+		JitterMax:        1,
+		DecayWindowMS:    1000,
+	}
+}
+
+func TestProbeSingleFlight(t *testing.T) {
+	m := NewManager()
+	cfg := testConfig()
+	key := BuildKey(1, "glm-4.7")
+	now := time.Now()
+
+	// 先连续失败触发 OPEN
+	a1 := m.Acquire(key, now, cfg)
+	m.RecordFailure(key, "upstream 500", a1, cfg, now)
+	a2 := m.Acquire(key, now, cfg)
+	m.RecordFailure(key, "upstream 500", a2, cfg, now)
+
+	// OPEN 窗口内应拒绝
+	rejected := m.Acquire(key, now.Add(100*time.Millisecond), cfg)
+	if rejected.Allowed {
+		t.Fatalf("expected acquire rejected while OPEN")
+	}
+
+	// 过了 openUntil 后，只允许一个 probe
+	snap := m.Snapshot(key)
+	probe1 := m.Acquire(key, snap.OpenUntil.Add(10*time.Millisecond), cfg)
+	probe2 := m.Acquire(key, snap.OpenUntil.Add(10*time.Millisecond), cfg)
+
+	if !probe1.Allowed && !probe2.Allowed {
+		t.Fatalf("expected one probe to be allowed")
+	}
+	if probe1.Allowed && probe2.Allowed {
+		t.Fatalf("expected only one probe to be allowed")
+	}
+}
+
+func TestDecayTripCount(t *testing.T) {
+	m := NewManager()
+	cfg := testConfig()
+	key := BuildKey(2, "gpt-4o")
+	now := time.Now()
+
+	// trip 1
+	a1 := m.Acquire(key, now, cfg)
+	m.RecordFailure(key, "x", a1, cfg, now)
+	a2 := m.Acquire(key, now, cfg)
+	m.RecordFailure(key, "x", a2, cfg, now)
+	s1 := m.Snapshot(key)
+	if s1.TripCount != 1 {
+		t.Fatalf("expected tripCount=1, got %d", s1.TripCount)
+	}
+
+	// 长时间稳定后再次故障，先衰减再计算
+	later := now.Add(5 * time.Second)
+	a3 := m.Acquire(key, later, cfg)
+	r3 := m.RecordFailure(key, "x", a3, cfg, later)
+	if r3.TripCount != 1 {
+		t.Fatalf("expected decay to reduce tripCount before re-trip, got %d", r3.TripCount)
+	}
+}

--- a/internal/relay/breaker/config.go
+++ b/internal/relay/breaker/config.go
@@ -1,0 +1,70 @@
+package breaker
+
+import (
+	"github.com/bestruirui/octopus/internal/model"
+	"github.com/bestruirui/octopus/internal/op"
+)
+
+var defaultConfig = model.CircuitBreakerConfig{
+	Enabled:          true,
+	FailureThreshold: 3,
+	BaseCooldownMS:   180_000,
+	MaxCooldownMS:    3_600_000,
+	BackoffFactor:    2,
+	JitterMin:        0.5,
+	JitterMax:        1.5,
+	DecayWindowMS:    21_600_000, // 6h
+}
+
+func loadGlobalConfig() model.CircuitBreakerConfig {
+	cfg := defaultConfig
+
+	if v, err := op.SettingGetBool(model.SettingKeyCBEnabled); err == nil {
+		cfg.Enabled = v
+	}
+	if v, err := op.SettingGetInt(model.SettingKeyCBFailureThreshold); err == nil {
+		cfg.FailureThreshold = v
+	}
+	if v, err := op.SettingGetInt(model.SettingKeyCBBaseCooldownMS); err == nil {
+		cfg.BaseCooldownMS = v
+	}
+	if v, err := op.SettingGetInt(model.SettingKeyCBMaxCooldownMS); err == nil {
+		cfg.MaxCooldownMS = v
+	}
+	if v, err := op.SettingGetFloat(model.SettingKeyCBBackoffFactor); err == nil {
+		cfg.BackoffFactor = v
+	}
+	return sanitizeConfig(cfg)
+}
+
+func ResolveEffectiveConfig() model.CircuitBreakerConfig {
+	return loadGlobalConfig()
+}
+
+func sanitizeConfig(cfg model.CircuitBreakerConfig) model.CircuitBreakerConfig {
+	if cfg.FailureThreshold <= 0 {
+		cfg.FailureThreshold = defaultConfig.FailureThreshold
+	}
+	if cfg.BaseCooldownMS <= 0 {
+		cfg.BaseCooldownMS = defaultConfig.BaseCooldownMS
+	}
+	if cfg.MaxCooldownMS <= 0 {
+		cfg.MaxCooldownMS = defaultConfig.MaxCooldownMS
+	}
+	if cfg.MaxCooldownMS < cfg.BaseCooldownMS {
+		cfg.MaxCooldownMS = cfg.BaseCooldownMS
+	}
+	if cfg.BackoffFactor < 1 {
+		cfg.BackoffFactor = defaultConfig.BackoffFactor
+	}
+	if cfg.JitterMin <= 0 {
+		cfg.JitterMin = defaultConfig.JitterMin
+	}
+	if cfg.JitterMax < cfg.JitterMin {
+		cfg.JitterMax = cfg.JitterMin
+	}
+	if cfg.DecayWindowMS <= 0 {
+		cfg.DecayWindowMS = defaultConfig.DecayWindowMS
+	}
+	return cfg
+}

--- a/internal/relay/error.go
+++ b/internal/relay/error.go
@@ -1,0 +1,90 @@
+package relay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+type RelayErrorSource string
+
+const (
+	RelayErrorSourceUpstream RelayErrorSource = "upstream"
+	RelayErrorSourceNetwork  RelayErrorSource = "network"
+	RelayErrorSourceTimeout  RelayErrorSource = "timeout"
+	RelayErrorSourceLocal    RelayErrorSource = "local"
+)
+
+type RelayError struct {
+	StatusCode int
+	Source     RelayErrorSource
+	Retryable  bool
+	Trippable  bool
+	Cause      error
+	Message    string
+}
+
+func (e *RelayError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	if e.Cause != nil {
+		return e.Cause.Error()
+	}
+	return "relay error"
+}
+
+func newRelayError(statusCode int, source RelayErrorSource, retryable, trippable bool, cause error, message string) *RelayError {
+	return &RelayError{
+		StatusCode: statusCode,
+		Source:     source,
+		Retryable:  retryable,
+		Trippable:  trippable,
+		Cause:      cause,
+		Message:    message,
+	}
+}
+
+func classifyTransportError(err error) *RelayError {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return newRelayError(0, RelayErrorSourceTimeout, true, true, err, err.Error())
+	}
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return newRelayError(0, RelayErrorSourceTimeout, true, true, err, err.Error())
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "deadline exceeded"),
+		strings.Contains(msg, "first token timeout"):
+		return newRelayError(0, RelayErrorSourceTimeout, true, true, err, err.Error())
+	default:
+		return newRelayError(0, RelayErrorSourceNetwork, true, true, err, err.Error())
+	}
+}
+
+func classifyUpstreamStatus(statusCode int, body string) *RelayError {
+	message := fmt.Sprintf("upstream error: %d", statusCode)
+	if body != "" {
+		message = fmt.Sprintf("upstream error: %d: %s", statusCode, body)
+	}
+	switch {
+	case statusCode == 429:
+		return newRelayError(statusCode, RelayErrorSourceUpstream, true, false, nil, message)
+	case statusCode >= 500 && statusCode < 600:
+		return newRelayError(statusCode, RelayErrorSourceUpstream, true, true, nil, message)
+	case statusCode == 401 || statusCode == 403:
+		return newRelayError(statusCode, RelayErrorSourceUpstream, false, false, nil, message)
+	default:
+		return newRelayError(statusCode, RelayErrorSourceUpstream, false, false, nil, message)
+	}
+}

--- a/internal/server/handlers/circuit_breaker.go
+++ b/internal/server/handlers/circuit_breaker.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"github.com/bestruirui/octopus/internal/op"
+	"github.com/bestruirui/octopus/internal/relay/breaker"
+	"github.com/bestruirui/octopus/internal/server/middleware"
+	"github.com/bestruirui/octopus/internal/server/resp"
+	"github.com/bestruirui/octopus/internal/server/router"
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	router.NewGroupRouter("/api/v1/circuit-breaker").
+		Use(middleware.Auth()).
+		AddRoute(
+			router.NewRoute("/group/:groupId/states", http.MethodGet).
+				Handle(getGroupCircuitBreakerStates),
+		).
+		AddRoute(
+			router.NewRoute("/channel/:channelId/reset", http.MethodPost).
+				Handle(resetChannelCircuitBreaker),
+		).
+		AddRoute(
+			router.NewRoute("/item/reset", http.MethodPost).
+				Use(middleware.RequireJSON()).
+				Handle(resetCircuitBreakerItem),
+		)
+}
+
+func getGroupCircuitBreakerStates(c *gin.Context) {
+	groupID, ok := parseParamInt(c, "groupId")
+	if !ok {
+		return
+	}
+	group, err := op.GroupGet(groupID, c.Request.Context())
+	if err != nil {
+		resp.Error(c, http.StatusNotFound, err.Error())
+		return
+	}
+
+	m := breaker.GetManager()
+	items := make([]model.GroupCircuitBreakerItemState, 0, len(group.Items))
+	for _, item := range group.Items {
+		channelName := ""
+		if ch, chErr := op.ChannelGet(item.ChannelID, c.Request.Context()); chErr == nil {
+			channelName = ch.Name
+		}
+		key := breaker.BuildKey(item.ChannelID, item.ModelName)
+		snap := m.Snapshot(key)
+		items = append(items, model.GroupCircuitBreakerItemState{
+			GroupID:             group.ID,
+			GroupName:           group.Name,
+			ChannelID:           item.ChannelID,
+			ChannelName:         channelName,
+			ModelName:           item.ModelName,
+			BreakerKey:          key,
+			State:               snap.State,
+			ConsecutiveFailures: snap.ConsecutiveFailures,
+			TripCount:           snap.TripCount,
+			LastFailureAt:       formatTime(snap.LastFailureAt),
+			LastFailureReason:   snap.LastFailureReason,
+			LastTripAt:          formatTime(snap.LastTripAt),
+			OpenUntil:           formatTime(snap.OpenUntil),
+			OpenRemainingSecond: openRemainingSeconds(snap.OpenUntil),
+			ProbeInFlight:       snap.ProbeInFlight,
+		})
+	}
+
+	resp.Success(c, model.GroupCircuitBreakerStatesResponse{
+		GroupID:   group.ID,
+		GroupName: group.Name,
+		Items:     items,
+	})
+}
+
+func resetChannelCircuitBreaker(c *gin.Context) {
+	channelID, ok := parseParamInt(c, "channelId")
+	if !ok {
+		return
+	}
+	affected, keys := breaker.GetManager().ResetChannel(channelID)
+	resp.Success(c, model.CircuitBreakerResetResponse{
+		ChannelID:        channelID,
+		AffectedBreakers: affected,
+		BreakerKeys:      keys,
+	})
+}
+
+func resetCircuitBreakerItem(c *gin.Context) {
+	var req struct {
+		ChannelID int    `json:"channel_id" binding:"required"`
+		ModelName string `json:"model_name" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resp.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	key := breaker.BuildKey(req.ChannelID, req.ModelName)
+	affected := 0
+	if breaker.GetManager().ResetKey(key) {
+		affected = 1
+	}
+	resp.Success(c, gin.H{
+		"breaker_key":       key,
+		"affected_breakers": affected,
+	})
+}
+
+func parseParamInt(c *gin.Context, name string) (int, bool) {
+	raw := c.Param(name)
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		resp.Error(c, http.StatusBadRequest, err.Error())
+		return 0, false
+	}
+	return v, true
+}
+
+func formatTime(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.UTC().Format(time.RFC3339Nano)
+}
+
+func openRemainingSeconds(openUntil time.Time) int {
+	if openUntil.IsZero() {
+		return 0
+	}
+	now := time.Now()
+	if !openUntil.After(now) {
+		return 0
+	}
+	return int(openUntil.Sub(now).Seconds() + 0.999)
+}

--- a/internal/server/resp/resp.go
+++ b/internal/server/resp/resp.go
@@ -26,3 +26,11 @@ func Error(c *gin.Context, code int, err string) {
 		Message: err,
 	})
 }
+
+func ErrorWithData(c *gin.Context, code int, err string, data any) {
+	c.AbortWithStatusJSON(code, ResponseStruct{
+		Code:    code,
+		Message: err,
+		Data:    data,
+	})
+}

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -280,6 +280,18 @@
             },
             "clearSuccess": "Logs cleared",
             "clearFailed": "Failed to clear logs"
+        },
+        "circuitBreaker": {
+            "title": "Circuit Breaker",
+            "enabled": "Enable Circuit Breaker",
+            "failureThreshold": "Failure Threshold",
+            "failureThresholdTip": "Consecutive failures needed before entering OPEN.",
+            "baseCooldownS": "Base Cooldown (s)",
+            "baseCooldownSTip": "Initial OPEN cooldown duration in seconds.",
+            "maxCooldownS": "Max Cooldown (s)",
+            "maxCooldownSTip": "Upper bound of cooldown duration in seconds.",
+            "backoffFactor": "Backoff Factor",
+            "backoffFactorTip": "Cooldown multiplier per trip, e.g. 2 means exponential growth."
         }
     },
     "group": {
@@ -322,6 +334,18 @@
             "clear": "Clear",
             "selectChannel": "Channel",
             "selectModel": "Model"
+        },
+        "circuitBreaker": {
+            "itemInfo": "Model (Channel)",
+            "resetChannel": "Reset Item",
+            "resetChannelSuccess": "Model breaker reset",
+            "col": {
+                "state": "State",
+                "trip": "Backoff Level",
+                "openUntil": "Open Until",
+                "action": "Reset Breaker",
+                "switch": "Breaker"
+            }
         },
         "mode": {
             "roundRobin": "Round Robin",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -280,6 +280,18 @@
             },
             "clearSuccess": "日志已清空",
             "clearFailed": "清空失败"
+        },
+        "circuitBreaker": {
+            "title": "熔断设置",
+            "enabled": "启用熔断",
+            "failureThreshold": "失败阈值",
+            "failureThresholdTip": "连续失败达到该值后进入 OPEN。",
+            "baseCooldownS": "基础冷却（秒）",
+            "baseCooldownSTip": "第一次 OPEN 时的冷却时长（秒）。",
+            "maxCooldownS": "最大冷却（秒）",
+            "maxCooldownSTip": "冷却时长上限（秒）。",
+            "backoffFactor": "退避系数",
+            "backoffFactorTip": "每次 trip 后冷却倍增系数，例如 2 表示指数增长。"
         }
     },
     "group": {
@@ -322,6 +334,18 @@
             "clear": "清空",
             "selectChannel": "渠道",
             "selectModel": "模型"
+        },
+        "circuitBreaker": {
+            "itemInfo": "模型（渠道）",
+            "resetChannel": "重置模型项",
+            "resetChannelSuccess": "模型熔断状态已重置",
+            "col": {
+                "state": "熔断状态",
+                "trip": "退避级别",
+                "openUntil": "恢复时间",
+                "action": "重置熔断",
+                "switch": "熔断"
+            }
         },
         "mode": {
             "roundRobin": "轮询",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -280,6 +280,18 @@
             },
             "clearSuccess": "日誌已清空",
             "clearFailed": "清空失敗"
+        },
+        "circuitBreaker": {
+            "title": "熔斷設定",
+            "enabled": "啟用熔斷",
+            "failureThreshold": "失敗閾值",
+            "failureThresholdTip": "連續失敗達到該值後進入 OPEN。",
+            "baseCooldownS": "基礎冷卻（秒）",
+            "baseCooldownSTip": "首次 OPEN 時的冷卻時長（秒）。",
+            "maxCooldownS": "最大冷卻（秒）",
+            "maxCooldownSTip": "冷卻時長上限（秒）。",
+            "backoffFactor": "退避係數",
+            "backoffFactorTip": "每次 trip 後冷卻倍增係數，例如 2 表示指數增長。"
         }
     },
     "group": {
@@ -322,6 +334,18 @@
             "clear": "清空",
             "selectChannel": "供應源",
             "selectModel": "模型"
+        },
+        "circuitBreaker": {
+            "itemInfo": "模型（渠道）",
+            "resetChannel": "重置模型項",
+            "resetChannelSuccess": "模型熔斷狀態已重置",
+            "col": {
+                "state": "熔斷狀態",
+                "trip": "退避級別",
+                "openUntil": "恢復時間",
+                "action": "重置熔斷",
+                "switch": "熔斷"
+            }
         },
         "mode": {
             "roundRobin": "輪詢",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -47,6 +47,7 @@ async function handleResponse<T>(response: Response): Promise<T> {
             message: (data && typeof data === 'object' && 'message' in data && typeof data.message === 'string')
                 ? data.message
                 : (typeof data === 'string' ? data : response.statusText),
+            data: data && typeof data === 'object' && 'data' in data ? data.data : undefined,
         };
 
         handleError(error);
@@ -136,4 +137,3 @@ export const apiClient = {
     patch: <T>(path: string, data?: unknown, params?: Record<string, string | number | boolean>): Promise<T> =>
         request<T>('PATCH', path, data ? JSON.stringify(data) : undefined, params),
 };
-

--- a/web/src/api/endpoints/circuit-breaker.ts
+++ b/web/src/api/endpoints/circuit-breaker.ts
@@ -1,0 +1,62 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../client';
+import { logger } from '@/lib/logger';
+import { useRef } from 'react';
+
+export interface GroupCircuitBreakerItemState {
+    group_id: number;
+    group_name: string;
+    channel_id: number;
+    channel_name: string;
+    model_name: string;
+    breaker_key: string;
+    state: 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+    consecutive_failures: number;
+    trip_count: number;
+    last_failure_at?: string;
+    last_failure_reason?: string;
+    last_trip_at?: string;
+    open_until?: string;
+    open_remaining_second?: number;
+    probe_in_flight: boolean;
+}
+
+export interface GroupCircuitBreakerStatesResponse {
+    group_id: number;
+    group_name: string;
+    items: GroupCircuitBreakerItemState[];
+}
+
+export interface CircuitBreakerResetResponse {
+    affected_breakers: number;
+    breaker_key?: string;
+    breaker_keys?: string[];
+}
+
+export function useGroupCircuitBreakerStates(groupId: number, enabled: boolean) {
+    const lastHotAtRef = useRef(0);
+    return useQuery({
+        queryKey: ['circuit-breaker', 'group-states', groupId],
+        queryFn: async () => {
+            const data = await apiClient.get<GroupCircuitBreakerStatesResponse>(`/api/v1/circuit-breaker/group/${groupId}/states`);
+            const hasHotState = (data.items ?? []).some(item => item.state === 'OPEN' || item.state === 'HALF_OPEN');
+            if (hasHotState) lastHotAtRef.current = Date.now();
+            return data;
+        },
+        enabled: enabled && groupId > 0,
+        refetchInterval: () => Date.now() < lastHotAtRef.current + 120000 ? 5000 : 15000,
+        refetchOnMount: 'always',
+    });
+}
+
+export function useResetCircuitBreakerItem() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: async (payload: { channel_id: number; model_name: string }) =>
+            apiClient.post<CircuitBreakerResetResponse>('/api/v1/circuit-breaker/item/reset', payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['circuit-breaker'] });
+        },
+        onError: (error) => logger.error('重置模型熔断状态失败:', error),
+    });
+}

--- a/web/src/api/endpoints/group.ts
+++ b/web/src/api/endpoints/group.ts
@@ -203,4 +203,3 @@ export function useDeleteGroup() {
 //         },
 //     });
 // }
-

--- a/web/src/api/endpoints/log.ts
+++ b/web/src/api/endpoints/log.ts
@@ -16,6 +16,19 @@ export interface ChannelAttempt {
     success: boolean;
     error?: string;
     duration: number;       // 耗时(毫秒)
+    relay_status_code?: number;
+    relay_error_source?: string;
+    relay_retryable?: boolean;
+    relay_trippable?: boolean;
+    breaker_key?: string;
+    cb_decision?: string;
+    cb_state_before?: string;
+    cb_state_after?: string;
+    cb_trip_count?: number;
+    cb_open_until?: string;
+    probe_in_flight?: boolean;
+    earliest_retry_at?: string;
+    retry_after_seconds?: number;
 }
 
 /**
@@ -39,6 +52,7 @@ export interface RelayLog {
     attempts?: ChannelAttempt[]; // 所有尝试记录
     total_attempts?: number;     // 总尝试次数
     successful_round?: number;   // 成功的轮次
+    cb_log_level_max?: number;
 }
 
 /**

--- a/web/src/api/endpoints/setting.ts
+++ b/web/src/api/endpoints/setting.ts
@@ -19,6 +19,14 @@ export const SettingKey = {
     RelayLogKeepEnabled: 'relay_log_keep_enabled',
     RelayLogKeepPeriod: 'relay_log_keep_period',
     CORSAllowOrigins: 'cors_allow_origins',
+    CBEnabled: 'cb_enabled',
+    CBFailureThreshold: 'cb_failure_threshold',
+    CBBaseCooldownMS: 'cb_base_cooldown_ms',
+    CBMaxCooldownMS: 'cb_max_cooldown_ms',
+    CBBackoffFactor: 'cb_backoff_factor',
+    CBJitterMin: 'cb_jitter_min',
+    CBJitterMax: 'cb_jitter_max',
+    CBDecayWindowMS: 'cb_decay_window_ms',
 } as const;
 
 /**
@@ -206,4 +214,3 @@ export function useImportDB() {
         },
     });
 }
-

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -13,6 +13,7 @@ export interface ApiResponse<T = unknown> {
 export interface ApiError {
     code: number;
     message: string;
+    data?: unknown;
 }
 
 /**

--- a/web/src/components/modules/group/Editor.tsx
+++ b/web/src/components/modules/group/Editor.tsx
@@ -443,5 +443,3 @@ export function GroupEditor({
         </form>
     );
 }
-
-

--- a/web/src/components/modules/group/index.tsx
+++ b/web/src/components/modules/group/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { GroupCard } from './Card';
 import { useGroupList } from '@/api/endpoints/group';
+import { useSettingList, SettingKey } from '@/api/endpoints/setting';
 import { usePaginationStore, useSearchStore } from '@/components/modules/toolbar';
 import { EASING } from '@/lib/animations/fluid-transitions';
 import { useGridPageSize } from '@/hooks/use-grid-page-size';
@@ -13,11 +14,13 @@ const GROUP_CARD_HEIGHT = 280;
 
 export function Group() {
     const { data: groups } = useGroupList();
+    const { data: settings = [] } = useSettingList();
+    const cbFeatureEnabled = settings.find(s => s.key === SettingKey.CBEnabled)?.value === 'true';
     const pageKey = 'group' as const;
     const pageSize = useGridPageSize({
         itemHeight: GROUP_CARD_HEIGHT,
         gap: 16,
-        columns: { default: 1, md: 2, lg: 3 },
+        columns: cbFeatureEnabled ? { default: 1 } : { default: 1, md: 2, lg: 3 },
     });
     const searchTerm = useSearchStore((s) => s.getSearchTerm(pageKey));
     const page = usePaginationStore((s) => s.getPage(pageKey));
@@ -65,7 +68,7 @@ export function Group() {
                 exit="exit"
                 transition={{ duration: 0.25, ease: EASING.easeOutExpo }}
             >
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div className={cbFeatureEnabled ? 'grid grid-cols-1 gap-4' : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'}>
                     <AnimatePresence mode="popLayout">
                         {pagedGroups.map((group, index) => (
                             <motion.div

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -292,6 +292,11 @@ export function LogCard({ log }: { log: RelayLog }) {
                                 </Badge>
                             )}
                             <span className="text-muted-foreground">{log.actual_model_name}</span>
+                            {typeof log.cb_log_level_max === 'number' && (
+                                <Badge variant="outline" className="text-[10px] h-5 px-2">
+                                    CB-L{log.cb_log_level_max}
+                                </Badge>
+                            )}
                         </MorphingDialogTitle>
 
                         <MorphingDialogDescription className="flex-1 min-h-0">
@@ -395,6 +400,14 @@ export function LogCard({ log }: { log: RelayLog }) {
                                                                         {attempt.error && (
                                                                             <div className="text-destructive/90 pl-2 border-l-2 border-destructive/30 text-[11px] leading-relaxed">
                                                                                 {attempt.error}
+                                                                            </div>
+                                                                        )}
+                                                                        {(attempt.cb_decision || attempt.cb_state_after) && (
+                                                                            <div className="text-[11px] text-muted-foreground space-y-0.5">
+                                                                                {attempt.cb_decision && <div>CB: {attempt.cb_decision}</div>}
+                                                                                {attempt.cb_state_after && <div>State: {attempt.cb_state_before || '-'} → {attempt.cb_state_after}</div>}
+                                                                                {typeof attempt.cb_trip_count === 'number' && <div>Trip: {attempt.cb_trip_count}</div>}
+                                                                                {attempt.cb_open_until && <div>OpenUntil: {attempt.cb_open_until}</div>}
                                                                             </div>
                                                                         )}
                                                                     </div>

--- a/web/src/components/modules/setting/System.tsx
+++ b/web/src/components/modules/setting/System.tsx
@@ -1,12 +1,29 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Monitor, Globe, Clock, Shield, HelpCircle } from 'lucide-react';
+import { Monitor, Globe, Clock, Shield, HelpCircle, ShieldAlert } from 'lucide-react';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { useSettingList, useSetSetting, SettingKey } from '@/api/endpoints/setting';
 import { toast } from '@/components/common/Toast';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/animate-ui/components/animate/tooltip';
+
+function TipLabel({ text, tip }: { text: string; tip: string }) {
+    return (
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+            {text}
+            <TooltipProvider>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <HelpCircle className="size-4 text-muted-foreground cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent>{tip}</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
+        </span>
+    );
+}
 
 export function SettingSystem() {
     const t = useTranslations('setting');
@@ -17,43 +34,60 @@ export function SettingSystem() {
     const [statsSaveInterval, setStatsSaveInterval] = useState('');
     const [corsAllowOrigins, setCorsAllowOrigins] = useState('');
 
+    const [cbEnabled, setCBEnabled] = useState(false);
+    const [cbFailureThreshold, setCBFailureThreshold] = useState('');
+    const [cbBaseCooldownS, setCBBaseCooldownS] = useState('');
+    const [cbMaxCooldownS, setCBMaxCooldownS] = useState('');
+    const [cbBackoffFactor, setCBBackoffFactor] = useState('');
+
     const initialProxyUrl = useRef('');
     const initialStatsSaveInterval = useRef('');
     const initialCorsAllowOrigins = useRef('');
+    const initialCBEnabled = useRef(false);
+    const initialCBFailureThreshold = useRef('');
+    const initialCBBaseCooldownMS = useRef('');
+    const initialCBMaxCooldownMS = useRef('');
+    const initialCBBackoffFactor = useRef('');
 
     useEffect(() => {
-        if (settings) {
-            const proxy = settings.find(s => s.key === SettingKey.ProxyURL);
-            const interval = settings.find(s => s.key === SettingKey.StatsSaveInterval);
-            const cors = settings.find(s => s.key === SettingKey.CORSAllowOrigins);
-            if (proxy) {
-                queueMicrotask(() => setProxyUrl(proxy.value));
-                initialProxyUrl.current = proxy.value;
-            }
-            if (interval) {
-                queueMicrotask(() => setStatsSaveInterval(interval.value));
-                initialStatsSaveInterval.current = interval.value;
-            }
-            if (cors) {
-                queueMicrotask(() => setCorsAllowOrigins(cors.value));
-                initialCorsAllowOrigins.current = cors.value;
-            }
-        }
+        if (!settings) return;
+        const get = (key: string) => settings.find(s => s.key === key)?.value ?? '';
+        const proxy = get(SettingKey.ProxyURL);
+        const interval = get(SettingKey.StatsSaveInterval);
+        const cors = get(SettingKey.CORSAllowOrigins);
+        const cbEnabledV = get(SettingKey.CBEnabled) === 'true';
+        const cbFailureThresholdV = get(SettingKey.CBFailureThreshold);
+        const cbBaseCooldownMSV = get(SettingKey.CBBaseCooldownMS);
+        const cbMaxCooldownMSV = get(SettingKey.CBMaxCooldownMS);
+        const cbBackoffFactorV = get(SettingKey.CBBackoffFactor);
+
+        queueMicrotask(() => {
+            setProxyUrl(proxy);
+            setStatsSaveInterval(interval);
+            setCorsAllowOrigins(cors);
+            setCBEnabled(cbEnabledV);
+            setCBFailureThreshold(cbFailureThresholdV);
+            setCBBaseCooldownS(msToSecondsString(cbBaseCooldownMSV));
+            setCBMaxCooldownS(msToSecondsString(cbMaxCooldownMSV));
+            setCBBackoffFactor(cbBackoffFactorV);
+        });
+
+        initialProxyUrl.current = proxy;
+        initialStatsSaveInterval.current = interval;
+        initialCorsAllowOrigins.current = cors;
+        initialCBEnabled.current = cbEnabledV;
+        initialCBFailureThreshold.current = cbFailureThresholdV;
+        initialCBBaseCooldownMS.current = cbBaseCooldownMSV;
+        initialCBMaxCooldownMS.current = cbMaxCooldownMSV;
+        initialCBBackoffFactor.current = cbBackoffFactorV;
     }, [settings]);
 
-    const handleSave = (key: string, value: string, initialValue: string) => {
+    const handleSave = (key: string, value: string, initialValue: string, onSaved?: () => void) => {
         if (value === initialValue) return;
-
         setSetting.mutate({ key, value }, {
             onSuccess: () => {
                 toast.success(t('saved'));
-                if (key === SettingKey.ProxyURL) {
-                    initialProxyUrl.current = value;
-                } else if (key === SettingKey.StatsSaveInterval) {
-                    initialStatsSaveInterval.current = value;
-                } else if (key === SettingKey.CORSAllowOrigins) {
-                    initialCorsAllowOrigins.current = value;
-                }
+                onSaved?.();
             }
         });
     };
@@ -65,7 +99,6 @@ export function SettingSystem() {
                 {t('system')}
             </h2>
 
-            {/* 代理地址 */}
             <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
                     <Globe className="h-5 w-5 text-muted-foreground" />
@@ -74,13 +107,14 @@ export function SettingSystem() {
                 <Input
                     value={proxyUrl}
                     onChange={(e) => setProxyUrl(e.target.value)}
-                    onBlur={() => handleSave('proxy_url', proxyUrl, initialProxyUrl.current)}
+                    onBlur={() => handleSave(SettingKey.ProxyURL, proxyUrl, initialProxyUrl.current, () => {
+                        initialProxyUrl.current = proxyUrl;
+                    })}
                     placeholder={t('proxyUrl.placeholder')}
                     className="w-48 rounded-xl"
                 />
             </div>
 
-            {/* 统计保存周期 */}
             <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
                     <Clock className="h-5 w-5 text-muted-foreground" />
@@ -90,13 +124,14 @@ export function SettingSystem() {
                     type="number"
                     value={statsSaveInterval}
                     onChange={(e) => setStatsSaveInterval(e.target.value)}
-                    onBlur={() => handleSave('stats_save_interval', statsSaveInterval, initialStatsSaveInterval.current)}
+                    onBlur={() => handleSave(SettingKey.StatsSaveInterval, statsSaveInterval, initialStatsSaveInterval.current, () => {
+                        initialStatsSaveInterval.current = statsSaveInterval;
+                    })}
                     placeholder={t('statsSaveInterval.placeholder')}
                     className="w-48 rounded-xl"
                 />
             </div>
 
-            {/* CORS 跨域白名单 */}
             <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
                     <Shield className="h-5 w-5 text-muted-foreground" />
@@ -117,10 +152,105 @@ export function SettingSystem() {
                 <Input
                     value={corsAllowOrigins}
                     onChange={(e) => setCorsAllowOrigins(e.target.value)}
-                    onBlur={() => handleSave(SettingKey.CORSAllowOrigins, corsAllowOrigins, initialCorsAllowOrigins.current)}
+                    onBlur={() => handleSave(SettingKey.CORSAllowOrigins, corsAllowOrigins, initialCorsAllowOrigins.current, () => {
+                        initialCorsAllowOrigins.current = corsAllowOrigins;
+                    })}
                     className="w-48 rounded-xl"
                 />
             </div>
+
+            <div className="pt-2 border-t border-border/50 space-y-3">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                        <ShieldAlert className="h-5 w-5 text-muted-foreground" />
+                        <span className="text-sm font-medium">{t('circuitBreaker.enabled')}</span>
+                    </div>
+                    <Switch
+                        checked={cbEnabled}
+                        onCheckedChange={(checked) => {
+                            setCBEnabled(checked);
+                            handleSave(SettingKey.CBEnabled, checked ? 'true' : 'false', initialCBEnabled.current ? 'true' : 'false', () => {
+                                initialCBEnabled.current = checked;
+                            });
+                        }}
+                    />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                        <TipLabel text={t('circuitBreaker.failureThreshold')} tip={t('circuitBreaker.failureThresholdTip')} />
+                        <Input
+                            type="number"
+                            value={cbFailureThreshold}
+                            onChange={(e) => setCBFailureThreshold(e.target.value)}
+                            onBlur={() => handleSave(SettingKey.CBFailureThreshold, cbFailureThreshold, initialCBFailureThreshold.current, () => {
+                                initialCBFailureThreshold.current = cbFailureThreshold;
+                            })}
+                            className="rounded-xl"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <TipLabel text={t('circuitBreaker.baseCooldownS')} tip={t('circuitBreaker.baseCooldownSTip')} />
+                        <Input
+                            type="number"
+                            value={cbBaseCooldownS}
+                            onChange={(e) => setCBBaseCooldownS(e.target.value)}
+                            onBlur={() => {
+                                const ms = secondsToMSString(cbBaseCooldownS);
+                                handleSave(SettingKey.CBBaseCooldownMS, ms, initialCBBaseCooldownMS.current, () => {
+                                    initialCBBaseCooldownMS.current = ms;
+                                    setCBBaseCooldownS(msToSecondsString(ms));
+                                });
+                            }}
+                            className="rounded-xl"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <TipLabel text={t('circuitBreaker.maxCooldownS')} tip={t('circuitBreaker.maxCooldownSTip')} />
+                        <Input
+                            type="number"
+                            value={cbMaxCooldownS}
+                            onChange={(e) => setCBMaxCooldownS(e.target.value)}
+                            onBlur={() => {
+                                const ms = secondsToMSString(cbMaxCooldownS);
+                                handleSave(SettingKey.CBMaxCooldownMS, ms, initialCBMaxCooldownMS.current, () => {
+                                    initialCBMaxCooldownMS.current = ms;
+                                    setCBMaxCooldownS(msToSecondsString(ms));
+                                });
+                            }}
+                            className="rounded-xl"
+                        />
+                    </div>
+
+                    <div className="space-y-1">
+                        <TipLabel text={t('circuitBreaker.backoffFactor')} tip={t('circuitBreaker.backoffFactorTip')} />
+                        <Input
+                            type="number"
+                            step="0.1"
+                            value={cbBackoffFactor}
+                            onChange={(e) => setCBBackoffFactor(e.target.value)}
+                            onBlur={() => handleSave(SettingKey.CBBackoffFactor, cbBackoffFactor, initialCBBackoffFactor.current, () => {
+                                initialCBBackoffFactor.current = cbBackoffFactor;
+                            })}
+                            className="rounded-xl"
+                        />
+                    </div>
+                </div>
+            </div>
         </div>
     );
+}
+
+function msToSecondsString(ms: string): string {
+    const n = Number(ms);
+    if (!Number.isFinite(n) || n <= 0) return '';
+    return String(Math.round(n / 1000));
+}
+
+function secondsToMSString(sec: string): string {
+    const n = Number(sec);
+    if (!Number.isFinite(n) || n <= 0) return '0';
+    return String(Math.round(n * 1000));
 }


### PR DESCRIPTION
## 变更目标
将熔断策略统一为**全局开关 + 全局唯一状态**，避免分组内开关导致的配置冲突与心智负担。

## 核心结论
- 熔断是否生效只由全局开关 `cb_enabled` 决定。
- 熔断状态按 `channel_id + model_name` 作为唯一键维护（跨 Group 共享）。
- 同一个上游模型实例出现在多个 Group 时，状态始终同步一致。

## 主要改动
### 后端
- 新增熔断管理模块与状态机：`internal/relay/breaker/*`
- relay 主流程接入熔断：`internal/relay/relay.go`
- 新增错误分类（是否可重试/可触发熔断）：`internal/relay/error.go`
- 新增熔断状态与重置接口：`internal/server/handlers/circuit_breaker.go`
- 移除分组/条目级熔断开关控制路径（仅保留全局开关生效）

### 前端
- 系统设置提供全局熔断配置（总开关、阈值、冷却、退避）
- 分组页移除条目级开关，仅展示状态与重置
- 分组页熔断区域做了多轮布局与交互优化（tooltip、间距、hover、文案）

### 迁移
- `003/004/005/006` 迁移补齐熔断字段与默认值升级
- 其中基础冷却默认值最终为 `180s`（180000ms）
- 迁移采用“仅升级旧默认值”的方式，不覆盖用户自定义值

## 熔断机制如何工作
### 1) 粒度与唯一键
- 粒度：`channel + model`（而不是 channel、也不是 group）
- 唯一键：`{channel_id}:{model_name}`
- 含义：一个上游模型实例一个熔断状态，全系统共享

### 2) 请求进入后的决策链路
1. 根据外部模型名命中 Group（路由分组）
2. 按 Group 路由策略（轮询/随机/故障转移/加权）选候选项
3. 若全局熔断开关开启：先按 breaker 状态过滤不可用项
4. 若全部候选都处于不可用状态，直接返回 503（含 `Retry-After` 与熔断信息）
5. 若有可用候选，继续转发；失败时按可重试策略切换下一个候选

### 3) 状态机
- `CLOSED`：正常放行
- `OPEN`：在冷却期内拒绝请求
- `HALF_OPEN`：冷却期后允许单探测请求（probe）

### 4) 触发与恢复规则
- 连续失败达到阈值 -> `OPEN`
- `OPEN` 到期 -> 进入 `HALF_OPEN` 探测
- 探测成功 -> 回 `CLOSED`，失败计数清零
- 探测失败 -> 回 `OPEN`，并提高退避级别

### 5) 指数退避与衰减
- 冷却时长按 `baseCooldown * backoffFactor^(tripCount-1)` 增长，受 `maxCooldown` 上限限制
- 支持 jitter（抖动）打散恢复时刻
- `tripCount` 不是历史总次数，会按衰减窗口递减（用于“当前惩罚级别”）

### 6) 错误分类与是否计入熔断
- 计入熔断：网络错误/超时/5xx 等可熔断错误
- 不计入熔断：429、鉴权类错误（401/403）等

## 验证
- `go test ./...` 通过
- `pnpm -C web exec tsc --noEmit` 通过
