### PR TITLE
feat: 渠道页面新增排序和复制功能，分组新增排序功能

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -59,6 +59,12 @@
             "noContent": "Nothing to copy"
         }
     },
+    "toolbar": {
+        "sort": {
+            "id": "ID",
+            "name": "Name"
+        }
+    },
     "home": {
         "activity": {
             "requestCount": "Requests",
@@ -449,7 +455,8 @@
                 "saving": "Saving...",
                 "delete": "Delete",
                 "confirmDelete": "Confirm Delete",
-                "deleting": "Deleting..."
+                "deleting": "Deleting...",
+                "copy": "Copy"
             }
         },
         "create": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -59,6 +59,12 @@
             "noContent": "无可复制内容"
         }
     },
+    "toolbar": {
+        "sort": {
+            "id": "ID",
+            "name": "名称"
+        }
+    },
     "home": {
         "activity": {
             "requestCount": "请求次数",
@@ -449,7 +455,8 @@
                 "saving": "保存中...",
                 "delete": "删除",
                 "confirmDelete": "确认删除",
-                "deleting": "删除中..."
+                "deleting": "删除中...",
+                "copy": "复制"
             }
         },
         "create": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -59,6 +59,12 @@
             "noContent": "無可複製內容"
         }
     },
+    "toolbar": {
+        "sort": {
+            "id": "ID",
+            "name": "名稱"
+        }
+    },
     "home": {
         "activity": {
             "requestCount": "請求次數",
@@ -449,7 +455,8 @@
                 "saving": "儲存中...",
                 "delete": "刪除",
                 "confirmDelete": "確認刪除",
-                "deleting": "刪除中..."
+                "deleting": "刪除中...",
+                "copy": "複製"
             }
         },
         "create": {

--- a/web/src/components/modules/group/index.tsx
+++ b/web/src/components/modules/group/index.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { GroupCard } from './Card';
 import { useGroupList } from '@/api/endpoints/group';
 import { usePaginationStore, useSearchStore } from '@/components/modules/toolbar';
+import { useSortStore } from '@/components/modules/toolbar/sort-store';
 import { EASING } from '@/lib/animations/fluid-transitions';
 import { useGridPageSize } from '@/hooks/use-grid-page-size';
 
@@ -25,14 +26,26 @@ export function Group() {
     const setTotalItems = usePaginationStore((s) => s.setTotalItems);
     const setPageSize = usePaginationStore((s) => s.setPageSize);
     const direction = usePaginationStore((s) => s.getDirection(pageKey));
+    const sortField = useSortStore((s) => s.getSortField(pageKey));
+    const sortOrder = useSortStore((s) => s.getSortOrder(pageKey));
 
     const filteredGroups = useMemo(() => {
         if (!groups) return [];
-        const sorted = [...groups].sort((a, b) => a.id! - b.id!);
-        if (!searchTerm.trim()) return sorted;
-        const term = searchTerm.toLowerCase();
-        return sorted.filter((g) => g.name.toLowerCase().includes(term));
-    }, [groups, searchTerm]);
+        const filtered = searchTerm.trim()
+            ? groups.filter((g) => g.name.toLowerCase().includes(searchTerm.toLowerCase()))
+            : [...groups];
+
+        // Sort by field and order
+        return filtered.sort((a, b) => {
+            let cmp = 0;
+            if (sortField === 'name') {
+                cmp = a.name.localeCompare(b.name);
+            } else {
+                cmp = a.id! - b.id!;
+            }
+            return sortOrder === 'desc' ? -cmp : cmp;
+        });
+    }, [groups, searchTerm, sortField, sortOrder]);
 
     // Sync to store for Toolbar to display pagination info
     useEffect(() => {

--- a/web/src/components/modules/toolbar/index.tsx
+++ b/web/src/components/modules/toolbar/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { ChevronLeft, ChevronRight, Plus, Search, X } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { ChevronLeft, ChevronRight, Plus, Search, X, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
     MorphingDialog,
@@ -16,8 +17,15 @@ import { CreateDialogContent as GroupCreateContent } from '@/components/modules/
 import { CreateDialogContent as ModelCreateContent } from '@/components/modules/model/Create';
 import { useSearchStore } from './search-store';
 import { usePaginationStore } from './pagination-store';
+import { useSortStore, type SortField } from './sort-store';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
 
 const TOOLBAR_PAGES: NavItem[] = ['channel', 'group', 'model'];
+const SORTABLE_PAGES: NavItem[] = ['channel', 'group'];
 
 function CreateDialogContent({ activeItem }: { activeItem: NavItem }) {
     switch (activeItem) {
@@ -33,6 +41,7 @@ function CreateDialogContent({ activeItem }: { activeItem: NavItem }) {
 }
 
 export function Toolbar() {
+    const t = useTranslations('toolbar');
     const { activeItem } = useNavStore();
     const searchTerm = useSearchStore((s) => s.searchTerms[activeItem] || '');
     const setSearchTerm = useSearchStore((s) => s.setSearchTerm);
@@ -42,6 +51,21 @@ export function Toolbar() {
     const nextPage = usePaginationStore((s) => s.nextPage);
     const setPage = usePaginationStore((s) => s.setPage);
     const [searchExpanded, setSearchExpanded] = useState(false);
+
+    const sortField = useSortStore((s) => s.getSortField(activeItem));
+    const sortOrder = useSortStore((s) => s.getSortOrder(activeItem));
+    const setSortField = useSortStore((s) => s.setSortField);
+    const toggleSortOrder = useSortStore((s) => s.toggleSortOrder);
+
+    const showSortButton = SORTABLE_PAGES.includes(activeItem);
+
+    const handleSortFieldChange = (field: SortField) => {
+        if (sortField === field) {
+            toggleSortOrder(activeItem);
+        } else {
+            setSortField(activeItem, field);
+        }
+    };
 
     useEffect(() => {
         queueMicrotask(() => {
@@ -131,6 +155,35 @@ export function Toolbar() {
                             <ChevronRight className="size-4" />
                         </button>
                     </div>
+
+                    {/* 排序按钮 */}
+                    {showSortButton && (
+                        <Popover>
+                            <PopoverTrigger className={buttonVariants({ variant: "ghost", size: "icon", className: "rounded-xl transition-none hover:bg-transparent text-muted-foreground hover:text-foreground" })}>
+                                <ArrowUpDown className="size-4 transition-colors duration-300" />
+                            </PopoverTrigger>
+                            <PopoverContent className="w-36 p-1" align="end">
+                                <button
+                                    onClick={() => handleSortFieldChange('id')}
+                                    className="w-full flex items-center justify-between px-3 py-2 text-sm rounded-lg hover:bg-accent transition-colors"
+                                >
+                                    <span>{t('sort.id')}</span>
+                                    {sortField === 'id' && (
+                                        sortOrder === 'asc' ? <ArrowUp className="size-3.5" /> : <ArrowDown className="size-3.5" />
+                                    )}
+                                </button>
+                                <button
+                                    onClick={() => handleSortFieldChange('name')}
+                                    className="w-full flex items-center justify-between px-3 py-2 text-sm rounded-lg hover:bg-accent transition-colors"
+                                >
+                                    <span>{t('sort.name')}</span>
+                                    {sortField === 'name' && (
+                                        sortOrder === 'asc' ? <ArrowUp className="size-3.5" /> : <ArrowDown className="size-3.5" />
+                                    )}
+                                </button>
+                            </PopoverContent>
+                        </Popover>
+                    )}
 
                     {/* 创建按钮 */}
                     <MorphingDialog>

--- a/web/src/components/modules/toolbar/sort-store.ts
+++ b/web/src/components/modules/toolbar/sort-store.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import type { NavItem } from '@/components/modules/navbar';
+
+export type SortField = 'id' | 'name';
+export type SortOrder = 'asc' | 'desc';
+
+interface SortState {
+    sortFields: Partial<Record<NavItem, SortField>>;
+    sortOrders: Partial<Record<NavItem, SortOrder>>;
+    getSortField: (page: NavItem) => SortField;
+    getSortOrder: (page: NavItem) => SortOrder;
+    setSortField: (page: NavItem, field: SortField) => void;
+    setSortOrder: (page: NavItem, order: SortOrder) => void;
+    toggleSortOrder: (page: NavItem) => void;
+}
+
+export const useSortStore = create<SortState>((set, get) => ({
+    sortFields: {},
+    sortOrders: {},
+    getSortField: (page) => get().sortFields[page] ?? 'id',
+    getSortOrder: (page) => get().sortOrders[page] ?? 'asc',
+    setSortField: (page, field) =>
+        set((state) => ({
+            sortFields: { ...state.sortFields, [page]: field },
+        })),
+    setSortOrder: (page, order) =>
+        set((state) => ({
+            sortOrders: { ...state.sortOrders, [page]: order },
+        })),
+    toggleSortOrder: (page) =>
+        set((state) => ({
+            sortOrders: {
+                ...state.sortOrders,
+                [page]: (state.sortOrders[page] ?? 'asc') === 'asc' ? 'desc' : 'asc',
+            },
+        })),
+}));


### PR DESCRIPTION
用claude添加了一些功能，不懂go语言，如果有问题，请关闭

## 功能说明：

渠道和分组页面支持按 ID 或名称排序（升序/降序），
- ID - 按渠道的数据库 ID 排序（创建顺序），ID 小的先创建，
- 名称 - 按渠道名称的字母/拼音顺序排序

渠道详情页添加复制按钮（复制渠道配置用于创建新渠道）

## 本次改动文件：

### 新增文件：

- web/src/components/modules/toolbar/sort-store.ts - 排序状态管理 store
### 修改文件：

- web/src/components/modules/toolbar/index.tsx - 添加排序按钮和下拉菜单
- web/src/components/modules/channel/index.tsx - 渠道列表排序逻辑
- web/src/components/modules/channel/CardContent.tsx - 添加复制渠道按钮
- web/src/components/modules/group/index.tsx - 分组列表排序逻辑
- web/public/locale/zh_hans.json - 添加 toolbar.sort 和 channel.detail.actions.copy 翻译
- web/public/locale/zh_hant.json - 添加翻译
- web/public/locale/en.json - 添加翻译


## 效果图
<img width="1187" height="357" alt="image" src="https://github.com/user-attachments/assets/232449d8-0e35-45a8-8aa2-f1c4d2a624f9" />
<img width="615" height="665" alt="image" src="https://github.com/user-attachments/assets/ebecdd72-b648-4f3c-907b-f7de37afd65f" />
