### PR TITLE
使用Kimi Coding ，Octopus作为中转增加兼容性

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ build
 static/out/*
 !static/out/README.md
 .vscode
+*_test.go
+progress.md
+findings.md
+task_plan.md
+AGENTS.md

--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -16,22 +16,23 @@ const (
 )
 
 type Channel struct {
-	ID            int                   `json:"id" gorm:"primaryKey"`
-	Name          string                `json:"name" gorm:"unique;not null"`
-	Type          outbound.OutboundType `json:"type"`
-	Enabled       bool                  `json:"enabled" gorm:"default:true"`
-	BaseUrls      []BaseUrl             `json:"base_urls" gorm:"serializer:json"`
-	Keys          []ChannelKey          `json:"keys" gorm:"foreignKey:ChannelID"`
-	Model         string                `json:"model"`
-	CustomModel   string                `json:"custom_model"`
-	Proxy         bool                  `json:"proxy" gorm:"default:false"`
-	AutoSync      bool                  `json:"auto_sync" gorm:"default:false"`
-	AutoGroup     AutoGroupType         `json:"auto_group" gorm:"default:0"`
-	CustomHeader  []CustomHeader        `json:"custom_header" gorm:"serializer:json"`
-	ParamOverride *string               `json:"param_override"`
-	ChannelProxy  *string               `json:"channel_proxy"`
-	Stats         *StatsChannel         `json:"stats,omitempty" gorm:"foreignKey:ChannelID"`
-	MatchRegex    *string               `json:"match_regex"`
+	ID                   int                   `json:"id" gorm:"primaryKey"`
+	Name                 string                `json:"name" gorm:"unique;not null"`
+	Type                 outbound.OutboundType `json:"type"`
+	Enabled              bool                  `json:"enabled" gorm:"default:true"`
+	EnableCircuitBreaker bool                  `json:"enable_circuit_breaker" gorm:"default:true"`
+	BaseUrls             []BaseUrl             `json:"base_urls" gorm:"serializer:json"`
+	Keys                 []ChannelKey          `json:"keys" gorm:"foreignKey:ChannelID"`
+	Model                string                `json:"model"`
+	CustomModel          string                `json:"custom_model"`
+	Proxy                bool                  `json:"proxy" gorm:"default:false"`
+	AutoSync             bool                  `json:"auto_sync" gorm:"default:false"`
+	AutoGroup            AutoGroupType         `json:"auto_group" gorm:"default:0"`
+	CustomHeader         []CustomHeader        `json:"custom_header" gorm:"serializer:json"`
+	ParamOverride        *string               `json:"param_override"`
+	ChannelProxy         *string               `json:"channel_proxy"`
+	Stats                *StatsChannel         `json:"stats,omitempty" gorm:"foreignKey:ChannelID"`
+	MatchRegex           *string               `json:"match_regex"`
 }
 
 type BaseUrl struct {
@@ -57,20 +58,21 @@ type ChannelKey struct {
 
 // ChannelUpdateRequest 渠道更新请求 - 仅包含变更的数据
 type ChannelUpdateRequest struct {
-	ID            int                    `json:"id" binding:"required"`
-	Name          *string                `json:"name,omitempty"`
-	Type          *outbound.OutboundType `json:"type,omitempty"`
-	Enabled       *bool                  `json:"enabled,omitempty"`
-	BaseUrls      *[]BaseUrl             `json:"base_urls,omitempty"`
-	Model         *string                `json:"model,omitempty"`
-	CustomModel   *string                `json:"custom_model,omitempty"`
-	Proxy         *bool                  `json:"proxy,omitempty"`
-	AutoSync      *bool                  `json:"auto_sync,omitempty"`
-	AutoGroup     *AutoGroupType         `json:"auto_group,omitempty"`
-	CustomHeader  *[]CustomHeader        `json:"custom_header,omitempty"`
-	ChannelProxy  *string                `json:"channel_proxy,omitempty"`
-	ParamOverride *string                `json:"param_override,omitempty"`
-	MatchRegex    *string                `json:"match_regex,omitempty"`
+	ID                   int                    `json:"id" binding:"required"`
+	Name                 *string                `json:"name,omitempty"`
+	Type                 *outbound.OutboundType `json:"type,omitempty"`
+	Enabled              *bool                  `json:"enabled,omitempty"`
+	EnableCircuitBreaker *bool                  `json:"enable_circuit_breaker,omitempty"`
+	BaseUrls             *[]BaseUrl             `json:"base_urls,omitempty"`
+	Model                *string                `json:"model,omitempty"`
+	CustomModel          *string                `json:"custom_model,omitempty"`
+	Proxy                *bool                  `json:"proxy,omitempty"`
+	AutoSync             *bool                  `json:"auto_sync,omitempty"`
+	AutoGroup            *AutoGroupType         `json:"auto_group,omitempty"`
+	CustomHeader         *[]CustomHeader        `json:"custom_header,omitempty"`
+	ChannelProxy         *string                `json:"channel_proxy,omitempty"`
+	ParamOverride        *string                `json:"param_override,omitempty"`
+	MatchRegex           *string                `json:"match_regex,omitempty"`
 
 	KeysToAdd    []ChannelKeyAddRequest    `json:"keys_to_add,omitempty"`
 	KeysToUpdate []ChannelKeyUpdateRequest `json:"keys_to_update,omitempty"`

--- a/internal/model/setting.go
+++ b/internal/model/setting.go
@@ -9,16 +9,17 @@ import (
 type SettingKey string
 
 const (
-	SettingKeyProxyURL                  SettingKey = "proxy_url"
-	SettingKeyStatsSaveInterval         SettingKey = "stats_save_interval"          // 将统计信息写入数据库的周期(分钟)
-	SettingKeyModelInfoUpdateInterval   SettingKey = "model_info_update_interval"   // 模型信息更新间隔(小时)
-	SettingKeySyncLLMInterval           SettingKey = "sync_llm_interval"            // LLM 同步间隔(小时)
-	SettingKeyRelayLogKeepPeriod        SettingKey = "relay_log_keep_period"        // 日志保存时间范围(天)
-	SettingKeyRelayLogKeepEnabled       SettingKey = "relay_log_keep_enabled"       // 是否保留历史日志
-	SettingKeyCORSAllowOrigins          SettingKey = "cors_allow_origins"           // 跨域白名单(逗号分隔, 如 "example.com,example2.com"). 为空不允许跨域, "*"允许所有
-	SettingKeyCircuitBreakerThreshold   SettingKey = "circuit_breaker_threshold"    // 熔断触发阈值（连续失败次数）
-	SettingKeyCircuitBreakerCooldown    SettingKey = "circuit_breaker_cooldown"     // 熔断基础冷却时间（秒）
-	SettingKeyCircuitBreakerMaxCooldown SettingKey = "circuit_breaker_max_cooldown" // 熔断最大冷却时间（秒），指数退避上限
+	SettingKeyProxyURL                       SettingKey = "proxy_url"
+	SettingKeyStatsSaveInterval              SettingKey = "stats_save_interval"                // 将统计信息写入数据库的周期(分钟)
+	SettingKeyModelInfoUpdateInterval        SettingKey = "model_info_update_interval"         // 模型信息更新间隔(小时)
+	SettingKeySyncLLMInterval                SettingKey = "sync_llm_interval"                  // LLM 同步间隔(小时)
+	SettingKeyRelayLogKeepPeriod             SettingKey = "relay_log_keep_period"              // 日志保存时间范围(天)
+	SettingKeyRelayLogKeepEnabled            SettingKey = "relay_log_keep_enabled"             // 是否保留历史日志
+	SettingKeyRelayLogRedundantFieldsEnabled SettingKey = "relay_log_redundant_fields_enabled" // 是否记录并读取日志冗余字段(_octopus_*)
+	SettingKeyCORSAllowOrigins               SettingKey = "cors_allow_origins"                 // 跨域白名单(逗号分隔, 如 "example.com,example2.com"). 为空不允许跨域, "*"允许所有
+	SettingKeyCircuitBreakerThreshold        SettingKey = "circuit_breaker_threshold"          // 熔断触发阈值（连续失败次数）
+	SettingKeyCircuitBreakerCooldown         SettingKey = "circuit_breaker_cooldown"           // 熔断基础冷却时间（秒）
+	SettingKeyCircuitBreakerMaxCooldown      SettingKey = "circuit_breaker_max_cooldown"       // 熔断最大冷却时间（秒），指数退避上限
 )
 
 type Setting struct {
@@ -29,15 +30,16 @@ type Setting struct {
 func DefaultSettings() []Setting {
 	return []Setting{
 		{Key: SettingKeyProxyURL, Value: ""},
-		{Key: SettingKeyStatsSaveInterval, Value: "10"},          // 默认10分钟保存一次统计信息
-		{Key: SettingKeyCORSAllowOrigins, Value: ""},             // CORS 默认不允许跨域，设置为 "*" 才允许所有来源
-		{Key: SettingKeyModelInfoUpdateInterval, Value: "24"},    // 默认24小时更新一次模型信息
-		{Key: SettingKeySyncLLMInterval, Value: "24"},            // 默认24小时同步一次LLM
-		{Key: SettingKeyRelayLogKeepPeriod, Value: "7"},          // 默认日志保存7天
-		{Key: SettingKeyRelayLogKeepEnabled, Value: "true"},      // 默认保留历史日志
-		{Key: SettingKeyCircuitBreakerThreshold, Value: "5"},     // 默认连续失败5次触发熔断
-		{Key: SettingKeyCircuitBreakerCooldown, Value: "60"},     // 默认基础冷却60秒
-		{Key: SettingKeyCircuitBreakerMaxCooldown, Value: "600"}, // 默认最大冷却600秒（10分钟）
+		{Key: SettingKeyStatsSaveInterval, Value: "10"},                // 默认10分钟保存一次统计信息
+		{Key: SettingKeyCORSAllowOrigins, Value: ""},                   // CORS 默认不允许跨域，设置为 "*" 才允许所有来源
+		{Key: SettingKeyModelInfoUpdateInterval, Value: "24"},          // 默认24小时更新一次模型信息
+		{Key: SettingKeySyncLLMInterval, Value: "24"},                  // 默认24小时同步一次LLM
+		{Key: SettingKeyRelayLogKeepPeriod, Value: "7"},                // 默认日志保存7天
+		{Key: SettingKeyRelayLogKeepEnabled, Value: "true"},            // 默认保留历史日志
+		{Key: SettingKeyRelayLogRedundantFieldsEnabled, Value: "true"}, // 默认记录并读取日志冗余字段
+		{Key: SettingKeyCircuitBreakerThreshold, Value: "5"},           // 默认连续失败5次触发熔断
+		{Key: SettingKeyCircuitBreakerCooldown, Value: "60"},           // 默认基础冷却60秒
+		{Key: SettingKeyCircuitBreakerMaxCooldown, Value: "600"},       // 默认最大冷却600秒（10分钟）
 	}
 }
 
@@ -50,9 +52,9 @@ func (s *Setting) Validate() error {
 			return fmt.Errorf("model info update interval must be an integer")
 		}
 		return nil
-	case SettingKeyRelayLogKeepEnabled:
+	case SettingKeyRelayLogKeepEnabled, SettingKeyRelayLogRedundantFieldsEnabled:
 		if s.Value != "true" && s.Value != "false" {
-			return fmt.Errorf("relay log keep enabled must be true or false")
+			return fmt.Errorf("%s must be true or false", s.Key)
 		}
 		return nil
 	case SettingKeyProxyURL:

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -137,6 +137,10 @@ func ChannelUpdate(req *model.ChannelUpdateRequest, ctx context.Context) (*model
 		selectFields = append(selectFields, "enabled")
 		updates.Enabled = *req.Enabled
 	}
+	if req.EnableCircuitBreaker != nil {
+		selectFields = append(selectFields, "enable_circuit_breaker")
+		updates.EnableCircuitBreaker = *req.EnableCircuitBreaker
+	}
 	if req.BaseUrls != nil {
 		selectFields = append(selectFields, "base_urls")
 		updates.BaseUrls = *req.BaseUrls

--- a/internal/op/log.go
+++ b/internal/op/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -26,6 +27,12 @@ var relayLogSubscribersLock sync.RWMutex
 
 var relayLogStreamTokens = make(map[string]struct{})
 var relayLogStreamTokensLock sync.RWMutex
+
+var relayLogRedundantFields = []string{
+	"_octopus_raw_request",
+	"_octopus_raw_response",
+	"_octopus_client_response",
+}
 
 func RelayLogStreamTokenCreate() (string, error) {
 	bytes := make([]byte, 32)
@@ -124,7 +131,11 @@ func RelayLogAdd(ctx context.Context, relayLog model.RelayLog) error {
 		maxSize = relayLogMaxSizeNoDB
 	}
 	relayLog.ID = snowflake.GenerateID()
-	go notifySubscribers(relayLog)
+	notifyLog := relayLog
+	if !isRelayLogRedundantFieldsEnabled() {
+		notifyLog = stripRelayLogRedundantFields(notifyLog)
+	}
+	go notifySubscribers(notifyLog)
 
 	relayLogCacheLock.Lock()
 	relayLogCache = append(relayLogCache, relayLog)
@@ -250,7 +261,58 @@ func RelayLogList(ctx context.Context, startTime, endTime *int, page, pageSize i
 		}
 	}
 
+	if !isRelayLogRedundantFieldsEnabled() {
+		for i := range result {
+			result[i] = stripRelayLogRedundantFields(result[i])
+		}
+	}
+
 	return result, nil
+}
+
+func isRelayLogRedundantFieldsEnabled() bool {
+	enabled, err := SettingGetBool(model.SettingKeyRelayLogRedundantFieldsEnabled)
+	if err != nil {
+		return true
+	}
+	return enabled
+}
+
+func stripRelayLogRedundantFields(relayLog model.RelayLog) model.RelayLog {
+	relayLog.RequestContent = stripJSONFields(relayLog.RequestContent, relayLogRedundantFields...)
+	relayLog.ResponseContent = stripJSONFields(relayLog.ResponseContent, relayLogRedundantFields...)
+	return relayLog
+}
+
+func stripJSONFields(payload string, fields ...string) string {
+	if payload == "" {
+		return payload
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+		return payload
+	}
+	if obj == nil {
+		return payload
+	}
+
+	changed := false
+	for _, field := range fields {
+		if _, exists := obj[field]; exists {
+			delete(obj, field)
+			changed = true
+		}
+	}
+	if !changed {
+		return payload
+	}
+
+	updated, err := json.Marshal(obj)
+	if err != nil {
+		return payload
+	}
+	return string(updated)
 }
 
 func RelayLogClear(ctx context.Context) error {

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -27,6 +27,7 @@ type RelayMetrics struct {
 	// 请求和响应内容
 	InternalRequest  *transformerModel.InternalLLMRequest
 	InternalResponse *transformerModel.InternalLLMResponse
+	RawResponse      []byte
 	ClientResponse   []byte
 
 	// 统计指标
@@ -86,6 +87,21 @@ func (m *RelayMetrics) SetClientResponse(resp []byte) {
 	m.ClientResponse = append([]byte(nil), resp...)
 }
 
+func (m *RelayMetrics) SetRawResponse(resp []byte) {
+	if len(resp) == 0 {
+		m.RawResponse = nil
+		return
+	}
+	m.RawResponse = append([]byte(nil), resp...)
+}
+
+func (m *RelayMetrics) AppendRawResponse(chunk []byte) {
+	if len(chunk) == 0 {
+		return
+	}
+	m.RawResponse = append(m.RawResponse, chunk...)
+}
+
 func (m *RelayMetrics) AppendClientResponse(chunk []byte) {
 	if len(chunk) == 0 {
 		return
@@ -142,6 +158,8 @@ func finalChannel(attempts []model.ChannelAttempt) (int, string) {
 }
 
 func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Duration, attempts []model.ChannelAttempt, channelID int, channelName string) {
+	includeRedundantFields := shouldRecordRelayLogRedundantFields()
+
 	actualModel := m.ActualModel
 	if actualModel == "" {
 		actualModel = m.RequestModel
@@ -174,9 +192,7 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 	if m.InternalRequest != nil {
 		if reqJSON, jsonErr := json.Marshal(m.InternalRequest); jsonErr == nil {
 			rawRequestValue := decodePayloadForLog(m.InternalRequest.RawRequest)
-			if rawRequestValue != nil {
-				reqJSON = appendFieldToJSONObject(reqJSON, "_octopus_raw_request", rawRequestValue)
-			}
+			reqJSON = appendFieldForRelayLog(reqJSON, "_octopus_raw_request", rawRequestValue, includeRedundantFields)
 			relayLog.RequestContent = string(reqJSON)
 		}
 	}
@@ -195,13 +211,10 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 			}
 		}
 	}
+	rawResponseValue := decodePayloadForLog(m.RawResponse)
+	respJSON = appendFieldForRelayLog(respJSON, "_octopus_raw_response", rawResponseValue, includeRedundantFields)
 	clientResponseValue := decodePayloadForLog(m.ClientResponse)
-	if clientResponseValue != nil {
-		if len(respJSON) == 0 {
-			respJSON = []byte("{}")
-		}
-		respJSON = appendFieldToJSONObject(respJSON, "_octopus_client_response", clientResponseValue)
-	}
+	respJSON = appendFieldForRelayLog(respJSON, "_octopus_client_response", clientResponseValue, includeRedundantFields)
 	if len(respJSON) > 0 {
 		relayLog.ResponseContent = string(respJSON)
 	}
@@ -294,4 +307,22 @@ func appendFieldToJSONObject(payload []byte, field string, value any) []byte {
 		return payload
 	}
 	return updated
+}
+
+func appendFieldForRelayLog(payload []byte, field string, value any, enabled bool) []byte {
+	if !enabled || value == nil {
+		return payload
+	}
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	return appendFieldToJSONObject(payload, field, value)
+}
+
+func shouldRecordRelayLogRedundantFields() bool {
+	enabled, err := op.SettingGetBool(model.SettingKeyRelayLogRedundantFieldsEnabled)
+	if err != nil {
+		return true
+	}
+	return enabled
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -332,6 +333,7 @@ func (ra *relayAttempt) sendRequest(req *http.Request) (*http.Response, error) {
 func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http.Response) error {
 	if ct := response.Header.Get("Content-Type"); ct != "" && !strings.Contains(strings.ToLower(ct), "text/event-stream") {
 		body, _ := io.ReadAll(io.LimitReader(response.Body, 16*1024))
+		ra.metrics.SetRawResponse(body)
 		return fmt.Errorf("upstream returned non-SSE content-type %q for stream request: %s", ct, string(body))
 	}
 
@@ -390,6 +392,7 @@ func (ra *relayAttempt) handleStreamResponse(ctx context.Context, response *http
 				log.Warnf("failed to read event: %v", r.err)
 				return fmt.Errorf("failed to read stream event: %w", r.err)
 			}
+			ra.metrics.AppendRawResponse([]byte("data: " + r.data + "\n\n"))
 
 			data, err := ra.transformStreamData(ctx, r.data)
 			if err != nil || len(data) == 0 {
@@ -441,6 +444,13 @@ func (ra *relayAttempt) transformStreamData(ctx context.Context, data string) ([
 
 // handleResponse 处理非流式响应
 func (ra *relayAttempt) handleResponse(ctx context.Context, response *http.Response) error {
+	rawBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read upstream response body: %w", err)
+	}
+	ra.metrics.SetRawResponse(rawBody)
+	response.Body = io.NopCloser(bytes.NewReader(rawBody))
+
 	internalResponse, err := ra.outAdapter.TransformResponse(ctx, response)
 	if err != nil {
 		log.Warnf("failed to transform response: %v", err)

--- a/internal/transformer/inbound/openai/response.go
+++ b/internal/transformer/inbound/openai/response.go
@@ -949,8 +949,10 @@ func convertToInternalRequest(req *ResponsesRequest) (*model.InternalLLMRequest,
 		Metadata:            req.Metadata,
 		MaxCompletionTokens: req.MaxOutputTokens,
 		TopLogprobs:         req.TopLogprobs,
+		ParallelToolCalls:   req.ParallelToolCalls,
 		RawAPIFormat:        model.APIFormatOpenAIResponse,
 		TransformerMetadata: map[string]string{},
+		Include:             append([]string(nil), req.Include...),
 	}
 
 	if req.Input.Text == nil && len(req.Input.Items) > 0 {

--- a/internal/transformer/inbound/openai/response.go
+++ b/internal/transformer/inbound/openai/response.go
@@ -1032,35 +1032,7 @@ func convertToolChoiceToInternal(src *ResponsesToolChoice) *model.ToolChoice {
 }
 
 func convertInputToMessages(input *ResponsesInput) ([]model.Message, error) {
-	if input == nil {
-		return nil, nil
-	}
-
-	// Simple text input
-	if input.Text != nil {
-		return []model.Message{
-			{
-				Role: "user",
-				Content: model.MessageContent{
-					Content: input.Text,
-				},
-			},
-		}, nil
-	}
-
-	// Array of items
-	messages := make([]model.Message, 0, len(input.Items))
-	for _, item := range input.Items {
-		msg, err := convertItemToMessage(&item)
-		if err != nil {
-			return nil, err
-		}
-		if msg != nil {
-			messages = append(messages, *msg)
-		}
-	}
-
-	return messages, nil
+	return convertResponsesInputToChatMessages(input)
 }
 
 func convertItemToMessage(item *ResponsesItem) (*model.Message, error) {

--- a/internal/transformer/inbound/openai/response.go
+++ b/internal/transformer/inbound/openai/response.go
@@ -1104,11 +1104,16 @@ func convertItemToMessage(item *ResponsesItem) (*model.Message, error) {
 		return nil, nil
 
 	case "function_call":
+		callID := item.CallID
+		if callID == "" {
+			callID = item.ID
+		}
+
 		return &model.Message{
 			Role: "assistant",
 			ToolCalls: []model.ToolCall{
 				{
-					ID:   item.CallID,
+					ID:   callID,
 					Type: "function",
 					Function: model.FunctionCall{
 						Name:      item.Name,
@@ -1119,9 +1124,19 @@ func convertItemToMessage(item *ResponsesItem) (*model.Message, error) {
 		}, nil
 
 	case "function_call_output":
+		callID := item.CallID
+		if callID == "" {
+			callID = item.ID
+		}
+
+		var toolCallID *string
+		if callID != "" {
+			toolCallID = lo.ToPtr(callID)
+		}
+
 		return &model.Message{
 			Role:       "tool",
-			ToolCallID: lo.ToPtr(item.CallID),
+			ToolCallID: toolCallID,
 			Content:    convertInputToMessageContent(*item.Output),
 		}, nil
 

--- a/internal/transformer/inbound/openai/response_chat_converter.go
+++ b/internal/transformer/inbound/openai/response_chat_converter.go
@@ -1,0 +1,117 @@
+package openai
+
+import (
+	"github.com/samber/lo"
+
+	"github.com/bestruirui/octopus/internal/transformer/model"
+)
+
+// convertResponsesInputToChatMessages is the dedicated conversion-layer entry for:
+// OpenAI Responses input -> OpenAI Chat-style internal messages.
+func convertResponsesInputToChatMessages(input *ResponsesInput) ([]model.Message, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	// Simple text input
+	if input.Text != nil {
+		return []model.Message{
+			{
+				Role: "user",
+				Content: model.MessageContent{
+					Content: input.Text,
+				},
+			},
+		}, nil
+	}
+
+	// Array of items
+	return convertResponsesItemsToChatMessages(input.Items)
+}
+
+// convertResponsesItemsToChatMessages converts Responses input items into OpenAI Chat-style messages.
+// It keeps full function_call -> function_call_output pairing by grouping consecutive function_call items
+// into one assistant message with tool_calls, then appending each tool output message.
+func convertResponsesItemsToChatMessages(items []ResponsesItem) ([]model.Message, error) {
+	messages := make([]model.Message, 0, len(items))
+	pendingToolCalls := make([]model.ToolCall, 0)
+
+	flushPendingToolCalls := func() {
+		if len(pendingToolCalls) == 0 {
+			return
+		}
+
+		grouped := make([]model.ToolCall, len(pendingToolCalls))
+		copy(grouped, pendingToolCalls)
+		messages = append(messages, model.Message{
+			Role:      "assistant",
+			ToolCalls: grouped,
+		})
+		pendingToolCalls = pendingToolCalls[:0]
+	}
+
+	for _, item := range items {
+		switch item.Type {
+		case "function_call":
+			pendingToolCalls = append(pendingToolCalls, convertFunctionCallItemToToolCall(item))
+		case "function_call_output":
+			flushPendingToolCalls()
+			msg := convertFunctionCallOutputItemToToolMessage(item)
+			if msg != nil {
+				messages = append(messages, *msg)
+			}
+		default:
+			flushPendingToolCalls()
+			msg, err := convertItemToMessage(&item)
+			if err != nil {
+				return nil, err
+			}
+			if msg != nil {
+				messages = append(messages, *msg)
+			}
+		}
+	}
+
+	flushPendingToolCalls()
+
+	return messages, nil
+}
+
+func convertFunctionCallItemToToolCall(item ResponsesItem) model.ToolCall {
+	callID := item.CallID
+	if callID == "" {
+		callID = item.ID
+	}
+
+	return model.ToolCall{
+		ID:   callID,
+		Type: "function",
+		Function: model.FunctionCall{
+			Name:      item.Name,
+			Arguments: item.Arguments,
+		},
+	}
+}
+
+func convertFunctionCallOutputItemToToolMessage(item ResponsesItem) *model.Message {
+	callID := item.CallID
+	if callID == "" {
+		callID = item.ID
+	}
+
+	var toolCallID *string
+	if callID != "" {
+		toolCallID = lo.ToPtr(callID)
+	}
+
+	content := model.MessageContent{}
+	if item.Output != nil {
+		content = convertInputToMessageContent(*item.Output)
+	}
+
+	return &model.Message{
+		Role:       "tool",
+		ToolCallID: toolCallID,
+		Content:    content,
+	}
+}

--- a/internal/transformer/inbound/openai/response_chat_converter.go
+++ b/internal/transformer/inbound/openai/response_chat_converter.go
@@ -35,6 +35,7 @@ func convertResponsesInputToChatMessages(input *ResponsesInput) ([]model.Message
 func convertResponsesItemsToChatMessages(items []ResponsesItem) ([]model.Message, error) {
 	messages := make([]model.Message, 0, len(items))
 	pendingToolCalls := make([]model.ToolCall, 0)
+	delayedInterleavedMessages := make([]model.Message, 0)
 
 	flushPendingToolCalls := func() {
 		if len(pendingToolCalls) == 0 {
@@ -50,6 +51,14 @@ func convertResponsesItemsToChatMessages(items []ResponsesItem) ([]model.Message
 		pendingToolCalls = pendingToolCalls[:0]
 	}
 
+	flushDelayedInterleavedMessages := func() {
+		if len(delayedInterleavedMessages) == 0 {
+			return
+		}
+		messages = append(messages, delayedInterleavedMessages...)
+		delayedInterleavedMessages = delayedInterleavedMessages[:0]
+	}
+
 	for _, item := range items {
 		switch item.Type {
 		case "function_call":
@@ -61,18 +70,25 @@ func convertResponsesItemsToChatMessages(items []ResponsesItem) ([]model.Message
 				messages = append(messages, *msg)
 			}
 		default:
-			flushPendingToolCalls()
 			msg, err := convertItemToMessage(&item)
 			if err != nil {
 				return nil, err
 			}
 			if msg != nil {
+				// OpenAI chat requires tool responses to directly follow assistant tool_calls.
+				// Keep interleaved messages, but postpone them until all pending tool outputs are emitted.
+				if len(pendingToolCalls) > 0 {
+					delayedInterleavedMessages = append(delayedInterleavedMessages, *msg)
+					continue
+				}
+				flushDelayedInterleavedMessages()
 				messages = append(messages, *msg)
 			}
 		}
 	}
 
 	flushPendingToolCalls()
+	flushDelayedInterleavedMessages()
 
 	return messages, nil
 }

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -274,7 +274,8 @@ func (r *InternalLLMRequest) Validate() error {
 	}
 
 	if isChatRequest {
-		r.fillMissingToolCallIDs()
+		r.fillMissingToolCallIDsFromToolMessages()
+		// r.fillMissingToolCallIDs()
 	}
 
 	return nil
@@ -312,6 +313,57 @@ func (r *InternalLLMRequest) fillMissingToolCallIDs() {
 
 			toolCall.ID = candidate
 			usedIDs[candidate] = struct{}{}
+		}
+	}
+}
+
+func (r *InternalLLMRequest) fillMissingToolCallIDsFromToolMessages() {
+	for msgIndex := 0; msgIndex < len(r.Messages); msgIndex++ {
+		msg := &r.Messages[msgIndex]
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			continue
+		}
+
+		candidates := make([]string, 0, len(msg.ToolCalls))
+		for nextIndex := msgIndex + 1; nextIndex < len(r.Messages); nextIndex++ {
+			nextMsg := r.Messages[nextIndex]
+			if nextMsg.Role != "tool" {
+				break
+			}
+			if nextMsg.ToolCallID == nil || *nextMsg.ToolCallID == "" {
+				continue
+			}
+			candidates = append(candidates, *nextMsg.ToolCallID)
+		}
+
+		if len(candidates) == 0 {
+			continue
+		}
+
+		used := make(map[string]struct{})
+		for _, toolCall := range msg.ToolCalls {
+			if toolCall.ID == "" {
+				continue
+			}
+			used[toolCall.ID] = struct{}{}
+		}
+
+		candidateIndex := 0
+		for toolCallIndex := range msg.ToolCalls {
+			if msg.ToolCalls[toolCallIndex].ID != "" {
+				continue
+			}
+
+			for candidateIndex < len(candidates) {
+				candidate := candidates[candidateIndex]
+				candidateIndex++
+				if _, exists := used[candidate]; exists {
+					continue
+				}
+				msg.ToolCalls[toolCallIndex].ID = candidate
+				used[candidate] = struct{}{}
+				break
+			}
 		}
 	}
 }

--- a/internal/transformer/outbound/openai/chat.go
+++ b/internal/transformer/outbound/openai/chat.go
@@ -17,6 +17,7 @@ type ChatOutbound struct{}
 
 func (o *ChatOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
 	request.ClearHelpFields()
+	ensureKimiReasoningContentForToolCalls(request, baseUrl)
 
 	// Convert developer role to system role for compatibility
 	for i := range request.Messages {
@@ -55,6 +56,71 @@ func (o *ChatOutbound) TransformRequest(ctx context.Context, request *model.Inte
 	req.URL = parsedUrl
 	req.Method = http.MethodPost
 	return req, nil
+}
+
+func ensureKimiReasoningContentForToolCalls(request *model.InternalLLMRequest, baseURL string) {
+	if request == nil || !isKimiChatCompatibilityRequired(request.Model, baseURL) {
+		return
+	}
+
+	for i := range request.Messages {
+		msg := &request.Messages[i]
+		if msg.Role != "assistant" || len(msg.ToolCalls) == 0 {
+			continue
+		}
+
+		existing := strings.TrimSpace(msg.GetReasoningContent())
+		if existing != "" {
+			msg.SetReasoningContent(existing)
+			continue
+		}
+
+		// Kimi treats empty reasoning_content as missing when thinking is enabled.
+		// Prefer nearby assistant reasoning/context, then fall back to a stable non-empty marker.
+		if inferred := inferAssistantReasoningContent(request.Messages, i); inferred != "" {
+			msg.SetReasoningContent(inferred)
+			continue
+		}
+
+		msg.SetReasoningContent("tool call")
+	}
+}
+
+func isKimiChatCompatibilityRequired(modelName, baseURL string) bool {
+	modelLower := strings.ToLower(strings.TrimSpace(modelName))
+	baseLower := strings.ToLower(strings.TrimSpace(baseURL))
+	return strings.Contains(modelLower, "kimi") || strings.Contains(baseLower, "api.kimi.com")
+}
+
+func inferAssistantReasoningContent(messages []model.Message, idx int) string {
+	if idx < 0 || idx >= len(messages) {
+		return ""
+	}
+
+	// Prefer most recent assistant reasoning before the current message.
+	for i := idx - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Role != "assistant" {
+			continue
+		}
+		if reasoning := strings.TrimSpace(msg.GetReasoningContent()); reasoning != "" {
+			return reasoning
+		}
+		if msg.Content.Content != nil {
+			if content := strings.TrimSpace(*msg.Content.Content); content != "" {
+				return content
+			}
+		}
+	}
+
+	// Fall back to current assistant textual content when present.
+	if messages[idx].Content.Content != nil {
+		if content := strings.TrimSpace(*messages[idx].Content.Content); content != "" {
+			return content
+		}
+	}
+
+	return ""
 }
 
 func (o *ChatOutbound) TransformResponse(ctx context.Context, response *http.Response) (*model.InternalLLMResponse, error) {

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -454,8 +454,8 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 	// Convert instructions from system messages
 	result.Instructions = convertInstructionsFromMessages(req.Messages)
 
-	// Convert input from messages
-	result.Input = convertInputFromMessages(req.Messages, req.TransformOptions)
+	// Convert input from messages (Chat -> Responses dedicated conversion-layer entry)
+	result.Input = convertChatMessagesToResponsesInput(req.Messages, req.TransformOptions)
 
 	// Convert tools
 	if len(req.Tools) > 0 {

--- a/internal/transformer/outbound/openai/response_chat_converter.go
+++ b/internal/transformer/outbound/openai/response_chat_converter.go
@@ -1,0 +1,9 @@
+package openai
+
+import "github.com/bestruirui/octopus/internal/transformer/model"
+
+// convertChatMessagesToResponsesInput is the dedicated conversion-layer entry for:
+// OpenAI Chat-style internal messages -> OpenAI Responses input.
+func convertChatMessagesToResponsesInput(msgs []model.Message, transformOptions model.TransformOptions) ResponsesInput {
+	return convertInputFromMessages(msgs, transformOptions)
+}

--- a/internal/transformer/outbound/register.go
+++ b/internal/transformer/outbound/register.go
@@ -17,6 +17,7 @@ const (
 	OutboundTypeGemini
 	OutboundTypeVolcengine
 	OutboundTypeOpenAIEmbedding
+	OutboundTypeKimiCoding
 )
 
 // EmbeddingChannelTypes 定义支持 embedding 请求的 channel 类型集合
@@ -31,6 +32,7 @@ var ChatChannelTypes = map[OutboundType]bool{
 	OutboundTypeAnthropic:      true,
 	OutboundTypeGemini:         true,
 	OutboundTypeVolcengine:     true,
+	OutboundTypeKimiCoding:     true,
 }
 
 // IsEmbeddingChannelType 判断 channel 类型是否支持 embedding 请求
@@ -50,6 +52,7 @@ var outboundFactories = map[OutboundType]func() model.Outbound{
 	OutboundTypeAnthropic:       func() model.Outbound { return &authropic.MessageOutbound{} },
 	OutboundTypeGemini:          func() model.Outbound { return &gemini.MessagesOutbound{} },
 	OutboundTypeVolcengine:      func() model.Outbound { return &volcengine.ResponseOutbound{} },
+	OutboundTypeKimiCoding:      func() model.Outbound { return &openai.ChatOutbound{} },
 }
 
 func Get(outboundType OutboundType) model.Outbound {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -476,6 +476,7 @@
             "paramOverridePlaceholder": "Optional: JSON string to override request params",
             "model": "Model",
             "enabled": "Enabled",
+            "enableCircuitBreaker": "Enable Circuit Breaker",
             "proxy": "Use Proxy",
             "modelCustomPlaceholder": "Custom model name",
             "modelAdd": "Add",

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -1,507 +1,511 @@
 {
-    "login": {
-        "username": "Username",
-        "usernamePlaceholder": "Enter your username",
-        "password": "Password",
-        "passwordPlaceholder": "Enter your password",
-        "apikey": "API Key",
-        "apikeyPlaceholder": "Enter your API Key (sk-octopus-...)",
-        "mode": {
-            "user": "Account",
-            "apikey": "API Key"
-        },
-        "error": {
-            "generic": "Login failed, please check your credentials"
-        },
-        "button": {
-            "loading": "Logging in...",
-            "submit": "Login"
-        }
+  "login": {
+    "username": "Username",
+    "usernamePlaceholder": "Enter your username",
+    "password": "Password",
+    "passwordPlaceholder": "Enter your password",
+    "apikey": "API Key",
+    "apikeyPlaceholder": "Enter your API Key (sk-octopus-...)",
+    "mode": {
+      "user": "Account",
+      "apikey": "API Key"
     },
-    "apiKeyDashboard": {
-        "error": "Failed to load data",
-        "logout": "Logout",
-        "requestStats": "Request Stats",
-        "totalStats": "Total Stats",
-        "inputStats": "Input Stats",
-        "outputStats": "Output Stats",
-        "requestCount": "Requests",
-        "timeConsumed": "Time Consumed",
-        "totalToken": "Tokens Used",
-        "totalCost": "Total Cost",
-        "inputTokens": "Input Tokens",
-        "inputCost": "Input Cost",
-        "outputTokens": "Output Tokens",
-        "outputCost": "Output Cost",
-        "successRequests": "Successful",
-        "failedRequests": "Failed",
-        "quota": "Remaining Quota",
+    "error": {
+      "generic": "Login failed, please check your credentials"
+    },
+    "button": {
+      "loading": "Logging in...",
+      "submit": "Login"
+    }
+  },
+  "apiKeyDashboard": {
+    "error": "Failed to load data",
+    "logout": "Logout",
+    "requestStats": "Request Stats",
+    "totalStats": "Total Stats",
+    "inputStats": "Input Stats",
+    "outputStats": "Output Stats",
+    "requestCount": "Requests",
+    "timeConsumed": "Time Consumed",
+    "totalToken": "Tokens Used",
+    "totalCost": "Total Cost",
+    "inputTokens": "Input Tokens",
+    "inputCost": "Input Cost",
+    "outputTokens": "Output Tokens",
+    "outputCost": "Output Cost",
+    "successRequests": "Successful",
+    "failedRequests": "Failed",
+    "quota": "Remaining Quota",
+    "unlimited": "Unlimited",
+    "expireAt": "Expires",
+    "neverExpire": "Never",
+    "daysLeft": "days left",
+    "expired": "Expired",
+    "supportedModels": "Supported Models"
+  },
+  "navbar": {
+    "home": "Home",
+    "channel": "Channel",
+    "group": "Group",
+    "key": "Key",
+    "model": "Price",
+    "log": "Log",
+    "setting": "Setting"
+  },
+  "common": {
+    "copy": {
+      "success": "Copied",
+      "failed": "Copy failed",
+      "noContent": "Nothing to copy"
+    }
+  },
+  "home": {
+    "activity": {
+      "requestCount": "Requests",
+      "waitTime": "Wait Time",
+      "totalToken": "Tokens Used",
+      "totalCost": "Total Cost",
+      "noData": "No Data"
+    },
+    "total": {
+      "requestStats": "Request Stats",
+      "totalStats": "Total Stats",
+      "inputStats": "Input Stats",
+      "outputStats": "Output Stats",
+      "requestCount": "Requests",
+      "timeConsumed": "Time Consumed",
+      "totalToken": "Tokens Used",
+      "totalCost": "Total Cost",
+      "inputTokens": "Input Tokens",
+      "inputCost": "Input Cost",
+      "outputTokens": "Output Tokens",
+      "outputCost": "Output Cost"
+    },
+    "chart": {
+      "totalRequests": "Total Requests",
+      "totalCost": "Total Cost",
+      "timePeriod": "Time Period",
+      "period": {
+        "today": "Today",
+        "last7Days": "7 Days",
+        "last30Days": "30 Days"
+      }
+    },
+    "rank": {
+      "title": "Ranking",
+      "sortByCost": "Cost",
+      "sortByCount": "Count",
+      "noData": "No ranking data",
+      "successRate": "Success Rate"
+    }
+  },
+  "setting": {
+    "appearance": "Appearance",
+    "system": "System",
+    "theme": {
+      "label": "Theme",
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    },
+    "language": {
+      "label": "Language",
+      "zh_hans": "Chinese (Simplified)",
+      "zh_hant": "Chinese (Traditional)",
+      "en": "English"
+    },
+    "proxyUrl": {
+      "label": "Proxy URL",
+      "placeholder": "Enter proxy URL"
+    },
+    "statsSaveInterval": {
+      "label": "Stats Save Interval",
+      "placeholder": "Enter interval in minutes"
+    },
+    "corsAllowOrigins": {
+      "label": "CORS Allowed Origins",
+      "hint": "Empty = deny all, * = allow all",
+      "example": "Only allow specific domains: https://example.com,https://example2.com"
+    },
+    "circuitBreaker": {
+      "title": "Circuit Breaker",
+      "threshold": {
+        "label": "Failure Threshold (consecutive failures)",
+        "placeholder": "Enter threshold"
+      },
+      "cooldown": {
+        "label": "Base Cooldown (seconds)",
+        "placeholder": "Enter cooldown in seconds"
+      },
+      "maxCooldown": {
+        "label": "Max Cooldown (seconds)",
+        "placeholder": "Enter max cooldown in seconds"
+      },
+      "hint": "When a channel fails consecutively up to the threshold, circuit breaker trips. Cooldown grows exponentially up to the max cooldown"
+    },
+    "saved": "Saved",
+    "backup": {
+      "title": "Backup / Restore",
+      "export": {
+        "title": "Export",
+        "includeLogs": "Include Logs",
+        "includeStats": "Include Stats",
+        "button": "Download JSON",
+        "exporting": "Exporting...",
+        "success": "Export started"
+      },
+      "import": {
+        "title": "Import (Incremental)",
+        "selected": "File selected",
+        "button": "Import JSON",
+        "importing": "Importing...",
+        "noFile": "Please select a JSON file first",
+        "success": "Import successful",
+        "failed": "Import failed",
+        "result": "Import result"
+      }
+    },
+    "apiKey": {
+      "title": "API Keys",
+      "empty": "No API keys",
+      "add": "Add Key",
+      "loadFailed": "Failed to load",
+      "form": {
+        "name": "Name",
+        "maxCost": "Max Cost",
+        "maxCostPlaceholder": "Enter amount",
         "unlimited": "Unlimited",
-        "expireAt": "Expires",
-        "neverExpire": "Never",
-        "daysLeft": "days left",
-        "expired": "Expired",
-        "supportedModels": "Supported Models"
+        "expireAt": "Expire Date",
+        "selectDate": "Select date",
+        "neverExpire": "Never Expire",
+        "supportedModels": "Supported Models",
+        "noModels": "No models available",
+        "modelsHint": "Leave empty for unlimited",
+        "enabled": "Enabled",
+        "cancel": "Cancel",
+        "create": "Create",
+        "save": "Save",
+        "confirm": "Confirm"
+      },
+      "stats": {
+        "noData": "No statistics available",
+        "inputToken": "Input Token",
+        "outputToken": "Output Token",
+        "inputCost": "Input Cost",
+        "outputCost": "Output Cost",
+        "requestSuccess": "Request Success",
+        "requestFailed": "Request Failed"
+      },
+      "toast": {
+        "createSuccess": "API key created",
+        "createError": "Failed to create API key",
+        "updateSuccess": "API key updated",
+        "updateError": "Failed to update API key",
+        "deleteSuccess": "API key deleted",
+        "deleteError": "Failed to delete API key"
+      }
     },
-    "navbar": {
-        "home": "Home",
-        "channel": "Channel",
-        "group": "Group",
-        "key": "Key",
-        "model": "Price",
-        "log": "Log",
-        "setting": "Setting"
+    "llmPrice": {
+      "title": "Model Pricing",
+      "updateInterval": {
+        "label": "Auto Update Interval (hours)",
+        "placeholder": "Enter interval in hours"
+      },
+      "manualUpdate": {
+        "label": "Manual Price Update",
+        "button": "Update Now",
+        "updating": "Updating..."
+      },
+      "lastUpdate": "Last Update",
+      "neverUpdated": "Never updated",
+      "updateSuccess": "Price updated successfully",
+      "updateFailed": "Failed to update price"
     },
-    "common": {
-        "copy": {
-            "success": "Copied",
-            "failed": "Copy failed",
-            "noContent": "Nothing to copy"
-        }
+    "llmSync": {
+      "title": "Channel Sync",
+      "syncInterval": {
+        "label": "Auto Sync Interval (hours)",
+        "placeholder": "Enter interval in hours"
+      },
+      "manualSync": {
+        "label": "Manual Channel Sync",
+        "button": "Sync Now",
+        "syncing": "Syncing..."
+      },
+      "lastSync": "Last Sync",
+      "neverSynced": "Never synced",
+      "syncSuccess": "Channel synced successfully",
+      "syncFailed": "Failed to sync channel"
     },
-    "home": {
-        "activity": {
-            "requestCount": "Requests",
-            "waitTime": "Wait Time",
-            "totalToken": "Tokens Used",
-            "totalCost": "Total Cost",
-            "noData": "No Data"
-        },
-        "total": {
-            "requestStats": "Request Stats",
-            "totalStats": "Total Stats",
-            "inputStats": "Input Stats",
-            "outputStats": "Output Stats",
-            "requestCount": "Requests",
-            "timeConsumed": "Time Consumed",
-            "totalToken": "Tokens Used",
-            "totalCost": "Total Cost",
-            "inputTokens": "Input Tokens",
-            "inputCost": "Input Cost",
-            "outputTokens": "Output Tokens",
-            "outputCost": "Output Cost"
-        },
-        "chart": {
-            "totalRequests": "Total Requests",
-            "totalCost": "Total Cost",
-            "timePeriod": "Time Period",
-            "period": {
-                "today": "Today",
-                "last7Days": "7 Days",
-                "last30Days": "30 Days"
-            }
-        },
-        "rank": {
-            "title": "Ranking",
-            "sortByCost": "Cost",
-            "sortByCount": "Count",
-            "noData": "No ranking data",
-            "successRate": "Success Rate"
-        }
+    "account": {
+      "title": "Account Settings",
+      "save": "Save",
+      "saving": "Saving...",
+      "username": {
+        "label": "Change Username",
+        "placeholder": "Enter new username",
+        "empty": "Username cannot be empty",
+        "success": "Username changed successfully",
+        "failed": "Failed to change username"
+      },
+      "password": {
+        "label": "Change Password",
+        "oldPlaceholder": "Enter current password",
+        "newPlaceholder": "Enter new password",
+        "confirmPlaceholder": "Confirm new password",
+        "oldEmpty": "Please enter current password",
+        "newEmpty": "Please enter new password",
+        "mismatch": "Passwords do not match",
+        "tooShort": "Password must be at least 6 characters",
+        "change": "Change Password",
+        "success": "Password changed successfully",
+        "failed": "Failed to change password"
+      }
     },
-    "setting": {
-        "appearance": "Appearance",
-        "system": "System",
-        "theme": {
-            "label": "Theme",
-            "light": "Light",
-            "dark": "Dark",
-            "system": "System"
-        },
-        "language": {
-            "label": "Language",
-            "zh_hans": "Chinese (Simplified)",
-            "zh_hant": "Chinese (Traditional)",
-            "en": "English"
-        },
-        "proxyUrl": {
-            "label": "Proxy URL",
-            "placeholder": "Enter proxy URL"
-        },
-        "statsSaveInterval": {
-            "label": "Stats Save Interval",
-            "placeholder": "Enter interval in minutes"
-        },
-        "corsAllowOrigins": {
-            "label": "CORS Allowed Origins",
-            "hint": "Empty = deny all, * = allow all",
-            "example": "Only allow specific domains: https://example.com,https://example2.com"
-        },
-        "circuitBreaker": {
-            "title": "Circuit Breaker",
-            "threshold": {
-                "label": "Failure Threshold (consecutive failures)",
-                "placeholder": "Enter threshold"
-            },
-            "cooldown": {
-                "label": "Base Cooldown (seconds)",
-                "placeholder": "Enter cooldown in seconds"
-            },
-            "maxCooldown": {
-                "label": "Max Cooldown (seconds)",
-                "placeholder": "Enter max cooldown in seconds"
-            },
-            "hint": "When a channel fails consecutively up to the threshold, circuit breaker trips. Cooldown grows exponentially up to the max cooldown"
-        },
-        "saved": "Saved",
-        "backup": {
-            "title": "Backup / Restore",
-            "export": {
-                "title": "Export",
-                "includeLogs": "Include Logs",
-                "includeStats": "Include Stats",
-                "button": "Download JSON",
-                "exporting": "Exporting...",
-                "success": "Export started"
-            },
-            "import": {
-                "title": "Import (Incremental)",
-                "selected": "File selected",
-                "button": "Import JSON",
-                "importing": "Importing...",
-                "noFile": "Please select a JSON file first",
-                "success": "Import successful",
-                "failed": "Import failed",
-                "result": "Import result"
-            }
-        },
-        "apiKey": {
-            "title": "API Keys",
-            "empty": "No API keys",
-            "add": "Add Key",
-            "loadFailed": "Failed to load",
-            "form": {
-                "name": "Name",
-                "maxCost": "Max Cost",
-                "maxCostPlaceholder": "Enter amount",
-                "unlimited": "Unlimited",
-                "expireAt": "Expire Date",
-                "selectDate": "Select date",
-                "neverExpire": "Never Expire",
-                "supportedModels": "Supported Models",
-                "noModels": "No models available",
-                "modelsHint": "Leave empty for unlimited",
-                "enabled": "Enabled",
-                "cancel": "Cancel",
-                "create": "Create",
-                "save": "Save",
-                "confirm": "Confirm"
-            },
-            "stats": {
-                "noData": "No statistics available",
-                "inputToken": "Input Token",
-                "outputToken": "Output Token",
-                "inputCost": "Input Cost",
-                "outputCost": "Output Cost",
-                "requestSuccess": "Request Success",
-                "requestFailed": "Request Failed"
-            },
-            "toast": {
-                "createSuccess": "API key created",
-                "createError": "Failed to create API key",
-                "updateSuccess": "API key updated",
-                "updateError": "Failed to update API key",
-                "deleteSuccess": "API key deleted",
-                "deleteError": "Failed to delete API key"
-            }
-        },
-        "llmPrice": {
-            "title": "Model Pricing",
-            "updateInterval": {
-                "label": "Auto Update Interval (hours)",
-                "placeholder": "Enter interval in hours"
-            },
-            "manualUpdate": {
-                "label": "Manual Price Update",
-                "button": "Update Now",
-                "updating": "Updating..."
-            },
-            "lastUpdate": "Last Update",
-            "neverUpdated": "Never updated",
-            "updateSuccess": "Price updated successfully",
-            "updateFailed": "Failed to update price"
-        },
-        "llmSync": {
-            "title": "Channel Sync",
-            "syncInterval": {
-                "label": "Auto Sync Interval (hours)",
-                "placeholder": "Enter interval in hours"
-            },
-            "manualSync": {
-                "label": "Manual Channel Sync",
-                "button": "Sync Now",
-                "syncing": "Syncing..."
-            },
-            "lastSync": "Last Sync",
-            "neverSynced": "Never synced",
-            "syncSuccess": "Channel synced successfully",
-            "syncFailed": "Failed to sync channel"
-        },
-        "account": {
-            "title": "Account Settings",
-            "save": "Save",
-            "saving": "Saving...",
-            "username": {
-                "label": "Change Username",
-                "placeholder": "Enter new username",
-                "empty": "Username cannot be empty",
-                "success": "Username changed successfully",
-                "failed": "Failed to change username"
-            },
-            "password": {
-                "label": "Change Password",
-                "oldPlaceholder": "Enter current password",
-                "newPlaceholder": "Enter new password",
-                "confirmPlaceholder": "Confirm new password",
-                "oldEmpty": "Please enter current password",
-                "newEmpty": "Please enter new password",
-                "mismatch": "Passwords do not match",
-                "tooShort": "Password must be at least 6 characters",
-                "change": "Change Password",
-                "success": "Password changed successfully",
-                "failed": "Failed to change password"
-            }
-        },
-        "info": {
-            "title": "Version Info",
-            "currentVersion": "Current Version",
-            "latestVersion": "Latest Version",
-            "buildTime": "Build Time",
-            "publishedAt": "Published At",
-            "github": "GitHub Repository",
-            "unknown": "Unknown",
-            "versionMismatch": "Version Mismatch",
-            "versionMismatchHint": "Frontend version ({frontend}) does not match backend version ({backend}). This may be a browser cache issue. Please force refresh the page.",
-            "forceRefresh": "Force Refresh",
-            "newVersionAvailable": "New version available",
-            "newVersionAvailableHint": "Please backup your data first, then update the system",
-            "updateNow": "Update Now",
-            "updating": "Updating...",
-            "updateSuccess": "Update successful, service will restart shortly",
-            "updateFailed": "Update failed"
-        },
-        "log": {
-            "title": "Log Settings",
-            "enabled": {
-                "label": "Enable History Logs"
-            },
-            "keepPeriod": {
-                "label": "Log Retention (days)",
-                "placeholder": "Enter days"
-            },
-            "clear": {
-                "label": "Clear History Logs",
-                "button": "Clear",
-                "clearing": "Clearing..."
-            },
-            "clearSuccess": "Logs cleared",
-            "clearFailed": "Failed to clear logs"
-        }
-    },
-    "group": {
-        "toast": {
-            "created": "Created successfully",
-            "createFailed": "Create failed",
-            "updated": "Updated successfully",
-            "updateFailed": "Update failed",
-            "deleted": "Deleted successfully",
-            "autoAddFailed": "Auto add failed"
-        },
-        "create": {
-            "title": "Create Group",
-            "submit": "Create",
-            "submitting": "Creating..."
-        },
-        "card": {
-            "empty": "No rules"
-        },
-        "detail": {
-            "actions": {
-                "edit": "Edit",
-                "cancel": "Cancel",
-                "save": "Save",
-                "copyName": "Copy Name",
-                "delete": "Delete",
-                "confirmDelete": "Confirm Delete"
-            }
-        },
-        "form": {
-            "name": "Group Name",
-            "matchRegex": "Match Regex",
-            "matchRegexPlaceholder": "Leave empty to use default fuzzy match by group name",
-            "matchRegexInvalid": "Invalid regex",
-            "firstTokenTimeOut": "First Token Timeout",
-            "firstTokenTimeOutHint": "Unit: seconds, only effective for streaming response, 0 = no limit",
-            "sessionKeepTime": "Session Keep Time",
-            "sessionKeepTimeHint": "Unit: seconds, keeps using the same channel within a session, 0 = disabled",
-            "items": "Selected Models",
-            "addItem": "Add Model",
-            "autoAdd": "Auto Add",
-            "clear": "Clear",
-            "selectChannel": "Channel",
-            "selectModel": "Model"
-        },
-        "mode": {
-            "roundRobin": "Round Robin",
-            "random": "Random",
-            "failover": "Failover",
-            "weighted": "Weighted"
-        },
-        "empty": "No groups yet, click the button above to create one"
-    },
-    "model": {
-        "create": {
-            "title": "Create Model",
-            "name": "Model Name",
-            "input": "Input Price",
-            "output": "Output Price",
-            "cacheRead": "Cache Read",
-            "cacheWrite": "Cache Write",
-            "submit": "Create",
-            "submitting": "Creating..."
-        },
-        "toast": {
-            "updated": "Model price updated",
-            "updateFailed": "Update failed",
-            "deleted": "Model deleted",
-            "deleteFailed": "Delete failed"
-        },
-        "card": {
-            "inputCache": "Input/Cache",
-            "outputCache": "Output/Cache",
-            "edit": "Edit",
-            "delete": "Delete"
-        },
-        "overlay": {
-            "cancel": "Cancel",
-            "deleting": "Deleting...",
-            "confirmDelete": "Confirm Delete",
-            "input": "Input",
-            "output": "Output",
-            "cacheRead": "Cache Read",
-            "cacheWrite": "Cache Write",
-            "save": "Save"
-        }
+    "info": {
+      "title": "Version Info",
+      "currentVersion": "Current Version",
+      "latestVersion": "Latest Version",
+      "buildTime": "Build Time",
+      "publishedAt": "Published At",
+      "github": "GitHub Repository",
+      "unknown": "Unknown",
+      "versionMismatch": "Version Mismatch",
+      "versionMismatchHint": "Frontend version ({frontend}) does not match backend version ({backend}). This may be a browser cache issue. Please force refresh the page.",
+      "forceRefresh": "Force Refresh",
+      "newVersionAvailable": "New version available",
+      "newVersionAvailableHint": "Please backup your data first, then update the system",
+      "updateNow": "Update Now",
+      "updating": "Updating...",
+      "updateSuccess": "Update successful, service will restart shortly",
+      "updateFailed": "Update failed"
     },
     "log": {
-        "list": {
-            "noMore": "No more logs"
-        },
-        "card": {
-            "error": "Error",
-            "errorInfo": "Error Info",
-            "firstToken": "TTFT",
-            "totalTime": "Total",
-            "input": "Input",
-            "output": "Output",
-            "cost": "Cost",
-            "requestContent": "Request Content",
-            "responseContent": "Response Content",
-            "noRequestContent": "(No request content)",
-            "noResponseContent": "(No response content)",
-            "firstTokenTime": "First Token Time",
-            "tokens": "tokens",
-            "retryDetails": "Retry Details",
-            "attempts": "attempts",
-            "success": "Success",
-            "failed": "Failed"
-        }
-    },
-    "channel": {
-        "card": {
-            "requestCount": "Requests",
-            "totalCost": "Total Cost",
-            "toast": {
-                "enabled": "Channel enabled",
-                "disabled": "Channel disabled"
-            }
-        },
-        "detail": {
-            "title": {
-                "edit": "Edit Channel",
-                "view": "Channel Details"
-            },
-            "sections": {
-                "requests": "Request Details",
-                "tokens": "Token Usage",
-                "costs": "Cost Details",
-                "baseUrls": "Base URLs",
-                "keys": "Keys"
-            },
-            "noBaseUrls": "No Base URLs",
-            "noKeys": "No Keys",
-            "metrics": {
-                "totalRequests": "Total Requests",
-                "totalToken": "Total Tokens",
-                "totalCost": "Total Cost",
-                "successRequests": "Successful Requests",
-                "failedRequests": "Failed Requests",
-                "inputToken": "Input Tokens",
-                "outputToken": "Output Tokens",
-                "inputCost": "Input Cost",
-                "outputCost": "Output Cost",
-                "avgWaitTime": "Wait Time"
-            },
-            "actions": {
-                "edit": "Edit",
-                "cancel": "Cancel",
-                "save": "Save",
-                "saving": "Saving...",
-                "delete": "Delete",
-                "confirmDelete": "Confirm Delete",
-                "deleting": "Deleting..."
-            }
-        },
-        "create": {
-            "dialogTitle": "Create New Channel",
-            "submit": "Create Channel",
-            "submitting": "Creating..."
-        },
-        "form": {
-            "add": "Add",
-            "name": "Channel Name",
-            "type": "Channel Type",
-            "baseUrls": "Base URLs",
-            "baseUrlUrl": "URL",
-            "baseUrlDelay": "Delay(ms)",
-            "advanced": "Advanced Settings",
-            "apiKey": "API Key",
-            "customHeader": "Custom Headers",
-            "customHeaderKey": "Header Key",
-            "customHeaderValue": "Header Value",
-            "customHeaderAdd": "Add Header",
-            "channelProxy": "Channel Proxy",
-            "channelProxyPlaceholder": "Optional: proxy for this channel (overrides global proxy)",
-            "paramOverride": "Param Override",
-            "paramOverridePlaceholder": "Optional: JSON string to override request params",
-            "model": "Model",
-            "enabled": "Enabled",
-            "enableCircuitBreaker": "Enable Circuit Breaker",
-            "proxy": "Use Proxy",
-            "modelCustomPlaceholder": "Custom model name",
-            "modelAdd": "Add",
-            "modelRefresh": "Refresh",
-            "modelRefreshSuccess": "Models fetched successfully",
-            "modelRefreshFailed": "Failed to fetch models",
-            "modelRefreshEmpty": "No models found",
-            "modelSelected": "Selected Models",
-            "modelNoSelected": "No models selected",
-            "modelClearAll": "Clear All",
-            "typeOpenAIChat": "OpenAI Chat",
-            "typeOpenAIResponse": "OpenAI Response",
-            "typeOpenAIEmbedding": "OpenAI Embedding",
-            "typeAnthropic": "Anthropic",
-            "typeGemini": "Gemini",
-            "typeVolcengine": "Volcengine",
-            "autoSync": "Auto Sync",
-            "autoGroup": "Auto Group",
-            "autoGroupNone": "None",
-            "autoGroupFuzzy": "Fuzzy",
-            "autoGroupExact": "Exact",
-            "autoGroupRegex": "Regex",
-            "matchRegex": "Match Regex",
-            "matchRegexPlaceholder": "Optional: regex pattern to match request model names",
-            "remark": "Remark"
-        }
+      "title": "Log Settings",
+      "enabled": {
+        "label": "Enable History Logs"
+      },
+      "keepPeriod": {
+        "label": "Log Retention (days)",
+        "placeholder": "Enter days"
+      },
+      "redundantFields": {
+        "label": "Record and expose log redundant fields (_octopus_*)"
+      },
+      "clear": {
+        "label": "Clear History Logs",
+        "button": "Clear",
+        "clearing": "Clearing..."
+      },
+      "clearSuccess": "Logs cleared",
+      "clearFailed": "Failed to clear logs"
     }
+  },
+  "group": {
+    "toast": {
+      "created": "Created successfully",
+      "createFailed": "Create failed",
+      "updated": "Updated successfully",
+      "updateFailed": "Update failed",
+      "deleted": "Deleted successfully",
+      "autoAddFailed": "Auto add failed"
+    },
+    "create": {
+      "title": "Create Group",
+      "submit": "Create",
+      "submitting": "Creating..."
+    },
+    "card": {
+      "empty": "No rules"
+    },
+    "detail": {
+      "actions": {
+        "edit": "Edit",
+        "cancel": "Cancel",
+        "save": "Save",
+        "copyName": "Copy Name",
+        "delete": "Delete",
+        "confirmDelete": "Confirm Delete"
+      }
+    },
+    "form": {
+      "name": "Group Name",
+      "matchRegex": "Match Regex",
+      "matchRegexPlaceholder": "Leave empty to use default fuzzy match by group name",
+      "matchRegexInvalid": "Invalid regex",
+      "firstTokenTimeOut": "First Token Timeout",
+      "firstTokenTimeOutHint": "Unit: seconds, only effective for streaming response, 0 = no limit",
+      "sessionKeepTime": "Session Keep Time",
+      "sessionKeepTimeHint": "Unit: seconds, keeps using the same channel within a session, 0 = disabled",
+      "items": "Selected Models",
+      "addItem": "Add Model",
+      "autoAdd": "Auto Add",
+      "clear": "Clear",
+      "selectChannel": "Channel",
+      "selectModel": "Model"
+    },
+    "mode": {
+      "roundRobin": "Round Robin",
+      "random": "Random",
+      "failover": "Failover",
+      "weighted": "Weighted"
+    },
+    "empty": "No groups yet, click the button above to create one"
+  },
+  "model": {
+    "create": {
+      "title": "Create Model",
+      "name": "Model Name",
+      "input": "Input Price",
+      "output": "Output Price",
+      "cacheRead": "Cache Read",
+      "cacheWrite": "Cache Write",
+      "submit": "Create",
+      "submitting": "Creating..."
+    },
+    "toast": {
+      "updated": "Model price updated",
+      "updateFailed": "Update failed",
+      "deleted": "Model deleted",
+      "deleteFailed": "Delete failed"
+    },
+    "card": {
+      "inputCache": "Input/Cache",
+      "outputCache": "Output/Cache",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "overlay": {
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "confirmDelete": "Confirm Delete",
+      "input": "Input",
+      "output": "Output",
+      "cacheRead": "Cache Read",
+      "cacheWrite": "Cache Write",
+      "save": "Save"
+    }
+  },
+  "log": {
+    "list": {
+      "noMore": "No more logs"
+    },
+    "card": {
+      "error": "Error",
+      "errorInfo": "Error Info",
+      "firstToken": "TTFT",
+      "totalTime": "Total",
+      "input": "Input",
+      "output": "Output",
+      "cost": "Cost",
+      "requestContent": "Request Content",
+      "responseContent": "Response Content",
+      "noRequestContent": "(No request content)",
+      "noResponseContent": "(No response content)",
+      "firstTokenTime": "First Token Time",
+      "tokens": "tokens",
+      "retryDetails": "Retry Details",
+      "attempts": "attempts",
+      "success": "Success",
+      "failed": "Failed"
+    }
+  },
+  "channel": {
+    "card": {
+      "requestCount": "Requests",
+      "totalCost": "Total Cost",
+      "toast": {
+        "enabled": "Channel enabled",
+        "disabled": "Channel disabled"
+      }
+    },
+    "detail": {
+      "title": {
+        "edit": "Edit Channel",
+        "view": "Channel Details"
+      },
+      "sections": {
+        "requests": "Request Details",
+        "tokens": "Token Usage",
+        "costs": "Cost Details",
+        "baseUrls": "Base URLs",
+        "keys": "Keys"
+      },
+      "noBaseUrls": "No Base URLs",
+      "noKeys": "No Keys",
+      "metrics": {
+        "totalRequests": "Total Requests",
+        "totalToken": "Total Tokens",
+        "totalCost": "Total Cost",
+        "successRequests": "Successful Requests",
+        "failedRequests": "Failed Requests",
+        "inputToken": "Input Tokens",
+        "outputToken": "Output Tokens",
+        "inputCost": "Input Cost",
+        "outputCost": "Output Cost",
+        "avgWaitTime": "Wait Time"
+      },
+      "actions": {
+        "edit": "Edit",
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving...",
+        "delete": "Delete",
+        "confirmDelete": "Confirm Delete",
+        "deleting": "Deleting..."
+      }
+    },
+    "create": {
+      "dialogTitle": "Create New Channel",
+      "submit": "Create Channel",
+      "submitting": "Creating..."
+    },
+    "form": {
+      "add": "Add",
+      "name": "Channel Name",
+      "type": "Channel Type",
+      "baseUrls": "Base URLs",
+      "baseUrlUrl": "URL",
+      "baseUrlDelay": "Delay(ms)",
+      "advanced": "Advanced Settings",
+      "apiKey": "API Key",
+      "customHeader": "Custom Headers",
+      "customHeaderKey": "Header Key",
+      "customHeaderValue": "Header Value",
+      "customHeaderAdd": "Add Header",
+      "channelProxy": "Channel Proxy",
+      "channelProxyPlaceholder": "Optional: proxy for this channel (overrides global proxy)",
+      "paramOverride": "Param Override",
+      "paramOverridePlaceholder": "Optional: JSON string to override request params",
+      "model": "Model",
+      "enabled": "Enabled",
+      "enableCircuitBreaker": "Enable Circuit Breaker",
+      "proxy": "Use Proxy",
+      "modelCustomPlaceholder": "Custom model name",
+      "modelAdd": "Add",
+      "modelRefresh": "Refresh",
+      "modelRefreshSuccess": "Models fetched successfully",
+      "modelRefreshFailed": "Failed to fetch models",
+      "modelRefreshEmpty": "No models found",
+      "modelSelected": "Selected Models",
+      "modelNoSelected": "No models selected",
+      "modelClearAll": "Clear All",
+      "typeOpenAIChat": "OpenAI Chat",
+      "typeOpenAIResponse": "OpenAI Response",
+      "typeOpenAIEmbedding": "OpenAI Embedding",
+      "typeAnthropic": "Anthropic",
+      "typeGemini": "Gemini",
+      "typeVolcengine": "Volcengine",
+      "autoSync": "Auto Sync",
+      "autoGroup": "Auto Group",
+      "autoGroupNone": "None",
+      "autoGroupFuzzy": "Fuzzy",
+      "autoGroupExact": "Exact",
+      "autoGroupRegex": "Regex",
+      "matchRegex": "Match Regex",
+      "matchRegexPlaceholder": "Optional: regex pattern to match request model names",
+      "remark": "Remark",
+      "typeKimiCoding": "Kimi Coding"
+    }
+  }
 }

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -476,6 +476,7 @@
             "paramOverridePlaceholder": "可选：JSON 字符串，用于覆盖请求参数",
             "model": "模型",
             "enabled": "启用",
+            "enableCircuitBreaker": "启用熔断器",
             "proxy": "使用代理",
             "modelCustomPlaceholder": "自定义模型名称",
             "modelAdd": "添加",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -1,507 +1,511 @@
 {
-    "login": {
-        "username": "用户名",
-        "usernamePlaceholder": "请输入用户名",
-        "password": "密码",
-        "passwordPlaceholder": "请输入密码",
-        "apikey": "API 密钥",
-        "apikeyPlaceholder": "请输入 API 密钥 (sk-octopus-...)",
-        "mode": {
-            "user": "账户登录",
-            "apikey": "密钥登录"
-        },
-        "error": {
-            "generic": "登录失败,请检查登录凭据"
-        },
-        "button": {
-            "loading": "登录中...",
-            "submit": "登录"
-        }
+  "login": {
+    "username": "用户名",
+    "usernamePlaceholder": "请输入用户名",
+    "password": "密码",
+    "passwordPlaceholder": "请输入密码",
+    "apikey": "API 密钥",
+    "apikeyPlaceholder": "请输入 API 密钥 (sk-octopus-...)",
+    "mode": {
+      "user": "账户登录",
+      "apikey": "密钥登录"
     },
-    "apiKeyDashboard": {
-        "error": "加载数据失败",
-        "logout": "退出",
-        "requestStats": "请求统计",
-        "totalStats": "全部统计",
-        "inputStats": "输入统计",
-        "outputStats": "输出统计",
-        "requestCount": "请求次数",
-        "timeConsumed": "消耗时间",
-        "totalToken": "消耗 Token",
-        "totalCost": "消耗费用",
-        "inputTokens": "输入 Tokens",
-        "inputCost": "输入费用",
-        "outputTokens": "输出 Tokens",
-        "outputCost": "输出费用",
-        "successRequests": "成功请求",
-        "failedRequests": "失败请求",
-        "quota": "剩余额度",
+    "error": {
+      "generic": "登录失败,请检查登录凭据"
+    },
+    "button": {
+      "loading": "登录中...",
+      "submit": "登录"
+    }
+  },
+  "apiKeyDashboard": {
+    "error": "加载数据失败",
+    "logout": "退出",
+    "requestStats": "请求统计",
+    "totalStats": "全部统计",
+    "inputStats": "输入统计",
+    "outputStats": "输出统计",
+    "requestCount": "请求次数",
+    "timeConsumed": "消耗时间",
+    "totalToken": "消耗 Token",
+    "totalCost": "消耗费用",
+    "inputTokens": "输入 Tokens",
+    "inputCost": "输入费用",
+    "outputTokens": "输出 Tokens",
+    "outputCost": "输出费用",
+    "successRequests": "成功请求",
+    "failedRequests": "失败请求",
+    "quota": "剩余额度",
+    "unlimited": "无限制",
+    "expireAt": "过期时间",
+    "neverExpire": "永不过期",
+    "daysLeft": "天后到期",
+    "expired": "已过期",
+    "supportedModels": "支持的模型"
+  },
+  "navbar": {
+    "home": "主页",
+    "channel": "渠道",
+    "group": "分组",
+    "key": "密钥",
+    "model": "价格",
+    "log": "日志",
+    "setting": "设置"
+  },
+  "common": {
+    "copy": {
+      "success": "复制成功",
+      "failed": "复制失败",
+      "noContent": "无可复制内容"
+    }
+  },
+  "home": {
+    "activity": {
+      "requestCount": "请求次数",
+      "waitTime": "等待时间",
+      "totalToken": "消耗 Token",
+      "totalCost": "消耗费用",
+      "noData": "无数据"
+    },
+    "total": {
+      "requestStats": "请求统计",
+      "totalStats": "全部统计",
+      "inputStats": "输入统计",
+      "outputStats": "输出统计",
+      "requestCount": "请求次数",
+      "timeConsumed": "消耗时间",
+      "totalToken": "消耗 Token",
+      "totalCost": "消耗费用",
+      "inputTokens": "输入 Tokens",
+      "inputCost": "输入费用",
+      "outputTokens": "输出 Tokens",
+      "outputCost": "输出费用"
+    },
+    "chart": {
+      "totalRequests": "请求次数",
+      "totalCost": "消费金额",
+      "timePeriod": "时间范围",
+      "period": {
+        "today": "今天",
+        "last7Days": "7天",
+        "last30Days": "30天"
+      }
+    },
+    "rank": {
+      "title": "排行榜",
+      "sortByCost": "金额",
+      "sortByCount": "次数",
+      "noData": "暂无排行数据",
+      "successRate": "成功率"
+    }
+  },
+  "setting": {
+    "appearance": "外观",
+    "system": "系统",
+    "theme": {
+      "label": "主题",
+      "light": "浅色",
+      "dark": "深色",
+      "system": "跟随系统"
+    },
+    "language": {
+      "label": "语言",
+      "zh_hans": "简体中文",
+      "zh_hant": "繁体中文",
+      "en": "English"
+    },
+    "proxyUrl": {
+      "label": "代理地址",
+      "placeholder": "请输入代理地址"
+    },
+    "statsSaveInterval": {
+      "label": "统计保存周期（分钟）",
+      "placeholder": "请输入周期（分钟）"
+    },
+    "corsAllowOrigins": {
+      "label": "CORS 跨域白名单",
+      "hint": "为空禁止跨域，* 允许所有",
+      "example": "只允许指定域名: https://example.com,https://example2.com"
+    },
+    "circuitBreaker": {
+      "title": "熔断器配置",
+      "threshold": {
+        "label": "熔断触发阈值（连续失败次数）",
+        "placeholder": "请输入阈值"
+      },
+      "cooldown": {
+        "label": "基础冷却时间（秒）",
+        "placeholder": "请输入冷却时间"
+      },
+      "maxCooldown": {
+        "label": "最大冷却时间（秒）",
+        "placeholder": "请输入最大冷却时间"
+      },
+      "hint": "当渠道连续失败达到阈值后触发熔断，冷却时间按指数退避增长，上限为最大冷却时间"
+    },
+    "saved": "已保存",
+    "backup": {
+      "title": "备份 / 恢复",
+      "export": {
+        "title": "导出",
+        "includeLogs": "包含日志",
+        "includeStats": "包含统计",
+        "button": "下载 JSON",
+        "exporting": "导出中...",
+        "success": "开始导出"
+      },
+      "import": {
+        "title": "导入（增量）",
+        "selected": "已选择文件",
+        "button": "导入 JSON",
+        "importing": "导入中...",
+        "noFile": "请先选择 JSON 文件",
+        "success": "导入成功",
+        "failed": "导入失败",
+        "result": "导入结果"
+      }
+    },
+    "apiKey": {
+      "title": "API 密钥",
+      "empty": "暂无 API 密钥",
+      "add": "添加密钥",
+      "loadFailed": "加载失败",
+      "form": {
+        "name": "名称",
+        "maxCost": "最大金额",
+        "maxCostPlaceholder": "请输入金额",
         "unlimited": "无限制",
-        "expireAt": "过期时间",
+        "expireAt": "过期日期",
+        "selectDate": "选择日期",
         "neverExpire": "永不过期",
-        "daysLeft": "天后到期",
-        "expired": "已过期",
-        "supportedModels": "支持的模型"
+        "supportedModels": "支持的模型",
+        "noModels": "暂无可选模型",
+        "modelsHint": "不选择则为无限制",
+        "enabled": "是否启用",
+        "cancel": "取消",
+        "create": "创建",
+        "save": "保存",
+        "confirm": "确认"
+      },
+      "stats": {
+        "noData": "暂无统计数据",
+        "inputToken": "输入 Token",
+        "outputToken": "输出 Token",
+        "inputCost": "输入费用",
+        "outputCost": "输出费用",
+        "requestSuccess": "成功请求",
+        "requestFailed": "失败请求"
+      },
+      "toast": {
+        "createSuccess": "API 密钥创建成功",
+        "createError": "API 密钥创建失败",
+        "updateSuccess": "API 密钥更新成功",
+        "updateError": "API 密钥更新失败",
+        "deleteSuccess": "API 密钥删除成功",
+        "deleteError": "API 密钥删除失败"
+      }
     },
-    "navbar": {
-        "home": "主页",
-        "channel": "渠道",
-        "group": "分组",
-        "key": "密钥",
-        "model": "价格",
-        "log": "日志",
-        "setting": "设置"
+    "llmPrice": {
+      "title": "模型价格",
+      "updateInterval": {
+        "label": "自动更新间隔（小时）",
+        "placeholder": "请输入间隔（小时）"
+      },
+      "manualUpdate": {
+        "label": "手动更新价格",
+        "button": "立即更新",
+        "updating": "更新中..."
+      },
+      "lastUpdate": "上次更新",
+      "neverUpdated": "从未更新",
+      "updateSuccess": "价格更新成功",
+      "updateFailed": "价格更新失败"
     },
-    "common": {
-        "copy": {
-            "success": "复制成功",
-            "failed": "复制失败",
-            "noContent": "无可复制内容"
-        }
+    "llmSync": {
+      "title": "渠道同步",
+      "syncInterval": {
+        "label": "自动同步间隔（小时）",
+        "placeholder": "请输入间隔（小时）"
+      },
+      "manualSync": {
+        "label": "手动同步渠道",
+        "button": "立即同步",
+        "syncing": "同步中..."
+      },
+      "lastSync": "上次同步",
+      "neverSynced": "从未同步",
+      "syncSuccess": "渠道同步成功",
+      "syncFailed": "渠道同步失败"
     },
-    "home": {
-        "activity": {
-            "requestCount": "请求次数",
-            "waitTime": "等待时间",
-            "totalToken": "消耗 Token",
-            "totalCost": "消耗费用",
-            "noData": "无数据"
-        },
-        "total": {
-            "requestStats": "请求统计",
-            "totalStats": "全部统计",
-            "inputStats": "输入统计",
-            "outputStats": "输出统计",
-            "requestCount": "请求次数",
-            "timeConsumed": "消耗时间",
-            "totalToken": "消耗 Token",
-            "totalCost": "消耗费用",
-            "inputTokens": "输入 Tokens",
-            "inputCost": "输入费用",
-            "outputTokens": "输出 Tokens",
-            "outputCost": "输出费用"
-        },
-        "chart": {
-            "totalRequests": "请求次数",
-            "totalCost": "消费金额",
-            "timePeriod": "时间范围",
-            "period": {
-                "today": "今天",
-                "last7Days": "7天",
-                "last30Days": "30天"
-            }
-        },
-        "rank": {
-            "title": "排行榜",
-            "sortByCost": "金额",
-            "sortByCount": "次数",
-            "noData": "暂无排行数据",
-            "successRate": "成功率"
-        }
+    "account": {
+      "title": "账户设置",
+      "save": "保存",
+      "saving": "保存中...",
+      "username": {
+        "label": "修改用户名",
+        "placeholder": "请输入新用户名",
+        "empty": "用户名不能为空",
+        "success": "用户名修改成功",
+        "failed": "用户名修改失败"
+      },
+      "password": {
+        "label": "修改密码",
+        "oldPlaceholder": "请输入当前密码",
+        "newPlaceholder": "请输入新密码",
+        "confirmPlaceholder": "请确认新密码",
+        "oldEmpty": "请输入当前密码",
+        "newEmpty": "请输入新密码",
+        "mismatch": "两次输入的密码不一致",
+        "tooShort": "密码长度至少为6位",
+        "change": "修改密码",
+        "success": "密码修改成功",
+        "failed": "密码修改失败"
+      }
     },
-    "setting": {
-        "appearance": "外观",
-        "system": "系统",
-        "theme": {
-            "label": "主题",
-            "light": "浅色",
-            "dark": "深色",
-            "system": "跟随系统"
-        },
-        "language": {
-            "label": "语言",
-            "zh_hans": "简体中文",
-            "zh_hant": "繁体中文",
-            "en": "English"
-        },
-        "proxyUrl": {
-            "label": "代理地址",
-            "placeholder": "请输入代理地址"
-        },
-        "statsSaveInterval": {
-            "label": "统计保存周期（分钟）",
-            "placeholder": "请输入周期（分钟）"
-        },
-        "corsAllowOrigins": {
-            "label": "CORS 跨域白名单",
-            "hint": "为空禁止跨域，* 允许所有",
-            "example": "只允许指定域名: https://example.com,https://example2.com"
-        },
-        "circuitBreaker": {
-            "title": "熔断器配置",
-            "threshold": {
-                "label": "熔断触发阈值（连续失败次数）",
-                "placeholder": "请输入阈值"
-            },
-            "cooldown": {
-                "label": "基础冷却时间（秒）",
-                "placeholder": "请输入冷却时间"
-            },
-            "maxCooldown": {
-                "label": "最大冷却时间（秒）",
-                "placeholder": "请输入最大冷却时间"
-            },
-            "hint": "当渠道连续失败达到阈值后触发熔断，冷却时间按指数退避增长，上限为最大冷却时间"
-        },
-        "saved": "已保存",
-        "backup": {
-            "title": "备份 / 恢复",
-            "export": {
-                "title": "导出",
-                "includeLogs": "包含日志",
-                "includeStats": "包含统计",
-                "button": "下载 JSON",
-                "exporting": "导出中...",
-                "success": "开始导出"
-            },
-            "import": {
-                "title": "导入（增量）",
-                "selected": "已选择文件",
-                "button": "导入 JSON",
-                "importing": "导入中...",
-                "noFile": "请先选择 JSON 文件",
-                "success": "导入成功",
-                "failed": "导入失败",
-                "result": "导入结果"
-            }
-        },
-        "apiKey": {
-            "title": "API 密钥",
-            "empty": "暂无 API 密钥",
-            "add": "添加密钥",
-            "loadFailed": "加载失败",
-            "form": {
-                "name": "名称",
-                "maxCost": "最大金额",
-                "maxCostPlaceholder": "请输入金额",
-                "unlimited": "无限制",
-                "expireAt": "过期日期",
-                "selectDate": "选择日期",
-                "neverExpire": "永不过期",
-                "supportedModels": "支持的模型",
-                "noModels": "暂无可选模型",
-                "modelsHint": "不选择则为无限制",
-                "enabled": "是否启用",
-                "cancel": "取消",
-                "create": "创建",
-                "save": "保存",
-                "confirm": "确认"
-            },
-            "stats": {
-                "noData": "暂无统计数据",
-                "inputToken": "输入 Token",
-                "outputToken": "输出 Token",
-                "inputCost": "输入费用",
-                "outputCost": "输出费用",
-                "requestSuccess": "成功请求",
-                "requestFailed": "失败请求"
-            },
-            "toast": {
-                "createSuccess": "API 密钥创建成功",
-                "createError": "API 密钥创建失败",
-                "updateSuccess": "API 密钥更新成功",
-                "updateError": "API 密钥更新失败",
-                "deleteSuccess": "API 密钥删除成功",
-                "deleteError": "API 密钥删除失败"
-            }
-        },
-        "llmPrice": {
-            "title": "模型价格",
-            "updateInterval": {
-                "label": "自动更新间隔（小时）",
-                "placeholder": "请输入间隔（小时）"
-            },
-            "manualUpdate": {
-                "label": "手动更新价格",
-                "button": "立即更新",
-                "updating": "更新中..."
-            },
-            "lastUpdate": "上次更新",
-            "neverUpdated": "从未更新",
-            "updateSuccess": "价格更新成功",
-            "updateFailed": "价格更新失败"
-        },
-        "llmSync": {
-            "title": "渠道同步",
-            "syncInterval": {
-                "label": "自动同步间隔（小时）",
-                "placeholder": "请输入间隔（小时）"
-            },
-            "manualSync": {
-                "label": "手动同步渠道",
-                "button": "立即同步",
-                "syncing": "同步中..."
-            },
-            "lastSync": "上次同步",
-            "neverSynced": "从未同步",
-            "syncSuccess": "渠道同步成功",
-            "syncFailed": "渠道同步失败"
-        },
-        "account": {
-            "title": "账户设置",
-            "save": "保存",
-            "saving": "保存中...",
-            "username": {
-                "label": "修改用户名",
-                "placeholder": "请输入新用户名",
-                "empty": "用户名不能为空",
-                "success": "用户名修改成功",
-                "failed": "用户名修改失败"
-            },
-            "password": {
-                "label": "修改密码",
-                "oldPlaceholder": "请输入当前密码",
-                "newPlaceholder": "请输入新密码",
-                "confirmPlaceholder": "请确认新密码",
-                "oldEmpty": "请输入当前密码",
-                "newEmpty": "请输入新密码",
-                "mismatch": "两次输入的密码不一致",
-                "tooShort": "密码长度至少为6位",
-                "change": "修改密码",
-                "success": "密码修改成功",
-                "failed": "密码修改失败"
-            }
-        },
-        "info": {
-            "title": "版本信息",
-            "currentVersion": "当前版本",
-            "latestVersion": "最新版本",
-            "buildTime": "构建时间",
-            "publishedAt": "发布时间",
-            "github": "GitHub 仓库",
-            "unknown": "未知",
-            "versionMismatch": "版本不匹配",
-            "versionMismatchHint": "前端版本 ({frontend}) 与后端版本 ({backend}) 不一致，可能是浏览器缓存问题，请强制刷新页面。",
-            "forceRefresh": "强制刷新",
-            "newVersionAvailable": "发现新版本可用",
-            "newVersionAvailableHint": "请先备份数据，然后更新系统",
-            "updateNow": "立即更新",
-            "updating": "更新中...",
-            "updateSuccess": "更新成功，服务即将重启",
-            "updateFailed": "更新失败"
-        },
-        "log": {
-            "title": "日志设置",
-            "enabled": {
-                "label": "启用历史日志"
-            },
-            "keepPeriod": {
-                "label": "日志保存天数",
-                "placeholder": "请输入天数"
-            },
-            "clear": {
-                "label": "清空历史日志",
-                "button": "清空",
-                "clearing": "清空中..."
-            },
-            "clearSuccess": "日志已清空",
-            "clearFailed": "清空失败"
-        }
-    },
-    "group": {
-        "toast": {
-            "created": "创建成功",
-            "createFailed": "创建失败",
-            "updated": "更新成功",
-            "updateFailed": "更新失败",
-            "deleted": "删除成功",
-            "autoAddFailed": "自动添加失败"
-        },
-        "create": {
-            "title": "创建分组",
-            "submit": "创建",
-            "submitting": "创建中..."
-        },
-        "card": {
-            "empty": "暂无规则"
-        },
-        "detail": {
-            "actions": {
-                "edit": "编辑",
-                "cancel": "取消",
-                "save": "保存",
-                "copyName": "复制名称",
-                "delete": "删除",
-                "confirmDelete": "确认删除"
-            }
-        },
-        "form": {
-            "name": "分组名称",
-            "matchRegex": "匹配正则",
-            "matchRegexPlaceholder": "留空则默认按分组名称模糊匹配",
-            "matchRegexInvalid": "正则无效",
-            "firstTokenTimeOut": "首字超时",
-            "firstTokenTimeOutHint": "单位秒，仅流式响应起效，0 表示不限制",
-            "sessionKeepTime": "会话保持",
-            "sessionKeepTimeHint": "单位秒，会话期间保持使用同一渠道，0 表示禁用",
-            "items": "已选模型",
-            "addItem": "添加模型",
-            "autoAdd": "自动添加",
-            "clear": "清空",
-            "selectChannel": "渠道",
-            "selectModel": "模型"
-        },
-        "mode": {
-            "roundRobin": "轮询",
-            "random": "随机",
-            "failover": "故障转移",
-            "weighted": "加权分配"
-        },
-        "empty": "暂无分组，点击左上角按钮创建"
-    },
-    "model": {
-        "create": {
-            "title": "创建模型",
-            "name": "模型名称",
-            "input": "输入价格",
-            "output": "输出价格",
-            "cacheRead": "缓存读取",
-            "cacheWrite": "缓存写入",
-            "submit": "创建",
-            "submitting": "创建中..."
-        },
-        "toast": {
-            "updated": "模型价格已更新",
-            "updateFailed": "更新失败",
-            "deleted": "模型已删除",
-            "deleteFailed": "删除失败"
-        },
-        "card": {
-            "inputCache": "输入/缓存",
-            "outputCache": "输出/缓存",
-            "edit": "编辑",
-            "delete": "删除"
-        },
-        "overlay": {
-            "cancel": "取消",
-            "deleting": "删除中...",
-            "confirmDelete": "确认删除",
-            "input": "输入",
-            "output": "输出",
-            "cacheRead": "缓存读取",
-            "cacheWrite": "缓存写入",
-            "save": "保存"
-        }
+    "info": {
+      "title": "版本信息",
+      "currentVersion": "当前版本",
+      "latestVersion": "最新版本",
+      "buildTime": "构建时间",
+      "publishedAt": "发布时间",
+      "github": "GitHub 仓库",
+      "unknown": "未知",
+      "versionMismatch": "版本不匹配",
+      "versionMismatchHint": "前端版本 ({frontend}) 与后端版本 ({backend}) 不一致，可能是浏览器缓存问题，请强制刷新页面。",
+      "forceRefresh": "强制刷新",
+      "newVersionAvailable": "发现新版本可用",
+      "newVersionAvailableHint": "请先备份数据，然后更新系统",
+      "updateNow": "立即更新",
+      "updating": "更新中...",
+      "updateSuccess": "更新成功，服务即将重启",
+      "updateFailed": "更新失败"
     },
     "log": {
-        "list": {
-            "noMore": "没有更多日志了"
-        },
-        "card": {
-            "error": "错误",
-            "errorInfo": "错误信息",
-            "firstToken": "首字",
-            "totalTime": "总耗时",
-            "input": "输入",
-            "output": "输出",
-            "cost": "费用",
-            "requestContent": "请求内容",
-            "responseContent": "响应内容",
-            "noRequestContent": "(无请求内容)",
-            "noResponseContent": "(无响应内容)",
-            "firstTokenTime": "首字时间",
-            "tokens": "tokens",
-            "retryDetails": "重试详情",
-            "attempts": "次尝试",
-            "success": "成功",
-            "failed": "失败"
-        }
-    },
-    "channel": {
-        "card": {
-            "requestCount": "请求次数",
-            "totalCost": "总成本",
-            "toast": {
-                "enabled": "渠道已启用",
-                "disabled": "渠道已禁用"
-            }
-        },
-        "detail": {
-            "title": {
-                "edit": "编辑渠道",
-                "view": "渠道详情"
-            },
-            "sections": {
-                "requests": "请求详情",
-                "tokens": "Token 使用",
-                "costs": "成本详情",
-                "baseUrls": "Base URLs",
-                "keys": "密钥"
-            },
-            "noBaseUrls": "暂无 Base URL",
-            "noKeys": "暂无密钥",
-            "metrics": {
-                "totalRequests": "总请求",
-                "totalToken": "总 Token",
-                "totalCost": "总成本",
-                "successRequests": "成功请求",
-                "failedRequests": "失败请求",
-                "inputToken": "输入 Token",
-                "outputToken": "输出 Token",
-                "inputCost": "输入成本",
-                "outputCost": "输出成本",
-                "avgWaitTime": "等待时间"
-            },
-            "actions": {
-                "edit": "编辑",
-                "cancel": "取消",
-                "save": "保存",
-                "saving": "保存中...",
-                "delete": "删除",
-                "confirmDelete": "确认删除",
-                "deleting": "删除中..."
-            }
-        },
-        "create": {
-            "dialogTitle": "创建新渠道",
-            "submit": "创建渠道",
-            "submitting": "创建中..."
-        },
-        "form": {
-            "add": "添加",
-            "name": "渠道名称",
-            "type": "渠道类型",
-            "baseUrls": "Base URLs",
-            "baseUrlUrl": "地址",
-            "baseUrlDelay": "延迟(ms)",
-            "advanced": "高级设置",
-            "apiKey": "API Key",
-            "customHeader": "自定义 Header",
-            "customHeaderKey": "Header Key",
-            "customHeaderValue": "Header Value",
-            "customHeaderAdd": "添加 Header",
-            "channelProxy": "渠道代理",
-            "channelProxyPlaceholder": "可选：仅对该渠道生效（覆盖全局代理）",
-            "paramOverride": "参数覆盖",
-            "paramOverridePlaceholder": "可选：JSON 字符串，用于覆盖请求参数",
-            "model": "模型",
-            "enabled": "启用",
-            "enableCircuitBreaker": "启用熔断器",
-            "proxy": "使用代理",
-            "modelCustomPlaceholder": "自定义模型名称",
-            "modelAdd": "添加",
-            "modelRefresh": "刷新",
-            "modelRefreshSuccess": "模型列表获取成功",
-            "modelRefreshFailed": "模型列表获取失败",
-            "modelRefreshEmpty": "未获取到模型列表",
-            "modelSelected": "已选模型",
-            "modelNoSelected": "暂未选择模型",
-            "modelClearAll": "清除全部",
-            "typeOpenAIChat": "OpenAI Chat",
-            "typeOpenAIResponse": "OpenAI Response",
-            "typeOpenAIEmbedding": "OpenAI Embedding",
-            "typeAnthropic": "Anthropic",
-            "typeGemini": "Gemini",
-            "typeVolcengine": "火山引擎",
-            "autoSync": "自动同步",
-            "autoGroup": "自动分组",
-            "autoGroupNone": "不自动分组",
-            "autoGroupFuzzy": "模糊匹配",
-            "autoGroupExact": "准确匹配",
-            "autoGroupRegex": "正则匹配",
-            "matchRegex": "匹配正则",
-            "matchRegexPlaceholder": "可选：用于匹配请求模型名称的正则表达式",
-            "remark": "备注"
-        }
+      "title": "日志设置",
+      "enabled": {
+        "label": "启用历史日志"
+      },
+      "keepPeriod": {
+        "label": "日志保存天数",
+        "placeholder": "请输入天数"
+      },
+      "redundantFields": {
+        "label": "记录并读取日志冗余字段 (_octopus_*)"
+      },
+      "clear": {
+        "label": "清空历史日志",
+        "button": "清空",
+        "clearing": "清空中..."
+      },
+      "clearSuccess": "日志已清空",
+      "clearFailed": "清空失败"
     }
+  },
+  "group": {
+    "toast": {
+      "created": "创建成功",
+      "createFailed": "创建失败",
+      "updated": "更新成功",
+      "updateFailed": "更新失败",
+      "deleted": "删除成功",
+      "autoAddFailed": "自动添加失败"
+    },
+    "create": {
+      "title": "创建分组",
+      "submit": "创建",
+      "submitting": "创建中..."
+    },
+    "card": {
+      "empty": "暂无规则"
+    },
+    "detail": {
+      "actions": {
+        "edit": "编辑",
+        "cancel": "取消",
+        "save": "保存",
+        "copyName": "复制名称",
+        "delete": "删除",
+        "confirmDelete": "确认删除"
+      }
+    },
+    "form": {
+      "name": "分组名称",
+      "matchRegex": "匹配正则",
+      "matchRegexPlaceholder": "留空则默认按分组名称模糊匹配",
+      "matchRegexInvalid": "正则无效",
+      "firstTokenTimeOut": "首字超时",
+      "firstTokenTimeOutHint": "单位秒，仅流式响应起效，0 表示不限制",
+      "sessionKeepTime": "会话保持",
+      "sessionKeepTimeHint": "单位秒，会话期间保持使用同一渠道，0 表示禁用",
+      "items": "已选模型",
+      "addItem": "添加模型",
+      "autoAdd": "自动添加",
+      "clear": "清空",
+      "selectChannel": "渠道",
+      "selectModel": "模型"
+    },
+    "mode": {
+      "roundRobin": "轮询",
+      "random": "随机",
+      "failover": "故障转移",
+      "weighted": "加权分配"
+    },
+    "empty": "暂无分组，点击左上角按钮创建"
+  },
+  "model": {
+    "create": {
+      "title": "创建模型",
+      "name": "模型名称",
+      "input": "输入价格",
+      "output": "输出价格",
+      "cacheRead": "缓存读取",
+      "cacheWrite": "缓存写入",
+      "submit": "创建",
+      "submitting": "创建中..."
+    },
+    "toast": {
+      "updated": "模型价格已更新",
+      "updateFailed": "更新失败",
+      "deleted": "模型已删除",
+      "deleteFailed": "删除失败"
+    },
+    "card": {
+      "inputCache": "输入/缓存",
+      "outputCache": "输出/缓存",
+      "edit": "编辑",
+      "delete": "删除"
+    },
+    "overlay": {
+      "cancel": "取消",
+      "deleting": "删除中...",
+      "confirmDelete": "确认删除",
+      "input": "输入",
+      "output": "输出",
+      "cacheRead": "缓存读取",
+      "cacheWrite": "缓存写入",
+      "save": "保存"
+    }
+  },
+  "log": {
+    "list": {
+      "noMore": "没有更多日志了"
+    },
+    "card": {
+      "error": "错误",
+      "errorInfo": "错误信息",
+      "firstToken": "首字",
+      "totalTime": "总耗时",
+      "input": "输入",
+      "output": "输出",
+      "cost": "费用",
+      "requestContent": "请求内容",
+      "responseContent": "响应内容",
+      "noRequestContent": "(无请求内容)",
+      "noResponseContent": "(无响应内容)",
+      "firstTokenTime": "首字时间",
+      "tokens": "tokens",
+      "retryDetails": "重试详情",
+      "attempts": "次尝试",
+      "success": "成功",
+      "failed": "失败"
+    }
+  },
+  "channel": {
+    "card": {
+      "requestCount": "请求次数",
+      "totalCost": "总成本",
+      "toast": {
+        "enabled": "渠道已启用",
+        "disabled": "渠道已禁用"
+      }
+    },
+    "detail": {
+      "title": {
+        "edit": "编辑渠道",
+        "view": "渠道详情"
+      },
+      "sections": {
+        "requests": "请求详情",
+        "tokens": "Token 使用",
+        "costs": "成本详情",
+        "baseUrls": "Base URLs",
+        "keys": "密钥"
+      },
+      "noBaseUrls": "暂无 Base URL",
+      "noKeys": "暂无密钥",
+      "metrics": {
+        "totalRequests": "总请求",
+        "totalToken": "总 Token",
+        "totalCost": "总成本",
+        "successRequests": "成功请求",
+        "failedRequests": "失败请求",
+        "inputToken": "输入 Token",
+        "outputToken": "输出 Token",
+        "inputCost": "输入成本",
+        "outputCost": "输出成本",
+        "avgWaitTime": "等待时间"
+      },
+      "actions": {
+        "edit": "编辑",
+        "cancel": "取消",
+        "save": "保存",
+        "saving": "保存中...",
+        "delete": "删除",
+        "confirmDelete": "确认删除",
+        "deleting": "删除中..."
+      }
+    },
+    "create": {
+      "dialogTitle": "创建新渠道",
+      "submit": "创建渠道",
+      "submitting": "创建中..."
+    },
+    "form": {
+      "add": "添加",
+      "name": "渠道名称",
+      "type": "渠道类型",
+      "baseUrls": "Base URLs",
+      "baseUrlUrl": "地址",
+      "baseUrlDelay": "延迟(ms)",
+      "advanced": "高级设置",
+      "apiKey": "API Key",
+      "customHeader": "自定义 Header",
+      "customHeaderKey": "Header Key",
+      "customHeaderValue": "Header Value",
+      "customHeaderAdd": "添加 Header",
+      "channelProxy": "渠道代理",
+      "channelProxyPlaceholder": "可选：仅对该渠道生效（覆盖全局代理）",
+      "paramOverride": "参数覆盖",
+      "paramOverridePlaceholder": "可选：JSON 字符串，用于覆盖请求参数",
+      "model": "模型",
+      "enabled": "启用",
+      "enableCircuitBreaker": "启用熔断器",
+      "proxy": "使用代理",
+      "modelCustomPlaceholder": "自定义模型名称",
+      "modelAdd": "添加",
+      "modelRefresh": "刷新",
+      "modelRefreshSuccess": "模型列表获取成功",
+      "modelRefreshFailed": "模型列表获取失败",
+      "modelRefreshEmpty": "未获取到模型列表",
+      "modelSelected": "已选模型",
+      "modelNoSelected": "暂未选择模型",
+      "modelClearAll": "清除全部",
+      "typeOpenAIChat": "OpenAI Chat",
+      "typeOpenAIResponse": "OpenAI Response",
+      "typeOpenAIEmbedding": "OpenAI Embedding",
+      "typeAnthropic": "Anthropic",
+      "typeGemini": "Gemini",
+      "typeVolcengine": "火山引擎",
+      "autoSync": "自动同步",
+      "autoGroup": "自动分组",
+      "autoGroupNone": "不自动分组",
+      "autoGroupFuzzy": "模糊匹配",
+      "autoGroupExact": "准确匹配",
+      "autoGroupRegex": "正则匹配",
+      "matchRegex": "匹配正则",
+      "matchRegexPlaceholder": "可选：用于匹配请求模型名称的正则表达式",
+      "remark": "备注",
+      "typeKimiCoding": "Kimi Coding"
+    }
+  }
 }

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -476,6 +476,7 @@
             "paramOverridePlaceholder": "可選：JSON 字串，用於覆蓋請求參數",
             "model": "模型",
             "enabled": "啟用",
+            "enableCircuitBreaker": "啟用熔斷器",
             "proxy": "使用代理",
             "modelCustomPlaceholder": "自定義模型名稱",
             "modelAdd": "新增",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -1,507 +1,511 @@
 {
-    "login": {
-        "username": "使用者名稱",
-        "usernamePlaceholder": "請輸入使用者名稱",
-        "password": "密碼",
-        "passwordPlaceholder": "請輸入密碼",
-        "apikey": "API 金鑰",
-        "apikeyPlaceholder": "請輸入 API 金鑰 (sk-octopus-...)",
-        "mode": {
-            "user": "帳戶登入",
-            "apikey": "金鑰登入"
-        },
-        "error": {
-            "generic": "登入失敗，請檢查登入憑證"
-        },
-        "button": {
-            "loading": "登入中...",
-            "submit": "登入"
-        }
+  "login": {
+    "username": "使用者名稱",
+    "usernamePlaceholder": "請輸入使用者名稱",
+    "password": "密碼",
+    "passwordPlaceholder": "請輸入密碼",
+    "apikey": "API 金鑰",
+    "apikeyPlaceholder": "請輸入 API 金鑰 (sk-octopus-...)",
+    "mode": {
+      "user": "帳戶登入",
+      "apikey": "金鑰登入"
     },
-    "apiKeyDashboard": {
-        "error": "載入資料失敗",
-        "logout": "登出",
-        "requestStats": "請求統計",
-        "totalStats": "全部統計",
-        "inputStats": "輸入統計",
-        "outputStats": "輸出統計",
-        "requestCount": "請求次數",
-        "timeConsumed": "消耗時間",
-        "totalToken": "消耗 Token",
-        "totalCost": "消耗費用",
-        "inputTokens": "輸入 Tokens",
-        "inputCost": "輸入費用",
-        "outputTokens": "輸出 Tokens",
-        "outputCost": "輸出費用",
-        "successRequests": "成功請求",
-        "failedRequests": "失敗請求",
-        "quota": "剩餘額度",
+    "error": {
+      "generic": "登入失敗，請檢查登入憑證"
+    },
+    "button": {
+      "loading": "登入中...",
+      "submit": "登入"
+    }
+  },
+  "apiKeyDashboard": {
+    "error": "載入資料失敗",
+    "logout": "登出",
+    "requestStats": "請求統計",
+    "totalStats": "全部統計",
+    "inputStats": "輸入統計",
+    "outputStats": "輸出統計",
+    "requestCount": "請求次數",
+    "timeConsumed": "消耗時間",
+    "totalToken": "消耗 Token",
+    "totalCost": "消耗費用",
+    "inputTokens": "輸入 Tokens",
+    "inputCost": "輸入費用",
+    "outputTokens": "輸出 Tokens",
+    "outputCost": "輸出費用",
+    "successRequests": "成功請求",
+    "failedRequests": "失敗請求",
+    "quota": "剩餘額度",
+    "unlimited": "無限制",
+    "expireAt": "過期時間",
+    "neverExpire": "永不過期",
+    "daysLeft": "天後到期",
+    "expired": "已過期",
+    "supportedModels": "支援的模型"
+  },
+  "navbar": {
+    "home": "主頁",
+    "channel": "供應源",
+    "group": "分組",
+    "key": "金鑰",
+    "model": "價格",
+    "log": "日誌",
+    "setting": "設定"
+  },
+  "common": {
+    "copy": {
+      "success": "複製成功",
+      "failed": "複製失敗",
+      "noContent": "無可複製內容"
+    }
+  },
+  "home": {
+    "activity": {
+      "requestCount": "請求次數",
+      "waitTime": "等待時間",
+      "totalToken": "消耗 Token",
+      "totalCost": "消耗費用",
+      "noData": "無數據"
+    },
+    "total": {
+      "requestStats": "請求統計",
+      "totalStats": "全部統計",
+      "inputStats": "輸入統計",
+      "outputStats": "輸出統計",
+      "requestCount": "請求次數",
+      "timeConsumed": "消耗時間",
+      "totalToken": "消耗 Token",
+      "totalCost": "消耗費用",
+      "inputTokens": "輸入 Tokens",
+      "inputCost": "輸入費用",
+      "outputTokens": "輸出 Tokens",
+      "outputCost": "輸出費用"
+    },
+    "chart": {
+      "totalRequests": "請求次數",
+      "totalCost": "消費金額",
+      "timePeriod": "時間範圍",
+      "period": {
+        "today": "今天",
+        "last7Days": "7天",
+        "last30Days": "30天"
+      }
+    },
+    "rank": {
+      "title": "排行榜",
+      "sortByCost": "金額",
+      "sortByCount": "次數",
+      "noData": "暫無排行數據",
+      "successRate": "成功率"
+    }
+  },
+  "setting": {
+    "appearance": "外觀",
+    "system": "系統",
+    "theme": {
+      "label": "主題",
+      "light": "淺色",
+      "dark": "深色",
+      "system": "跟隨系統"
+    },
+    "language": {
+      "label": "語言",
+      "zh_hans": "簡體中文",
+      "zh_hant": "繁體中文",
+      "en": "English"
+    },
+    "proxyUrl": {
+      "label": "代理位址",
+      "placeholder": "請輸入代理位址"
+    },
+    "statsSaveInterval": {
+      "label": "統計保存週期（分鐘）",
+      "placeholder": "請輸入週期（分鐘）"
+    },
+    "corsAllowOrigins": {
+      "label": "CORS 跨網域白名單",
+      "hint": "為空禁止跨網域，* 允許所有",
+      "example": "只允許指定域名: https://example.com,https://example2.com"
+    },
+    "circuitBreaker": {
+      "title": "熔斷器配置",
+      "threshold": {
+        "label": "熔斷觸發閾值（連續失敗次數）",
+        "placeholder": "請輸入閾值"
+      },
+      "cooldown": {
+        "label": "基礎冷卻時間（秒）",
+        "placeholder": "請輸入冷卻時間"
+      },
+      "maxCooldown": {
+        "label": "最大冷卻時間（秒）",
+        "placeholder": "請輸入最大冷卻時間"
+      },
+      "hint": "當渠道連續失敗達到閾值後觸發熔斷，冷卻時間按指數退避增長，上限為最大冷卻時間"
+    },
+    "saved": "已儲存",
+    "backup": {
+      "title": "備份 / 復原",
+      "export": {
+        "title": "匯出",
+        "includeLogs": "包含日誌",
+        "includeStats": "包含統計",
+        "button": "下載 JSON",
+        "exporting": "匯出中...",
+        "success": "開始匯出"
+      },
+      "import": {
+        "title": "匯入（增量）",
+        "selected": "已選擇檔案",
+        "button": "匯入 JSON",
+        "importing": "匯入中...",
+        "noFile": "請先選擇 JSON 檔案",
+        "success": "匯入成功",
+        "failed": "匯入失敗",
+        "result": "匯入結果"
+      }
+    },
+    "apiKey": {
+      "title": "API 金鑰",
+      "empty": "暫無 API 金鑰",
+      "add": "新增金鑰",
+      "loadFailed": "載入失敗",
+      "form": {
+        "name": "名稱",
+        "maxCost": "最大金額",
+        "maxCostPlaceholder": "請輸入金額",
         "unlimited": "無限制",
-        "expireAt": "過期時間",
+        "expireAt": "過期日期",
+        "selectDate": "選擇日期",
         "neverExpire": "永不過期",
-        "daysLeft": "天後到期",
-        "expired": "已過期",
-        "supportedModels": "支援的模型"
+        "supportedModels": "支援的模型",
+        "noModels": "暫無可選模型",
+        "modelsHint": "不選擇則為無限制",
+        "enabled": "是否啟用",
+        "cancel": "取消",
+        "create": "建立",
+        "save": "儲存",
+        "confirm": "確認"
+      },
+      "stats": {
+        "noData": "暫無統計數據",
+        "inputToken": "輸入 Token",
+        "outputToken": "輸出 Token",
+        "inputCost": "輸入費用",
+        "outputCost": "輸出費用",
+        "requestSuccess": "成功請求",
+        "requestFailed": "失敗請求"
+      },
+      "toast": {
+        "createSuccess": "API 金鑰建立成功",
+        "createError": "API 金鑰建立失敗",
+        "updateSuccess": "API 金鑰更新成功",
+        "updateError": "API 金鑰更新失敗",
+        "deleteSuccess": "API 金鑰刪除成功",
+        "deleteError": "API 金鑰刪除失敗"
+      }
     },
-    "navbar": {
-        "home": "主頁",
-        "channel": "供應源",
-        "group": "分組",
-        "key": "金鑰",
-        "model": "價格",
-        "log": "日誌",
-        "setting": "設定"
+    "llmPrice": {
+      "title": "模型價格",
+      "updateInterval": {
+        "label": "自動更新間隔（小時）",
+        "placeholder": "請輸入間隔（小時）"
+      },
+      "manualUpdate": {
+        "label": "手動更新價格",
+        "button": "立即更新",
+        "updating": "更新中..."
+      },
+      "lastUpdate": "上次更新",
+      "neverUpdated": "從未更新",
+      "updateSuccess": "價格更新成功",
+      "updateFailed": "價格更新失敗"
     },
-    "common": {
-        "copy": {
-            "success": "複製成功",
-            "failed": "複製失敗",
-            "noContent": "無可複製內容"
-        }
+    "llmSync": {
+      "title": "供應源同步",
+      "syncInterval": {
+        "label": "自動同步間隔（小時）",
+        "placeholder": "請輸入間隔（小時）"
+      },
+      "manualSync": {
+        "label": "手動同步供應源",
+        "button": "立即同步",
+        "syncing": "同步中..."
+      },
+      "lastSync": "上次同步",
+      "neverSynced": "從未同步",
+      "syncSuccess": "供應源同步成功",
+      "syncFailed": "供應源同步失敗"
     },
-    "home": {
-        "activity": {
-            "requestCount": "請求次數",
-            "waitTime": "等待時間",
-            "totalToken": "消耗 Token",
-            "totalCost": "消耗費用",
-            "noData": "無數據"
-        },
-        "total": {
-            "requestStats": "請求統計",
-            "totalStats": "全部統計",
-            "inputStats": "輸入統計",
-            "outputStats": "輸出統計",
-            "requestCount": "請求次數",
-            "timeConsumed": "消耗時間",
-            "totalToken": "消耗 Token",
-            "totalCost": "消耗費用",
-            "inputTokens": "輸入 Tokens",
-            "inputCost": "輸入費用",
-            "outputTokens": "輸出 Tokens",
-            "outputCost": "輸出費用"
-        },
-        "chart": {
-            "totalRequests": "請求次數",
-            "totalCost": "消費金額",
-            "timePeriod": "時間範圍",
-            "period": {
-                "today": "今天",
-                "last7Days": "7天",
-                "last30Days": "30天"
-            }
-        },
-        "rank": {
-            "title": "排行榜",
-            "sortByCost": "金額",
-            "sortByCount": "次數",
-            "noData": "暫無排行數據",
-            "successRate": "成功率"
-        }
+    "account": {
+      "title": "帳戶設定",
+      "save": "儲存",
+      "saving": "儲存中...",
+      "username": {
+        "label": "修改使用者名稱",
+        "placeholder": "請輸入新使用者名稱",
+        "empty": "使用者名稱不能為空",
+        "success": "使用者名稱修改成功",
+        "failed": "使用者名稱修改失敗"
+      },
+      "password": {
+        "label": "修改密碼",
+        "oldPlaceholder": "請輸入當前密碼",
+        "newPlaceholder": "請輸入新密碼",
+        "confirmPlaceholder": "請確認新密碼",
+        "oldEmpty": "請輸入當前密碼",
+        "newEmpty": "請輸入新密碼",
+        "mismatch": "兩次輸入的密碼不一致",
+        "tooShort": "密碼長度至少為6位",
+        "change": "修改密碼",
+        "success": "密碼修改成功",
+        "failed": "密碼修改失敗"
+      }
     },
-    "setting": {
-        "appearance": "外觀",
-        "system": "系統",
-        "theme": {
-            "label": "主題",
-            "light": "淺色",
-            "dark": "深色",
-            "system": "跟隨系統"
-        },
-        "language": {
-            "label": "語言",
-            "zh_hans": "簡體中文",
-            "zh_hant": "繁體中文",
-            "en": "English"
-        },
-        "proxyUrl": {
-            "label": "代理位址",
-            "placeholder": "請輸入代理位址"
-        },
-        "statsSaveInterval": {
-            "label": "統計保存週期（分鐘）",
-            "placeholder": "請輸入週期（分鐘）"
-        },
-        "corsAllowOrigins": {
-            "label": "CORS 跨網域白名單",
-            "hint": "為空禁止跨網域，* 允許所有",
-            "example": "只允許指定域名: https://example.com,https://example2.com"
-        },
-        "circuitBreaker": {
-            "title": "熔斷器配置",
-            "threshold": {
-                "label": "熔斷觸發閾值（連續失敗次數）",
-                "placeholder": "請輸入閾值"
-            },
-            "cooldown": {
-                "label": "基礎冷卻時間（秒）",
-                "placeholder": "請輸入冷卻時間"
-            },
-            "maxCooldown": {
-                "label": "最大冷卻時間（秒）",
-                "placeholder": "請輸入最大冷卻時間"
-            },
-            "hint": "當渠道連續失敗達到閾值後觸發熔斷，冷卻時間按指數退避增長，上限為最大冷卻時間"
-        },
-        "saved": "已儲存",
-        "backup": {
-            "title": "備份 / 復原",
-            "export": {
-                "title": "匯出",
-                "includeLogs": "包含日誌",
-                "includeStats": "包含統計",
-                "button": "下載 JSON",
-                "exporting": "匯出中...",
-                "success": "開始匯出"
-            },
-            "import": {
-                "title": "匯入（增量）",
-                "selected": "已選擇檔案",
-                "button": "匯入 JSON",
-                "importing": "匯入中...",
-                "noFile": "請先選擇 JSON 檔案",
-                "success": "匯入成功",
-                "failed": "匯入失敗",
-                "result": "匯入結果"
-            }
-        },
-        "apiKey": {
-            "title": "API 金鑰",
-            "empty": "暫無 API 金鑰",
-            "add": "新增金鑰",
-            "loadFailed": "載入失敗",
-            "form": {
-                "name": "名稱",
-                "maxCost": "最大金額",
-                "maxCostPlaceholder": "請輸入金額",
-                "unlimited": "無限制",
-                "expireAt": "過期日期",
-                "selectDate": "選擇日期",
-                "neverExpire": "永不過期",
-                "supportedModels": "支援的模型",
-                "noModels": "暫無可選模型",
-                "modelsHint": "不選擇則為無限制",
-                "enabled": "是否啟用",
-                "cancel": "取消",
-                "create": "建立",
-                "save": "儲存",
-                "confirm": "確認"
-            },
-            "stats": {
-                "noData": "暫無統計數據",
-                "inputToken": "輸入 Token",
-                "outputToken": "輸出 Token",
-                "inputCost": "輸入費用",
-                "outputCost": "輸出費用",
-                "requestSuccess": "成功請求",
-                "requestFailed": "失敗請求"
-            },
-            "toast": {
-                "createSuccess": "API 金鑰建立成功",
-                "createError": "API 金鑰建立失敗",
-                "updateSuccess": "API 金鑰更新成功",
-                "updateError": "API 金鑰更新失敗",
-                "deleteSuccess": "API 金鑰刪除成功",
-                "deleteError": "API 金鑰刪除失敗"
-            }
-        },
-        "llmPrice": {
-            "title": "模型價格",
-            "updateInterval": {
-                "label": "自動更新間隔（小時）",
-                "placeholder": "請輸入間隔（小時）"
-            },
-            "manualUpdate": {
-                "label": "手動更新價格",
-                "button": "立即更新",
-                "updating": "更新中..."
-            },
-            "lastUpdate": "上次更新",
-            "neverUpdated": "從未更新",
-            "updateSuccess": "價格更新成功",
-            "updateFailed": "價格更新失敗"
-        },
-        "llmSync": {
-            "title": "供應源同步",
-            "syncInterval": {
-                "label": "自動同步間隔（小時）",
-                "placeholder": "請輸入間隔（小時）"
-            },
-            "manualSync": {
-                "label": "手動同步供應源",
-                "button": "立即同步",
-                "syncing": "同步中..."
-            },
-            "lastSync": "上次同步",
-            "neverSynced": "從未同步",
-            "syncSuccess": "供應源同步成功",
-            "syncFailed": "供應源同步失敗"
-        },
-        "account": {
-            "title": "帳戶設定",
-            "save": "儲存",
-            "saving": "儲存中...",
-            "username": {
-                "label": "修改使用者名稱",
-                "placeholder": "請輸入新使用者名稱",
-                "empty": "使用者名稱不能為空",
-                "success": "使用者名稱修改成功",
-                "failed": "使用者名稱修改失敗"
-            },
-            "password": {
-                "label": "修改密碼",
-                "oldPlaceholder": "請輸入當前密碼",
-                "newPlaceholder": "請輸入新密碼",
-                "confirmPlaceholder": "請確認新密碼",
-                "oldEmpty": "請輸入當前密碼",
-                "newEmpty": "請輸入新密碼",
-                "mismatch": "兩次輸入的密碼不一致",
-                "tooShort": "密碼長度至少為6位",
-                "change": "修改密碼",
-                "success": "密碼修改成功",
-                "failed": "密碼修改失敗"
-            }
-        },
-        "info": {
-            "title": "版本資訊",
-            "currentVersion": "當前版本",
-            "latestVersion": "最新版本",
-            "buildTime": "建構時間",
-            "publishedAt": "發布時間",
-            "github": "GitHub 倉庫",
-            "unknown": "未知",
-            "versionMismatch": "版本不匹配",
-            "versionMismatchHint": "前端版本 ({frontend}) 與後端版本 ({backend}) 不一致，可能是瀏覽器快取問題，請強制重新整理頁面。",
-            "forceRefresh": "強制重新整理",
-            "newVersionAvailable": "發現新版本可用",
-            "newVersionAvailableHint": "請先備份數據，然後更新系統",
-            "updateNow": "立即更新",
-            "updating": "更新中...",
-            "updateSuccess": "更新成功，服務即將重啟",
-            "updateFailed": "更新失敗"
-        },
-        "log": {
-            "title": "日誌設定",
-            "enabled": {
-                "label": "啟用歷史日誌"
-            },
-            "keepPeriod": {
-                "label": "日誌保存天數",
-                "placeholder": "請輸入天數"
-            },
-            "clear": {
-                "label": "清空歷史日誌",
-                "button": "清空",
-                "clearing": "清空中..."
-            },
-            "clearSuccess": "日誌已清空",
-            "clearFailed": "清空失敗"
-        }
-    },
-    "group": {
-        "toast": {
-            "created": "建立成功",
-            "createFailed": "建立失敗",
-            "updated": "更新成功",
-            "updateFailed": "更新失敗",
-            "deleted": "刪除成功",
-            "autoAddFailed": "自動新增失敗"
-        },
-        "create": {
-            "title": "建立分組",
-            "submit": "建立",
-            "submitting": "建立中..."
-        },
-        "card": {
-            "empty": "暫無規則"
-        },
-        "detail": {
-            "actions": {
-                "edit": "編輯",
-                "cancel": "取消",
-                "save": "儲存",
-                "copyName": "複製名稱",
-                "delete": "刪除",
-                "confirmDelete": "確認刪除"
-            }
-        },
-        "form": {
-            "name": "分組名稱",
-            "matchRegex": "匹配正規",
-            "matchRegexPlaceholder": "留空則預設按分組名稱模糊比對",
-            "matchRegexInvalid": "正規無效",
-            "firstTokenTimeOut": "首字逾時",
-            "firstTokenTimeOutHint": "單位秒，僅串流響應起效，0 表示不限制",
-            "sessionKeepTime": "會話保持",
-            "sessionKeepTimeHint": "單位秒，會話期間保持使用同一供應源，0 表示停用",
-            "items": "已選模型",
-            "addItem": "新增模型",
-            "autoAdd": "自動新增",
-            "clear": "清空",
-            "selectChannel": "供應源",
-            "selectModel": "模型"
-        },
-        "mode": {
-            "roundRobin": "輪詢",
-            "random": "隨機",
-            "failover": "故障轉移",
-            "weighted": "加權分配"
-        },
-        "empty": "暫無分組，點擊左上角按鈕建立"
-    },
-    "model": {
-        "create": {
-            "title": "建立模型",
-            "name": "模型名稱",
-            "input": "輸入價格",
-            "output": "輸出價格",
-            "cacheRead": "快取讀取",
-            "cacheWrite": "快取寫入",
-            "submit": "建立",
-            "submitting": "建立中..."
-        },
-        "toast": {
-            "updated": "模型價格已更新",
-            "updateFailed": "更新失敗",
-            "deleted": "模型已刪除",
-            "deleteFailed": "刪除失敗"
-        },
-        "card": {
-            "inputCache": "輸入/快取",
-            "outputCache": "輸出/快取",
-            "edit": "編輯",
-            "delete": "刪除"
-        },
-        "overlay": {
-            "cancel": "取消",
-            "deleting": "刪除中...",
-            "confirmDelete": "確認刪除",
-            "input": "輸入",
-            "output": "輸出",
-            "cacheRead": "快取讀取",
-            "cacheWrite": "快取寫入",
-            "save": "儲存"
-        }
+    "info": {
+      "title": "版本資訊",
+      "currentVersion": "當前版本",
+      "latestVersion": "最新版本",
+      "buildTime": "建構時間",
+      "publishedAt": "發布時間",
+      "github": "GitHub 倉庫",
+      "unknown": "未知",
+      "versionMismatch": "版本不匹配",
+      "versionMismatchHint": "前端版本 ({frontend}) 與後端版本 ({backend}) 不一致，可能是瀏覽器快取問題，請強制重新整理頁面。",
+      "forceRefresh": "強制重新整理",
+      "newVersionAvailable": "發現新版本可用",
+      "newVersionAvailableHint": "請先備份數據，然後更新系統",
+      "updateNow": "立即更新",
+      "updating": "更新中...",
+      "updateSuccess": "更新成功，服務即將重啟",
+      "updateFailed": "更新失敗"
     },
     "log": {
-        "list": {
-            "noMore": "沒有更多日誌了"
-        },
-        "card": {
-            "error": "錯誤",
-            "errorInfo": "錯誤訊息",
-            "firstToken": "首字",
-            "totalTime": "總耗時",
-            "input": "輸入",
-            "output": "輸出",
-            "cost": "費用",
-            "requestContent": "請求內容",
-            "responseContent": "響應內容",
-            "noRequestContent": "(無請求內容)",
-            "noResponseContent": "(無響應內容)",
-            "firstTokenTime": "首字時間",
-            "tokens": "tokens",
-            "retryDetails": "重試詳情",
-            "attempts": "次嘗試",
-            "success": "成功",
-            "failed": "失敗"
-        }
-    },
-    "channel": {
-        "card": {
-            "requestCount": "請求次數",
-            "totalCost": "總成本",
-            "toast": {
-                "enabled": "供應源已啟用",
-                "disabled": "供應源已停用"
-            }
-        },
-        "detail": {
-            "title": {
-                "edit": "編輯供應源",
-                "view": "供應源詳情"
-            },
-            "sections": {
-                "requests": "請求詳情",
-                "tokens": "Token 使用",
-                "costs": "成本詳情",
-                "baseUrls": "Base URLs",
-                "keys": "金鑰"
-            },
-            "noBaseUrls": "暫無 Base URL",
-            "noKeys": "暫無金鑰",
-            "metrics": {
-                "totalRequests": "總請求",
-                "totalToken": "總 Token",
-                "totalCost": "總成本",
-                "successRequests": "成功請求",
-                "failedRequests": "失敗請求",
-                "inputToken": "輸入 Token",
-                "outputToken": "輸出 Token",
-                "inputCost": "輸入成本",
-                "outputCost": "輸出成本",
-                "avgWaitTime": "等待時間"
-            },
-            "actions": {
-                "edit": "編輯",
-                "cancel": "取消",
-                "save": "儲存",
-                "saving": "儲存中...",
-                "delete": "刪除",
-                "confirmDelete": "確認刪除",
-                "deleting": "刪除中..."
-            }
-        },
-        "create": {
-            "dialogTitle": "建立新供應源",
-            "submit": "建立供應源",
-            "submitting": "建立中..."
-        },
-        "form": {
-            "add": "新增",
-            "name": "供應源名稱",
-            "type": "供應源類型",
-            "baseUrls": "Base URLs",
-            "baseUrlUrl": "地址",
-            "baseUrlDelay": "延遲(ms)",
-            "advanced": "進階設定",
-            "apiKey": "API Key",
-            "customHeader": "自定義 Header",
-            "customHeaderKey": "Header Key",
-            "customHeaderValue": "Header Value",
-            "customHeaderAdd": "新增 Header",
-            "channelProxy": "供應源代理",
-            "channelProxyPlaceholder": "可選：僅對該供應源生效（覆蓋全域代理）",
-            "paramOverride": "參數覆蓋",
-            "paramOverridePlaceholder": "可選：JSON 字串，用於覆蓋請求參數",
-            "model": "模型",
-            "enabled": "啟用",
-            "enableCircuitBreaker": "啟用熔斷器",
-            "proxy": "使用代理",
-            "modelCustomPlaceholder": "自定義模型名稱",
-            "modelAdd": "新增",
-            "modelRefresh": "重新整理",
-            "modelRefreshSuccess": "模型列表獲取成功",
-            "modelRefreshFailed": "模型列表獲取失敗",
-            "modelRefreshEmpty": "未獲取到模型列表",
-            "modelSelected": "已選模型",
-            "modelNoSelected": "暫未選擇模型",
-            "modelClearAll": "清除全部",
-            "typeOpenAIChat": "OpenAI Chat",
-            "typeOpenAIResponse": "OpenAI Response",
-            "typeOpenAIEmbedding": "OpenAI Embedding",
-            "typeAnthropic": "Anthropic",
-            "typeGemini": "Gemini",
-            "typeVolcengine": "火山引擎",
-            "autoSync": "自動同步",
-            "autoGroup": "自動分組",
-            "autoGroupNone": "不自動分組",
-            "autoGroupFuzzy": "模糊比對",
-            "autoGroupExact": "準確比對",
-            "autoGroupRegex": "正規比對",
-            "matchRegex": "匹配正規",
-            "matchRegexPlaceholder": "可選：用於匹配請求模型名稱的正規表示式",
-            "remark": "備註"
-        }
+      "title": "日誌設定",
+      "enabled": {
+        "label": "啟用歷史日誌"
+      },
+      "keepPeriod": {
+        "label": "日誌保存天數",
+        "placeholder": "請輸入天數"
+      },
+      "redundantFields": {
+        "label": "記錄並讀取日誌冗餘欄位 (_octopus_*)"
+      },
+      "clear": {
+        "label": "清空歷史日誌",
+        "button": "清空",
+        "clearing": "清空中..."
+      },
+      "clearSuccess": "日誌已清空",
+      "clearFailed": "清空失敗"
     }
+  },
+  "group": {
+    "toast": {
+      "created": "建立成功",
+      "createFailed": "建立失敗",
+      "updated": "更新成功",
+      "updateFailed": "更新失敗",
+      "deleted": "刪除成功",
+      "autoAddFailed": "自動新增失敗"
+    },
+    "create": {
+      "title": "建立分組",
+      "submit": "建立",
+      "submitting": "建立中..."
+    },
+    "card": {
+      "empty": "暫無規則"
+    },
+    "detail": {
+      "actions": {
+        "edit": "編輯",
+        "cancel": "取消",
+        "save": "儲存",
+        "copyName": "複製名稱",
+        "delete": "刪除",
+        "confirmDelete": "確認刪除"
+      }
+    },
+    "form": {
+      "name": "分組名稱",
+      "matchRegex": "匹配正規",
+      "matchRegexPlaceholder": "留空則預設按分組名稱模糊比對",
+      "matchRegexInvalid": "正規無效",
+      "firstTokenTimeOut": "首字逾時",
+      "firstTokenTimeOutHint": "單位秒，僅串流響應起效，0 表示不限制",
+      "sessionKeepTime": "會話保持",
+      "sessionKeepTimeHint": "單位秒，會話期間保持使用同一供應源，0 表示停用",
+      "items": "已選模型",
+      "addItem": "新增模型",
+      "autoAdd": "自動新增",
+      "clear": "清空",
+      "selectChannel": "供應源",
+      "selectModel": "模型"
+    },
+    "mode": {
+      "roundRobin": "輪詢",
+      "random": "隨機",
+      "failover": "故障轉移",
+      "weighted": "加權分配"
+    },
+    "empty": "暫無分組，點擊左上角按鈕建立"
+  },
+  "model": {
+    "create": {
+      "title": "建立模型",
+      "name": "模型名稱",
+      "input": "輸入價格",
+      "output": "輸出價格",
+      "cacheRead": "快取讀取",
+      "cacheWrite": "快取寫入",
+      "submit": "建立",
+      "submitting": "建立中..."
+    },
+    "toast": {
+      "updated": "模型價格已更新",
+      "updateFailed": "更新失敗",
+      "deleted": "模型已刪除",
+      "deleteFailed": "刪除失敗"
+    },
+    "card": {
+      "inputCache": "輸入/快取",
+      "outputCache": "輸出/快取",
+      "edit": "編輯",
+      "delete": "刪除"
+    },
+    "overlay": {
+      "cancel": "取消",
+      "deleting": "刪除中...",
+      "confirmDelete": "確認刪除",
+      "input": "輸入",
+      "output": "輸出",
+      "cacheRead": "快取讀取",
+      "cacheWrite": "快取寫入",
+      "save": "儲存"
+    }
+  },
+  "log": {
+    "list": {
+      "noMore": "沒有更多日誌了"
+    },
+    "card": {
+      "error": "錯誤",
+      "errorInfo": "錯誤訊息",
+      "firstToken": "首字",
+      "totalTime": "總耗時",
+      "input": "輸入",
+      "output": "輸出",
+      "cost": "費用",
+      "requestContent": "請求內容",
+      "responseContent": "響應內容",
+      "noRequestContent": "(無請求內容)",
+      "noResponseContent": "(無響應內容)",
+      "firstTokenTime": "首字時間",
+      "tokens": "tokens",
+      "retryDetails": "重試詳情",
+      "attempts": "次嘗試",
+      "success": "成功",
+      "failed": "失敗"
+    }
+  },
+  "channel": {
+    "card": {
+      "requestCount": "請求次數",
+      "totalCost": "總成本",
+      "toast": {
+        "enabled": "供應源已啟用",
+        "disabled": "供應源已停用"
+      }
+    },
+    "detail": {
+      "title": {
+        "edit": "編輯供應源",
+        "view": "供應源詳情"
+      },
+      "sections": {
+        "requests": "請求詳情",
+        "tokens": "Token 使用",
+        "costs": "成本詳情",
+        "baseUrls": "Base URLs",
+        "keys": "金鑰"
+      },
+      "noBaseUrls": "暫無 Base URL",
+      "noKeys": "暫無金鑰",
+      "metrics": {
+        "totalRequests": "總請求",
+        "totalToken": "總 Token",
+        "totalCost": "總成本",
+        "successRequests": "成功請求",
+        "failedRequests": "失敗請求",
+        "inputToken": "輸入 Token",
+        "outputToken": "輸出 Token",
+        "inputCost": "輸入成本",
+        "outputCost": "輸出成本",
+        "avgWaitTime": "等待時間"
+      },
+      "actions": {
+        "edit": "編輯",
+        "cancel": "取消",
+        "save": "儲存",
+        "saving": "儲存中...",
+        "delete": "刪除",
+        "confirmDelete": "確認刪除",
+        "deleting": "刪除中..."
+      }
+    },
+    "create": {
+      "dialogTitle": "建立新供應源",
+      "submit": "建立供應源",
+      "submitting": "建立中..."
+    },
+    "form": {
+      "add": "新增",
+      "name": "供應源名稱",
+      "type": "供應源類型",
+      "baseUrls": "Base URLs",
+      "baseUrlUrl": "地址",
+      "baseUrlDelay": "延遲(ms)",
+      "advanced": "進階設定",
+      "apiKey": "API Key",
+      "customHeader": "自定義 Header",
+      "customHeaderKey": "Header Key",
+      "customHeaderValue": "Header Value",
+      "customHeaderAdd": "新增 Header",
+      "channelProxy": "供應源代理",
+      "channelProxyPlaceholder": "可選：僅對該供應源生效（覆蓋全域代理）",
+      "paramOverride": "參數覆蓋",
+      "paramOverridePlaceholder": "可選：JSON 字串，用於覆蓋請求參數",
+      "model": "模型",
+      "enabled": "啟用",
+      "enableCircuitBreaker": "啟用熔斷器",
+      "proxy": "使用代理",
+      "modelCustomPlaceholder": "自定義模型名稱",
+      "modelAdd": "新增",
+      "modelRefresh": "重新整理",
+      "modelRefreshSuccess": "模型列表獲取成功",
+      "modelRefreshFailed": "模型列表獲取失敗",
+      "modelRefreshEmpty": "未獲取到模型列表",
+      "modelSelected": "已選模型",
+      "modelNoSelected": "暫未選擇模型",
+      "modelClearAll": "清除全部",
+      "typeOpenAIChat": "OpenAI Chat",
+      "typeOpenAIResponse": "OpenAI Response",
+      "typeOpenAIEmbedding": "OpenAI Embedding",
+      "typeAnthropic": "Anthropic",
+      "typeGemini": "Gemini",
+      "typeVolcengine": "火山引擎",
+      "autoSync": "自動同步",
+      "autoGroup": "自動分組",
+      "autoGroupNone": "不自動分組",
+      "autoGroupFuzzy": "模糊比對",
+      "autoGroupExact": "準確比對",
+      "autoGroupRegex": "正規比對",
+      "matchRegex": "匹配正規",
+      "matchRegexPlaceholder": "可選：用於匹配請求模型名稱的正規表示式",
+      "remark": "備註",
+      "typeKimiCoding": "Kimi Coding"
+    }
+  }
 }

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -54,6 +54,7 @@ export type Channel = {
     name: string;
     type: ChannelType;
     enabled: boolean;
+    enable_circuit_breaker: boolean;
     base_urls: BaseUrl[];
     keys: ChannelKey[];
     model: string;
@@ -69,7 +70,8 @@ export type Channel = {
 };
 
 // Internal type: backend may return null for slice fields; normalize to [] in select()
-type ChannelServer = Omit<Channel, 'base_urls' | 'custom_header' | 'keys'> & {
+type ChannelServer = Omit<Channel, 'base_urls' | 'custom_header' | 'keys' | 'enable_circuit_breaker'> & {
+    enable_circuit_breaker?: boolean | null;
     base_urls: BaseUrl[] | null;
     custom_header: CustomHeader[] | null;
     keys: ChannelKey[] | null;
@@ -82,6 +84,7 @@ export type CreateChannelRequest = {
     name: string;
     type: ChannelType;
     enabled?: boolean;
+    enable_circuit_breaker?: boolean;
     base_urls: BaseUrl[];
     keys: Array<Pick<ChannelKey, 'enabled' | 'channel_key' | 'remark'>>;
     model: string;
@@ -103,6 +106,7 @@ export type UpdateChannelRequest = {
     name?: string;
     type?: ChannelType;
     enabled?: boolean;
+    enable_circuit_breaker?: boolean;
     base_urls?: BaseUrl[];
     model?: string;
     custom_model?: string;
@@ -148,6 +152,7 @@ export function useChannelList() {
         select: (data) => data.map((item) => ({
             raw: ({
                 ...item,
+                enable_circuit_breaker: item.enable_circuit_breaker ?? true,
                 base_urls: item.base_urls ?? [],
                 custom_header: item.custom_header ?? [],
                 keys: item.keys ?? [],

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -13,6 +13,7 @@ export enum ChannelType {
     Gemini = 3,
     Volcengine = 4,
     OpenAIEmbedding = 5,
+    KimiCoding = 6,
 }
 
 /**

--- a/web/src/api/endpoints/setting.ts
+++ b/web/src/api/endpoints/setting.ts
@@ -18,6 +18,7 @@ export const SettingKey = {
     SyncLLMInterval: 'sync_llm_interval',
     RelayLogKeepEnabled: 'relay_log_keep_enabled',
     RelayLogKeepPeriod: 'relay_log_keep_period',
+    RelayLogRedundantFieldsEnabled: 'relay_log_redundant_fields_enabled',
     CORSAllowOrigins: 'cors_allow_origins',
     CircuitBreakerThreshold: 'circuit_breaker_threshold',
     CircuitBreakerCooldown: 'circuit_breaker_cooldown',
@@ -209,4 +210,3 @@ export function useImportDB() {
         },
     });
 }
-

--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -37,6 +37,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         name: channel.name,
         type: channel.type,
         enabled: channel.enabled,
+        enable_circuit_breaker: channel.enable_circuit_breaker,
         base_urls: channel.base_urls?.length ? channel.base_urls : [{ url: '', delay: 0 }],
         custom_header: channel.custom_header ?? [],
         channel_proxy: channel.channel_proxy ?? '',
@@ -76,6 +77,9 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         if (formData.name !== channel.name) req.name = formData.name;
         if (formData.type !== channel.type) req.type = formData.type;
         if (formData.enabled !== channel.enabled) req.enabled = formData.enabled;
+        if (formData.enable_circuit_breaker !== channel.enable_circuit_breaker) {
+            req.enable_circuit_breaker = formData.enable_circuit_breaker;
+        }
         if (!baseUrlsEqual(formData.base_urls, channel.base_urls)) {
             req.base_urls = (formData.base_urls ?? []).filter((u) => u.url.trim()).map((u) => ({
                 url: u.url.trim(),

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -25,6 +25,7 @@ export function CreateDialogContent() {
         auto_sync: false,
         auto_group: AutoGroupType.None,
         enabled: true,
+        enable_circuit_breaker: true,
         proxy: false,
         match_regex: '',
     });
@@ -50,6 +51,7 @@ export function CreateDialogContent() {
                 name: formData.name,
                 type: formData.type,
                 enabled: formData.enabled,
+                enable_circuit_breaker: formData.enable_circuit_breaker,
                 base_urls: normalizedBaseUrls,
                 keys: normalizedKeys,
                 model: formData.model,
@@ -77,6 +79,7 @@ export function CreateDialogContent() {
                         auto_sync: false,
                         auto_group: AutoGroupType.None,
                         enabled: true,
+                        enable_circuit_breaker: true,
                         proxy: false,
                         match_regex: '',
                     });

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -122,7 +122,7 @@ export function ChannelForm({
                     .map((k) => ({ enabled: k.enabled, channel_key: k.channel_key.trim() })),
                 proxy: formData.proxy,
                 match_regex: formData.match_regex.trim() || null,
-                custom_header: formData.custom_header,
+                custom_header: formData.custom_header?.filter((h) => h.header_key.trim()) || [],
             },
             {
                 onSuccess: (data) => {

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -36,6 +36,7 @@ export interface ChannelFormData {
     model: string;
     custom_model: string;
     enabled: boolean;
+    enable_circuit_breaker: boolean;
     proxy: boolean;
     auto_sync: boolean;
     auto_group: AutoGroupType;
@@ -586,6 +587,13 @@ export function ChannelForm({
                     <span className="text-sm font-medium text-card-foreground">{t('enabled')}</span>
                 </label>
                 <div className="flex items-center gap-6">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                        <Switch
+                            checked={formData.enable_circuit_breaker}
+                            onCheckedChange={(checked) => onFormDataChange({ ...formData, enable_circuit_breaker: checked })}
+                        />
+                        <span className="text-sm text-card-foreground">{t('enableCircuitBreaker')}</span>
+                    </label>
                     <label className="flex items-center gap-2 cursor-pointer">
                         <Switch
                             checked={formData.proxy}

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -256,6 +256,7 @@ export function ChannelForm({
                             <SelectItem className='rounded-xl' value={String(ChannelType.Gemini)}>{t('typeGemini')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.Volcengine)}>{t('typeVolcengine')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.OpenAIEmbedding)}>{t('typeOpenAIEmbedding')}</SelectItem>
+                            <SelectItem className='rounded-xl' value={String(ChannelType.KimiCoding)}>{t('typeKimiCoding')}</SelectItem>
                         </SelectContent>
                     </Select>
                 </div>

--- a/web/src/components/modules/setting/Log.tsx
+++ b/web/src/components/modules/setting/Log.tsx
@@ -17,20 +17,28 @@ export function SettingLog() {
     const clearLogs = useClearLogs();
 
     const [enabled, setEnabled] = useState(true);
+    const [redundantFieldsEnabled, setRedundantFieldsEnabled] = useState(true);
     const [keepPeriod, setKeepPeriod] = useState('7');
     const [isClearing, setIsClearing] = useState(false);
 
     const initialEnabled = useRef(true);
+    const initialRedundantFieldsEnabled = useRef(true);
     const initialKeepPeriod = useRef('7');
 
     useEffect(() => {
         if (settings) {
             const enabledSetting = settings.find(s => s.key === SettingKey.RelayLogKeepEnabled);
+            const redundantFieldsSetting = settings.find(s => s.key === SettingKey.RelayLogRedundantFieldsEnabled);
             const periodSetting = settings.find(s => s.key === SettingKey.RelayLogKeepPeriod);
             if (enabledSetting) {
                 const isEnabled = enabledSetting.value === 'true';
                 queueMicrotask(() => setEnabled(isEnabled));
                 initialEnabled.current = isEnabled;
+            }
+            if (redundantFieldsSetting) {
+                const isEnabled = redundantFieldsSetting.value === 'true';
+                queueMicrotask(() => setRedundantFieldsEnabled(isEnabled));
+                initialRedundantFieldsEnabled.current = isEnabled;
             }
             if (periodSetting) {
                 queueMicrotask(() => setKeepPeriod(periodSetting.value));
@@ -61,6 +69,19 @@ export function SettingLog() {
                 onSuccess: () => {
                     toast.success(t('saved'));
                     initialKeepPeriod.current = keepPeriod;
+                }
+            }
+        );
+    };
+
+    const handleRedundantFieldsEnabledChange = (checked: boolean) => {
+        setRedundantFieldsEnabled(checked);
+        setSetting.mutate(
+            { key: SettingKey.RelayLogRedundantFieldsEnabled, value: checked ? 'true' : 'false' },
+            {
+                onSuccess: () => {
+                    toast.success(t('saved'));
+                    initialRedundantFieldsEnabled.current = checked;
                 }
             }
         );
@@ -116,6 +137,18 @@ export function SettingLog() {
                 />
             </div>
 
+            {/* 日志冗余字段记录与读取 */}
+            <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                    <ScrollText className="h-5 w-5 text-muted-foreground" />
+                    <span className="text-sm font-medium">{t('log.redundantFields.label')}</span>
+                </div>
+                <Switch
+                    checked={redundantFieldsEnabled}
+                    onCheckedChange={handleRedundantFieldsEnabledChange}
+                />
+            </div>
+
             {/* 清空历史日志 */}
             <div className="flex items-center justify-between gap-4">
                 <div className="flex items-center gap-3">
