### PR TITLE
feat: :sparkles: 渠道自定义标签系统（创建/编辑/筛选/记忆）

### DIFF
--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -32,6 +32,7 @@ type Channel struct {
 	ChannelProxy  *string               `json:"channel_proxy"`
 	Stats         *StatsChannel         `json:"stats,omitempty" gorm:"foreignKey:ChannelID"`
 	MatchRegex    *string               `json:"match_regex"`
+	Tags          []string              `json:"tags" gorm:"serializer:json"`
 }
 
 type BaseUrl struct {
@@ -71,6 +72,8 @@ type ChannelUpdateRequest struct {
 	ChannelProxy  *string                `json:"channel_proxy,omitempty"`
 	ParamOverride *string                `json:"param_override,omitempty"`
 	MatchRegex    *string                `json:"match_regex,omitempty"`
+
+	Tags          *[]string                 `json:"tags,omitempty"`
 
 	KeysToAdd    []ChannelKeyAddRequest    `json:"keys_to_add,omitempty"`
 	KeysToUpdate []ChannelKeyUpdateRequest `json:"keys_to_update,omitempty"`

--- a/internal/model/llm.go
+++ b/internal/model/llm.go
@@ -13,10 +13,11 @@ type LLMInfo struct {
 }
 
 type LLMChannel struct {
-	Name        string `json:"name"`
-	Enabled     bool   `json:"enabled"`
-	ChannelID   int    `json:"channel_id"`
-	ChannelName string `json:"channel_name"`
+	Name        string   `json:"name"`
+	Enabled     bool     `json:"enabled"`
+	ChannelID   int      `json:"channel_id"`
+	ChannelName string   `json:"channel_name"`
+	Tags        []string `json:"tags"`
 }
 
 type GeminiModel struct {

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -177,6 +177,10 @@ func ChannelUpdate(req *model.ChannelUpdateRequest, ctx context.Context) (*model
 		selectFields = append(selectFields, "match_regex")
 		updates.MatchRegex = req.MatchRegex
 	}
+	if req.Tags != nil {
+		selectFields = append(selectFields, "tags")
+		updates.Tags = *req.Tags
+	}
 
 	// 只有当有字段需要更新时才执行 UPDATE
 	if len(selectFields) > 0 {
@@ -345,6 +349,7 @@ func ChannelLLMList(ctx context.Context) ([]model.LLMChannel, error) {
 				Enabled:     channel.Enabled,
 				ChannelID:   channel.ID,
 				ChannelName: channel.Name,
+				Tags:        channel.Tags,
 			})
 		}
 	}

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -339,7 +339,9 @@
             "autoAdd": "Auto Add",
             "clear": "Clear",
             "selectChannel": "Channel",
-            "selectModel": "Model"
+            "selectModel": "Model",
+            "filterByTag": "Filter by Tag",
+            "allChannels": "All"
         },
         "mode": {
             "roundRobin": "Round Robin",
@@ -500,7 +502,9 @@
             "autoGroupRegex": "Regex",
             "matchRegex": "Match Regex",
             "matchRegexPlaceholder": "Optional: regex pattern to match request model names",
-            "remark": "Remark"
+            "remark": "Remark",
+            "tags": "Tags",
+            "tagsPlaceholder": "Enter tag name and press Enter"
         }
     }
 }

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -339,7 +339,9 @@
             "autoAdd": "自动添加",
             "clear": "清空",
             "selectChannel": "渠道",
-            "selectModel": "模型"
+            "selectModel": "模型",
+            "filterByTag": "按标签筛选",
+            "allChannels": "全部"
         },
         "mode": {
             "roundRobin": "轮询",
@@ -500,7 +502,9 @@
             "autoGroupRegex": "正则匹配",
             "matchRegex": "匹配正则",
             "matchRegexPlaceholder": "可选：用于匹配请求模型名称的正则表达式",
-            "remark": "备注"
+            "remark": "备注",
+            "tags": "标签",
+            "tagsPlaceholder": "输入标签名后按回车"
         }
     }
 }

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -339,7 +339,9 @@
             "autoAdd": "自動新增",
             "clear": "清空",
             "selectChannel": "供應源",
