### PR TITLE
fix: 修复渠道延迟检测导致的空指针 panic

### DIFF
--- a/internal/helper/channel.go
+++ b/internal/helper/channel.go
@@ -18,33 +18,50 @@ func ChannelHttpClient(channel *model.Channel) (*http.Client, error) {
 	if channel == nil {
 		return nil, errors.New("channel is nil")
 	}
+	var (
+		httpClient *http.Client
+		err        error
+	)
 	if !channel.Proxy {
-		return client.GetHTTPClientSystemProxy(false)
+		httpClient, err = client.GetHTTPClientSystemProxy(false)
 	} else if channel.ChannelProxy == nil || strings.TrimSpace(*channel.ChannelProxy) == "" {
-		return client.GetHTTPClientSystemProxy(true)
+		httpClient, err = client.GetHTTPClientSystemProxy(true)
 	} else {
-		return client.GetHTTPClientCustomProxy(strings.TrimSpace(*channel.ChannelProxy))
+		httpClient, err = client.GetHTTPClientCustomProxy(strings.TrimSpace(*channel.ChannelProxy))
 	}
+	if err != nil {
+		return nil, err
+	}
+	if httpClient == nil {
+		return nil, errors.New("http client is nil")
+	}
+	return httpClient, nil
 }
 
 func ChannelBaseUrlDelayUpdate(channel *model.Channel, ctx context.Context) {
 	if channel == nil {
 		return
 	}
+	httpClient, err := ChannelHttpClient(channel)
+	if err != nil {
+		log.Warnf("failed to get http client (channel=%d): %v", channel.ID, err)
+		return
+	}
+
 	newBaseUrls := make([]model.BaseUrl, 0, len(channel.BaseUrls))
 	for _, baseUrl := range channel.BaseUrls {
-		httpClient, err := ChannelHttpClient(channel)
-		if err != nil {
-			log.Warnf("failed to get http client (channel=%d): %v", channel.ID, err)
+		url := strings.TrimSpace(baseUrl.URL)
+		if url == "" {
+			log.Warnf("skip empty base url (channel=%d)", channel.ID)
 			continue
 		}
-		delay, err := GetUrlDelay(httpClient, baseUrl.URL, ctx)
+		delay, err := GetUrlDelay(httpClient, url, ctx)
 		if err != nil {
-			log.Warnf("failed to get url delay (channel=%d): %v", channel.ID, err)
+			log.Warnf("failed to get url delay (channel=%d, url=%s): %v", channel.ID, url, err)
 			continue
 		}
 		newBaseUrls = append(newBaseUrls, model.BaseUrl{
-			URL:   baseUrl.URL,
+			URL:   url,
 			Delay: delay,
 		})
 	}

--- a/internal/helper/delay.go
+++ b/internal/helper/delay.go
@@ -2,17 +2,33 @@ package helper
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 )
 
 func GetUrlDelay(httpClient *http.Client, url string, ctx context.Context) (int, error) {
+	if httpClient == nil {
+		return 0, errors.New("http client is nil")
+	}
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return 0, errors.New("url is empty")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	start := time.Now()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return 0, err
+	}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return 0, err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return int(time.Since(start).Milliseconds()), nil
 }


### PR DESCRIPTION
## 问题背景
在 Docker 运行场景下，`ChannelBaseUrlDelayTask` 会周期性检测渠道 Base URL 延迟。
当渠道代理配置异常或 URL 非法时，服务偶发出现 `panic: invalid memory address or nil pointer dereference`，导致进程退出重启。
该问题会在异常配置存在时触发进程崩溃；容器重启后又会命中同一路径，形成崩溃重启循环。由于服务无法稳定存活，用户通常无法通过 WebUI 进入渠道页修正配置，只能通过手动修改 SQLite 数据（或离线清理异常渠道）来恢复。

## 根因分析
- `GetUrlDelay` 对异常输入防御不足：
- `httpClient` 可能为 `nil`
- URL 可能为空或非法
- `http.NewRequestWithContext` 的错误未处理
上述场景下会触发 `httpClient.Do(...)` 的空指针路径，最终 panic。

