### PR TITLE
Add 'z-ai' prefix to Zhipu model entry

### DIFF
--- a/web/src/lib/model-icons.tsx
+++ b/web/src/lib/model-icons.tsx
@@ -69,7 +69,7 @@ const MODEL_ICON_PATTERNS: ModelIconConfig[] = [
     // Alibaba - Qwen series
     { prefixes: ['qwen', 'qwq', 'alibaba'], Avatar: Qwen.Avatar, color: '#6B4EFF' },
     // Zhipu - GLM series
-    { prefixes: ['glm', 'chatglm', 'zhipu'], Avatar: Zhipu.Avatar, color: '#3C5BFC' },
+    { prefixes: ['glm', 'chatglm', 'zhipu', 'z-ai'], Avatar: Zhipu.Avatar, color: '#3C5BFC' },
     // MiniMax series
     { prefixes: ['minimax', 'abab'], Avatar: Minimax.Avatar, color: '#1A1A2E' },
     // Moonshot/Kimi series


### PR DESCRIPTION
作者你好，部分 API 供应商给智谱国际站添加了 z-ai 的前缀，希望可以加上这个前缀配置。