-            "selectModel": "模型"
+            "selectModel": "模型",
+            "filterByTag": "按標籤篩選",
+            "allChannels": "全部"
         },
         "mode": {
             "roundRobin": "輪詢",
@@ -500,7 +502,9 @@
             "autoGroupRegex": "正規比對",
             "matchRegex": "匹配正規",
             "matchRegexPlaceholder": "可選：用於匹配請求模型名稱的正規表示式",
-            "remark": "備註"
+            "remark": "備註",
+            "tags": "標籤",
+            "tagsPlaceholder": "輸入標籤名後按回車"
         }
     }
 }

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -65,14 +65,16 @@ export type Channel = {
     param_override?: string | null;
     channel_proxy?: string | null;
     match_regex?: string | null;
+    tags: string[];
     stats: StatsChannel;
 };
 
 // Internal type: backend may return null for slice fields; normalize to [] in select()
-type ChannelServer = Omit<Channel, 'base_urls' | 'custom_header' | 'keys'> & {
+type ChannelServer = Omit<Channel, 'base_urls' | 'custom_header' | 'keys' | 'tags'> & {
     base_urls: BaseUrl[] | null;
     custom_header: CustomHeader[] | null;
     keys: ChannelKey[] | null;
+    tags: string[] | null;
 };
 
 /**
@@ -93,6 +95,7 @@ export type CreateChannelRequest = {
     channel_proxy?: string | null;
     param_override?: string | null;
     match_regex?: string | null;
+    tags?: string[];
 };
 
 /**
@@ -113,6 +116,7 @@ export type UpdateChannelRequest = {
     channel_proxy?: string | null;
     param_override?: string | null;
     match_regex?: string | null;
+    tags?: string[];
     // keys diff
     keys_to_add?: Array<Pick<ChannelKey, 'enabled' | 'channel_key' | 'remark'>>;
     keys_to_update?: Array<{ id: number; enabled?: boolean; channel_key?: string; remark?: string }>;
@@ -151,6 +155,7 @@ export function useChannelList() {
                 base_urls: item.base_urls ?? [],
                 custom_header: item.custom_header ?? [],
                 keys: item.keys ?? [],
+                tags: item.tags ?? [],
             }) satisfies Channel,
             formatted: {
                 input_token: formatCount(item.stats.input_token),

--- a/web/src/api/endpoints/model.ts
+++ b/web/src/api/endpoints/model.ts
@@ -27,6 +27,7 @@ export interface LLMChannel {
     enabled: boolean;
     channel_id: number;
     channel_name: string;
+    tags: string[];
 }
 
 /**
@@ -68,6 +69,10 @@ export function useModelChannelList() {
         queryFn: async () => {
             return apiClient.get<LLMChannel[]>('/api/v1/model/channel');
         },
+        select: (data) => data.map((item) => ({
+            ...item,
+            tags: item.tags ?? [],
+        })),
         refetchInterval: 30000,
     });
 }

--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -58,6 +58,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         auto_sync: channel.auto_sync,
         auto_group: channel.auto_group,
         match_regex: channel.match_regex ?? '',
+        tags: channel.tags ?? [],
     });
     const t = useTranslations('channel.detail');
 
@@ -113,6 +114,10 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         if (nextMatchRegex !== curMatchRegex) {
             // Empty string means "clear" for patch semantics; backend maps it to NULL.
             req.match_regex = nextMatchRegex;
+        }
+
+        if (JSON.stringify(formData.tags ?? []) !== JSON.stringify(channel.tags ?? [])) {
+            req.tags = formData.tags ?? [];
         }
 
         const originalKeys = channel.keys;

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -27,6 +27,7 @@ export function CreateDialogContent() {
         enabled: true,
         proxy: false,
         match_regex: '',
+        tags: [],
     });
     const t = useTranslations('channel.create');
 
@@ -61,6 +62,7 @@ export function CreateDialogContent() {
                 channel_proxy: channelProxy,
                 param_override: paramOverride,
                 match_regex: formData.match_regex.trim(),
+                tags: formData.tags,
             },
             {
                 onSuccess: () => {
@@ -79,6 +81,7 @@ export function CreateDialogContent() {
                         enabled: true,
                         proxy: false,
                         match_regex: '',
+                        tags: [],
                     });
                     setIsOpen(false);
                 }

--- a/web/src/components/modules/group/Card.tsx
+++ b/web/src/components/modules/group/Card.tsx
@@ -49,6 +49,7 @@ function EditDialogContent({ group, displayMembers, isSubmitting, onSubmit }: Ed
             <MorphingDialogDescription className="flex-1 min-h-0 overflow-hidden">
                 <GroupEditor
                     key={`edit-group-${group.id}`}
+                    groupId={group.id}
                     initial={{
                         name: group.name,
                         match_regex: group.match_regex ?? '',
@@ -89,6 +90,14 @@ export function GroupCard({ group }: { group: Group }) {
         return map;
     }, [modelChannels]);
 
+    const tagsByKey = useMemo(() => {
+        const map = new Map<string, string[]>();
+        modelChannels.forEach((mc) => {
+            map.set(modelChannelKey(mc.channel_id, mc.name), mc.tags ?? []);
+        });
+        return map;
+    }, [modelChannels]);
+
     const displayMembers = useMemo((): SelectedMember[] =>
         [...(group.items || [])]
             .sort((a, b) => a.priority - b.priority)
@@ -98,10 +107,11 @@ export function GroupCard({ group }: { group: Group }) {
                 enabled: enabledByKey.get(modelChannelKey(item.channel_id, item.model_name)) ?? true,
                 channel_id: item.channel_id,
                 channel_name: channelNameByKey.get(modelChannelKey(item.channel_id, item.model_name)) ?? `Channel ${item.channel_id}`,
+                tags: tagsByKey.get(modelChannelKey(item.channel_id, item.model_name)) ?? [],
                 item_id: item.id,
                 weight: item.weight,
             })),
-        [group.items, channelNameByKey, enabledByKey]
+        [group.items, channelNameByKey, enabledByKey, tagsByKey]
     );
 
     useEffect(() => {

--- a/web/src/components/modules/group/Editor.tsx
+++ b/web/src/components/modules/group/Editor.tsx
@@ -527,7 +527,7 @@ export function GroupEditor({
                                     onClick={() => toggleTag(tag)}
                                     className={cn(
                                         'px-2 py-0.5 text-xs rounded-md transition-colors',
-                                        selectedTags.includes(tag)
+                                        effectiveTags.includes(tag)
                                             ? 'bg-primary text-primary-foreground'
                                             : 'bg-muted text-muted-foreground hover:bg-muted/80'
                                     )}
@@ -535,7 +535,7 @@ export function GroupEditor({
                                     {tag}
                                 </button>
                             ))}
-                            {selectedTags.length > 0 && (
+                            {effectiveTags.length > 0 && (
                                 <button
                                     type="button"
                                     onClick={() => setSelectedTags([])}

--- a/web/src/components/modules/group/Editor.tsx
+++ b/web/src/components/modules/group/Editor.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useMemo, useState, type FormEvent } from 'react';
-import { Check, ChevronDownIcon, Plus, Sparkles, Trash2 } from 'lucide-react';
+import { create } from 'zustand';
+import { Check, ChevronDownIcon, Plus, Sparkles, Tag, Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { useModelChannelList, type LLMChannel } from '@/api/endpoints/model';
@@ -18,7 +19,29 @@ import { matchesGroupName, memberKey, normalizeKey, MODE_LABELS } from './utils'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/animate-ui/components/animate/tooltip';
 import { HelpCircle } from 'lucide-react';
 
+const EMPTY_TAGS: string[] = [];
 
+const useTagFilterStore = create<{
+    tagsByGroup: Record<string, string[]>;
+    setSelectedTags: (groupId: string, tags: string[]) => void;
+    toggleTag: (groupId: string, tag: string) => void;
+}>((set) => ({
+    tagsByGroup: {},
+    setSelectedTags: (groupId, tags) => set((state) => ({
+        tagsByGroup: { ...state.tagsByGroup, [groupId]: tags },
+    })),
+    toggleTag: (groupId, tag) => set((state) => {
+        const current = state.tagsByGroup[groupId] ?? [];
+        return {
+            tagsByGroup: {
+                ...state.tagsByGroup,
+                [groupId]: current.includes(tag)
+                    ? current.filter((t) => t !== tag)
+                    : [...current, tag],
+            },
+        };
+    }),
+}));
 
 export type GroupEditorValues = {
     name: string;
@@ -212,6 +235,7 @@ function SortSection({
 }
 
 export function GroupEditor({
+    groupId,
     initial,
     submitText,
     submittingText,
@@ -219,6 +243,7 @@ export function GroupEditor({
     onSubmit,
     onCancel,
 }: {
+    groupId?: number;
     initial?: Partial<GroupEditorValues>;
     submitText: string;
     submittingText: string;
@@ -236,6 +261,47 @@ export function GroupEditor({
     const [sessionKeepTime, setSessionKeepTime] = useState<number>(initial?.session_keep_time ?? 0);
     const [selectedMembers, setSelectedMembers] = useState<SelectedMember[]>(initial?.members ?? []);
     const [removingIds, setRemovingIds] = useState<Set<string>>(new Set());
+
+    // Per-group tag filter: use store for edit (has groupId), local state for create
+    const storeKey = groupId != null ? String(groupId) : '';
+    const storeSelectedTags = useTagFilterStore((s) => s.tagsByGroup[storeKey]) ?? EMPTY_TAGS;
+    const storeSetSelectedTags = useTagFilterStore((s) => s.setSelectedTags);
+    const storeToggleTag = useTagFilterStore((s) => s.toggleTag);
+    const [localSelectedTags, setLocalSelectedTags] = useState<string[]>([]);
+
+    const selectedTags = groupId != null ? storeSelectedTags : localSelectedTags;
+    const setSelectedTags = useCallback((tags: string[]) => {
+        if (groupId != null) storeSetSelectedTags(storeKey, tags);
+        else setLocalSelectedTags(tags);
+    }, [groupId, storeKey, storeSetSelectedTags]);
+    const toggleTag = useCallback((tag: string) => {
+        if (groupId != null) storeToggleTag(storeKey, tag);
+        else setLocalSelectedTags((prev) =>
+            prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+        );
+    }, [groupId, storeKey, storeToggleTag]);
+
+    const allTags = useMemo(() => {
+        const tagSet = new Set<string>();
+        modelChannels.forEach((mc) => mc.tags?.forEach((t) => tagSet.add(t)));
+        return Array.from(tagSet).sort();
+    }, [modelChannels]);
+
+    // Derive effective tags: prune any selectedTags that no longer exist in
+    // allTags. This avoids an empty model list when persisted tags become stale
+    // (e.g., all channel tags removed), without needing a useEffect + setState.
+    const effectiveTags = useMemo(() => {
+        if (selectedTags.length === 0) return selectedTags;
+        const validSet = new Set(allTags);
+        return selectedTags.filter((t) => validSet.has(t));
+    }, [selectedTags, allTags]);
+
+    const filteredModelChannels = useMemo(() => {
+        if (effectiveTags.length === 0) return modelChannels;
+        return modelChannels.filter((mc) =>
+            mc.tags?.some((t) => effectiveTags.includes(t))
+        );
+    }, [modelChannels, effectiveTags]);
 
     const groupKey = normalizeKey(groupName);
     const regexKey = matchRegex.trim();
@@ -255,14 +321,14 @@ export function GroupEditor({
         if (regexKey) {
             try {
                 const re = parseRegex(regexKey);
-                return { matchedModelChannels: modelChannels.filter((mc) => re.test(mc.name)), regexError: '' };
+                return { matchedModelChannels: filteredModelChannels.filter((mc) => re.test(mc.name)), regexError: '' };
             } catch (e) {
                 return { matchedModelChannels: [], regexError: (e as Error)?.message ?? 'Invalid regex' };
             }
         }
         if (!groupKey) return { matchedModelChannels: [], regexError: '' };
-        return { matchedModelChannels: modelChannels.filter((mc) => matchesGroupName(mc.name, groupKey)), regexError: '' };
-    }, [groupKey, regexKey, modelChannels]);
+        return { matchedModelChannels: filteredModelChannels.filter((mc) => matchesGroupName(mc.name, groupKey)), regexError: '' };
+    }, [groupKey, regexKey, filteredModelChannels]);
 
     const handleAddMember = useCallback((channel: LLMChannel) => {
         const key = memberKey(channel);
@@ -438,10 +504,44 @@ export function GroupEditor({
                         ))}
                     </div>
 
+                    {/* Tag filter */}
+                    {allTags.length > 0 && (
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <span className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+                                <Tag className="size-3" />
+                                {t('form.filterByTag')}
+                            </span>
+                            {allTags.map((tag) => (
+                                <button
+                                    key={tag}
+                                    type="button"
+                                    onClick={() => toggleTag(tag)}
+                                    className={cn(
+                                        'px-2 py-0.5 text-xs rounded-md transition-colors',
+                                        selectedTags.includes(tag)
+                                            ? 'bg-primary text-primary-foreground'
+                                            : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                                    )}
+                                >
+                                    {tag}
+                                </button>
+                            ))}
+                            {selectedTags.length > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => setSelectedTags([])}
+                                    className="px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                    {t('form.allChannels')}
+                                </button>
+                            )}
+                        </div>
+                    )}
+
                     <div className="flex-1 min-h-0">
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 h-full min-h-0">
                             <ModelPickerSection