## 修改内容
- `internal/helper/delay.go`
    - 增加 `httpClient == nil` 检查
    - 增加空 URL 检查（trim 后）
    - `ctx == nil` 时回退 `context.Background()`
    - 显式处理 `http.NewRequestWithContext` 返回错误
    - 使用 `defer resp.Body.Close()` 保证资源释放

- `internal/helper/channel.go`
    - `ChannelHttpClient` 增加返回值兜底，避免返回 `nil` client
    - `ChannelBaseUrlDelayUpdate` 改为先获取一次 client，失败直接返回
    - 跳过空 Base URL，避免无效请求
    - 增强日志信息（包含 channel id / url），便于排查配置问题

## 影响范围
- 仅影响渠道延迟探测逻辑
- 正常请求转发逻辑不变
- 异常配置从“进程崩溃”变为“记录告警并跳过”

## 验证方式
- 异常配置场景下不再 panic，服务可持续运行

---

以下是我使用时v0.9.19的崩溃日志：
```text
🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T01:51:58+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T01:51:58+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
2026-02-26T01:52:06+08:00       WARN    helper/channel.go:43    failed to get url delay (channel=25): Head "https://open-ai.xxxxx.xxxx/v1": stopped after 10 redirects
2026-02-26T01:52:36+08:00       WARN    helper/channel.go:43    failed to get url delay (channel=25): Head "https://open-ai.xxxxx.xxxx/v1": stopped after 10 redirects
2026-02-26T01:52:51+08:00       INFO    relay/relay.go:129      request model claude-sonnet-4-6, mode: 3, forwarding to channel: HuanAPI model: claude-sonnet-4-6 (attempt 1/3, sticky=false)
2026-02-26T01:53:03+08:00       INFO    relay/relay.go:379      stream end
2026-02-26T01:53:03+08:00       INFO    relay/metrics.go:102    relay complete: model=claude-sonnet-4-6, channel=19(API), success=true, duration=11582ms, input_token=808, output_token=114, input_cost=0.002424, output_cost=0.001710, total_cost=0.004134, attempts=1
2026-02-26T01:53:20+08:00       WARN    helper/channel.go:38    failed to get http client (channel=2): proxy url is empty
2026-02-26T01:53:34+08:00       WARN    helper/channel.go:38    failed to get http client (channel=26): proxy url is empty
2026-02-26T01:53:34+08:00       WARN    helper/channel.go:38    failed to get http client (channel=6): proxy url is empty
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 30 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0x3cd7fc3bc660, {0x3cd7fc48dca0, 0x1d}, {0x210e150, 0x3cd7fc3771f0})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0x3cd7fc2a1e08, {0x210e150, 0x3cd7fc3771f0})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 21
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45

 ██████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗███████╗
██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗██║   ██║██╔════╝
██║   ██║██║        ██║   ██║   ██║██████╔╝██║   ██║███████╗
██║   ██║██║        ██║   ██║   ██║██╔═══╝ ██║   ██║╚════██║
╚██████╔╝╚██████╗   ██║   ╚██████╔╝██║     ╚██████╔╝███████║
 ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚═╝      ╚═════╝ ╚══════╝
          🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T11:49:04+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T11:49:04+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
2026-02-26T11:49:04+08:00       WARN    helper/channel.go:38    failed to get http client (channel=26): proxy url is empty
2026-02-26T11:49:04+08:00       WARN    helper/channel.go:38    failed to get http client (channel=6): proxy url is empty
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 47 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0x3d511370a1b0, {0x3d511394e080, 0x1d}, {0x210e150, 0x3d511361d1f0})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0x3d51139bbe08, {0x210e150, 0x3d511361d1f0})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 37
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45

 ██████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗███████╗
██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗██║   ██║██╔════╝
██║   ██║██║        ██║   ██║   ██║██████╔╝██║   ██║███████╗
██║   ██║██║        ██║   ██║   ██║██╔═══╝ ██║   ██║╚════██║
╚██████╔╝╚██████╗   ██║   ╚██████╔╝██║     ╚██████╔╝███████║
 ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚═╝      ╚═════╝ ╚══════╝
          🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T11:49:14+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T11:49:14+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 8 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0x245efcb58e40, {0x245efc9e02e0, 0x1d}, {0x210e150, 0x245efcaf21c0})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0x245efcb79e08, {0x210e150, 0x245efcaf21c0})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 51
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45

 ██████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗███████╗
██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗██║   ██║██╔════╝
██║   ██║██║        ██║   ██║   ██║██████╔╝██║   ██║███████╗
██║   ██║██║        ██║   ██║   ██║██╔═══╝ ██║   ██║╚════██║
╚██████╔╝╚██████╗   ██║   ╚██████╔╝██║     ╚██████╔╝███████║
 ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚═╝      ╚═════╝ ╚══════╝
          🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T11:49:24+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T11:49:24+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 49 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0x4a4c95f6f60, {0x4a4c945e2e0, 0x1d}, {0x210e150, 0x4a4c944b2d0})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0x4a4c9707e08, {0x210e150, 0x4a4c944b2d0})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 9
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45

 ██████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗███████╗
██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗██║   ██║██╔════╝
██║   ██║██║        ██║   ██║   ██║██████╔╝██║   ██║███████╗
██║   ██║██║        ██║   ██║   ██║██╔═══╝ ██║   ██║╚════██║
╚██████╔╝╚██████╗   ██║   ╚██████╔╝██║     ╚██████╔╝███████║
 ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚═╝      ╚═════╝ ╚══════╝
          🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T11:50:00+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T11:50:00+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 52 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0xacaa9c349f0, {0xacaa9ca25a0, 0x1d}, {0x210e150, 0xacaa9accee0})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0xacaa9d8be08, {0x210e150, 0xacaa9accee0})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 11
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45

 ██████╗  ██████╗████████╗ ██████╗ ██████╗ ██╗   ██╗███████╗
██╔═══██╗██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗██║   ██║██╔════╝
██║   ██║██║        ██║   ██║   ██║██████╔╝██║   ██║███████╗
██║   ██║██║        ██║   ██║   ██║██╔═══╝ ██║   ██║╚════██║
╚██████╔╝╚██████╗   ██║   ╚██████╔╝██║     ╚██████╔╝███████║
 ╚═════╝  ╚═════╝   ╚═╝    ╚═════╝ ╚═╝      ╚═════╝ ╚══════╝
          🚀 octopus - all ai service in one place
────────────────────────────────────────────────────────────
Version:     v0.9.19
Commit:      ab2e9a6
Build Time:  2026-02-25 16:58:42 +0800
Built By:    bestrui
Repo:        https://github.com/bestruirui/octopus
════════════════════════════════════════════════════════════
2026-02-26T11:50:18+08:00       INFO    conf/config.go:50       Using config file: /app/data/config.json
2026-02-26T11:50:18+08:00       INFO    cmd/start.go:52 Program started, press Ctrl+C to exit
2026-02-26T11:50:24+08:00       WARN    helper/channel.go:43    failed to get url delay (channel=2): Head "https://xxxx.xxxx.xxxx/v1": Bad Gateway
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6f9846]

goroutine 46 [running]:
net/http.(*Client).do(0x210e150?, 0x0)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:601 +0xa6
net/http.(*Client).Do(...)
        /opt/hostedtoolcache/go/1.26.0/x64/src/net/http/client.go:592
github.com/bestruirui/octopus/internal/helper.GetUrlDelay(0xe6a73187b30, {0xe6a73300240, 0x1d}, {0x210e150, 0xe6a72f34f50})
        /home/runner/work/octopus/octopus/internal/helper/delay.go:12 +0x85
github.com/bestruirui/octopus/internal/helper.ChannelBaseUrlDelayUpdate(0xe6a73243e08, {0x210e150, 0xe6a72f34f50})
        /home/runner/work/octopus/octopus/internal/helper/channel.go:41 +0x247
github.com/bestruirui/octopus/internal/task.ChannelBaseUrlDelayTask()
        /home/runner/work/octopus/octopus/internal/task/channel.go:26 +0x21c
created by github.com/bestruirui/octopus/internal/task.runTask in goroutine 45
        /home/runner/work/octopus/octopus/internal/task/task.go:95 +0x45
```
