### PR TITLE
feat: 当上游 API 返回内容长度为 0 时，将其认定为失败并触发负载均衡重试

### DIFF
--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -687,6 +687,53 @@ func (r *InternalLLMResponse) IsChatResponse() bool {
 	return len(r.Choices) > 0
 }
 
+func (r *InternalLLMResponse) IsEmpty() bool {
+	if r == nil {
+		return true
+	}
+
+	if len(r.EmbeddingData) > 0 {
+		return false
+	}
+
+	if len(r.Choices) == 0 {
+		return true
+	}
+
+	for _, choice := range r.Choices {
+		msg := choice.Message
+		if choice.Delta != nil {
+			msg = choice.Delta
+		}
+
+		if msg == nil {
+			continue
+		}
+
+		if len(msg.ToolCalls) > 0 {
+			return false
+		}
+
+		if msg.Content.Content != nil && *msg.Content.Content != "" {
+			return false
+		}
+
+		if len(msg.Content.MultipleContent) > 0 {
+			return false
+		}
+
+		if msg.ReasoningContent != nil && *msg.ReasoningContent != "" {
+			return false
+		}
+
+		if msg.Reasoning != nil && *msg.Reasoning != "" {
+			return false
+		}
+	}
+
+	return true
+}
+
 // Choice represents a choice in the response.
 // Choice represents a choice in the response.
 type Choice struct {

--- a/internal/transformer/outbound/authropic/messages.go
+++ b/internal/transformer/outbound/authropic/messages.go
@@ -107,7 +107,13 @@ func (o *MessageOutbound) TransformResponse(ctx context.Context, response *http.
 	}
 
 	// Convert to internal response
-	return convertToLLMResponse(&anthropicResp), nil
+	internalResp := convertToLLMResponse(&anthropicResp)
+
+	if internalResp.IsEmpty() {
+		return nil, fmt.Errorf("response content is empty")
+	}
+
+	return internalResp, nil
 }
 
 func (o *MessageOutbound) TransformStream(ctx context.Context, eventData []byte) (*model.InternalLLMResponse, error) {

--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -82,7 +82,13 @@ func (o *MessagesOutbound) TransformResponse(ctx context.Context, response *http
 	}
 
 	// Convert Gemini response to internal format
-	return convertGeminiToLLMResponse(&geminiResp, false), nil
+	internalResp := convertGeminiToLLMResponse(&geminiResp, false)
+
+	if internalResp.IsEmpty() {
+		return nil, fmt.Errorf("response content is empty")
+	}
+
+	return internalResp, nil
 }
 
 func (o *MessagesOutbound) TransformStream(ctx context.Context, eventData []byte) (*model.InternalLLMResponse, error) {

--- a/internal/transformer/outbound/openai/chat.go
+++ b/internal/transformer/outbound/openai/chat.go
@@ -71,6 +71,11 @@ func (o *ChatOutbound) TransformResponse(ctx context.Context, response *http.Res
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+
+	if resp.IsEmpty() {
+		return nil, fmt.Errorf("response content is empty")
+	}
+
 	return &resp, nil
 }
 

--- a/internal/transformer/outbound/openai/embedding.go
+++ b/internal/transformer/outbound/openai/embedding.go
@@ -110,6 +110,10 @@ func (o *EmbeddingOutbound) TransformResponse(ctx context.Context, response *htt
 		Usage:         openAIResp.Usage,
 	}
 
+	if resp.IsEmpty() {
+		return nil, fmt.Errorf("response content is empty")
+	}
+
 	return resp, nil
 }
 

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -92,7 +92,13 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 	}
 
 	// Convert to internal response
-	return convertToLLMResponseFromResponses(&resp), nil
+	internalResp := convertToLLMResponseFromResponses(&resp)
+
+	if internalResp.IsEmpty() {
+		return nil, fmt.Errorf("response content is empty")
+	}
+
+	return internalResp, nil
 }
 
 func (o *ResponseOutbound) TransformStream(ctx context.Context, eventData []byte) (*model.InternalLLMResponse, error) {


### PR DESCRIPTION
我遇到某些上游中转，会出现回包不为空(http 200，有json包体)，但是没有实际内容(assistant消息/工具调用)的情况，所以有了这个PR

例如这样的：
```
{
  "id": "chatcmpl-20260226085904630433901GfXOX42G",
  "object": "chat.completion",
  "created": 1772096386,
  "model": "gemini-3-flash-preview",
  "usage": {
    "prompt_tokens": 0,
    "completion_tokens": 0,
    "total_tokens": 0,
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": 0
    },
    "completion_tokens_details": {
      "audio_tokens": 0,
      "reasoning_tokens": 0,
      "accepted_prediction_tokens": 0,
      "rejected_prediction_tokens": 0
    }
  }
}
```

由于流式没办法在转发流量之前判断，所以这个只能覆盖非流式响应