-                                modelChannels={modelChannels}
+                                modelChannels={filteredModelChannels}
                                 selectedMembers={selectedMembers}
                                 onAdd={handleAddMember}
                                 onAutoAdd={handleAutoAdd}

--- a/web/src/components/modules/group/Editor.tsx
+++ b/web/src/components/modules/group/Editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState, type FormEvent } from 'react';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import { Check, ChevronDownIcon, Plus, Sparkles, Tag, Trash2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
@@ -25,23 +26,31 @@ const useTagFilterStore = create<{
     tagsByGroup: Record<string, string[]>;
     setSelectedTags: (groupId: string, tags: string[]) => void;
     toggleTag: (groupId: string, tag: string) => void;
-}>((set) => ({
-    tagsByGroup: {},
-    setSelectedTags: (groupId, tags) => set((state) => ({
-        tagsByGroup: { ...state.tagsByGroup, [groupId]: tags },
-    })),
-    toggleTag: (groupId, tag) => set((state) => {
-        const current = state.tagsByGroup[groupId] ?? [];
-        return {
-            tagsByGroup: {
-                ...state.tagsByGroup,
-                [groupId]: current.includes(tag)
-                    ? current.filter((t) => t !== tag)
-                    : [...current, tag],
-            },
-        };
-    }),
-}));
+}>()(
+    persist(
+        (set) => ({
+            tagsByGroup: {},
+            setSelectedTags: (groupId, tags) => set((state) => ({
+                tagsByGroup: { ...state.tagsByGroup, [groupId]: tags },
+            })),
+            toggleTag: (groupId, tag) => set((state) => {
+                const current = state.tagsByGroup[groupId] ?? [];
+                return {
+                    tagsByGroup: {
+                        ...state.tagsByGroup,
+                        [groupId]: current.includes(tag)
+                            ? current.filter((t) => t !== tag)
+                            : [...current, tag],
+                    },
+                };
+            }),
+        }),
+        {
+            name: 'tag-filter-storage',
+            partialize: (state) => ({ tagsByGroup: state.tagsByGroup }),
+        }
+    )
+);
 
 export type GroupEditorValues = {
     name: string;


### PR DESCRIPTION
- 渠道模型新增 Tags 字段（GORM serializer:json）
- 渠道创建/编辑表单支持标签输入，支持从已有标签快速选择（Popover 建议）
- 分组编辑器新增按标签筛选，筛选状态按分组独立记忆（Zustand store）
- LLMChannel / model/channel API 透传 tags，前端 null 归一化
- i18n：中英文标签相关翻译

实际效果:
标签下拉菜单(从已有标签快速选择)：
<img width="720" height="144" alt="image" src="https://github.com/user-attachments/assets/46db296b-4da5-4685-9b0d-0821839a31fa" />
已添加标签：
<img width="734" height="134" alt="image" src="https://github.com/user-attachments/assets/ae18e1eb-3f58-4a39-b3f6-d907514e9f3e" />
编辑分组页面效果：
<img width="1156" height="426" alt="image" src="https://github.com/user-attachments/assets/4a04427f-8723-4182-a155-883934b0ed54" />