@@ -135,4 +168,3 @@ export function SettingLog() {
         </div>
     );
 }
-


### PR DESCRIPTION
上述场景存在两个问题，
1.  Claude Code客户端使用
```
channel Kimi failed: upstream error: 400: {"error":{"message":"thinking is enabled but reasoning_content is missing in assistant tool call message at index 3","type":"invalid_request_error"}}
```
Anthropic 协议转Openai Chat协议时候，没有把Anthropic协议的thinking部分转换时候丢失，因为`Message.ClearHelpFields() 里有 m.ReasoningContent = nil`出站前会清理掉 reasoning_content字段。 修复方案， 在显示开启推理模式时候，会保留 reasoning_content字段。

model.go 新增逻辑：当 thinking/reasoning 开启且消息是 assistant + tool_calls 时：
若已有 reasoning_content，保留
若只有 reasoning，映射到 reasoning_content
若都没有，补 reasoning_content: ""

2. Openclaw客户端
```
upstream error: 400: {"error":{"message":"tool_call_id is not found","type":"invalid_request_error"}}
```
这个可能是是Openclaw自身bug, 我之前提到过，Openclaw客户端发送的请求中会存在空的tool call id和function name字段，现在是octopus增加了校验，转换时候会丢失这种无效字段

上述两个问题修复时候，采取了保守策略，尽量做最小的改动，