### PR TITLE
fix: 🐛 API 密钥表单弹窗设置页被截断

### DIFF
--- a/web/src/components/modules/setting/APIKey.tsx
+++ b/web/src/components/modules/setting/APIKey.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { KeyRound, Plus, Loader, Trash2, Check, X, Info, CalendarDays, Pencil, Maximize2 } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
@@ -359,20 +360,30 @@ function APIKeyFormOverlay({
     onSubmit: (data: Omit<APIKey, 'id' | 'api_key'>) => void;
     onClose: () => void;
 }) {
-    return (
-        <motion.div
-            layoutId={layoutId}
-            className="absolute left-1/2 top-1/2 z-20 w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 bg-card p-5 rounded-3xl border border-border max-h-[80vh] overflow-auto"
-            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-        >
-            <APIKeyForm
-                apiKey={apiKey}
-                isPending={isPending}
-                submitLabel={submitLabel}
-                onSubmit={onSubmit}
-                onClose={onClose}
+    return createPortal(
+        <>
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 z-40 bg-black/40"
+                onClick={onClose}
             />
-        </motion.div>
+            <motion.div
+                layoutId={layoutId}
+                className="fixed left-1/2 top-1/2 z-50 w-[min(420px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 bg-card p-5 rounded-3xl border border-border max-h-[80vh] overflow-auto"
+                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+            >
+                <APIKeyForm
+                    apiKey={apiKey}
+                    isPending={isPending}
+                    submitLabel={submitLabel}
+                    onSubmit={onSubmit}
+                    onClose={onClose}
+                />
+            </motion.div>
+        </>,
+        document.body
     );
 }
 
@@ -389,74 +400,85 @@ function APIKeyStatsCard({
     const { data: statsList = [] } = useStatsAPIKey();
     const stats = useMemo(() => statsList.find((s) => s.api_key_id === apiKey.id), [statsList, apiKey.id]);
 
-    return (
-        <motion.div
-            layoutId={layoutId}
-            className="absolute left-1/2 top-1/2 z-30 w-[min(320px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex flex-col bg-card p-5 rounded-3xl border border-border max-h-[80vh] overflow-auto"
-            transition={{ type: 'spring', stiffness: 400, damping: 30 }}
-        >
-            <div className="flex items-center justify-between gap-2 mb-3">
-                <h3 className="text-sm font-semibold text-card-foreground line-clamp-1">
-                    {apiKey.name}
-                </h3>
-                <button
-                    type="button"
-                    onClick={onClose}
-                    className="size-8 flex items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors hover:bg-muted/80"
-                >
-                    <X className="size-4" />
-                </button>
-            </div>
-
-            {!stats ? (
-                <div className="text-sm text-muted-foreground">{t('apiKey.stats.noData')}</div>
-            ) : (
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.inputToken')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.input_token.formatted.value}
-                            {stats.input_token.formatted.unit}
-                        </div>
-                    </div>
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.outputToken')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.output_token.formatted.value}
-                            {stats.output_token.formatted.unit}
-                        </div>
-                    </div>
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.inputCost')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.input_cost.formatted.value}
-                            {stats.input_cost.formatted.unit}
-                        </div>
-                    </div>
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.outputCost')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.output_cost.formatted.value}
-                            {stats.output_cost.formatted.unit}
-                        </div>
-                    </div>
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.requestSuccess')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.request_success.formatted.value}
-                            {stats.request_success.formatted.unit}
-                        </div>
-                    </div>
-                    <div className="rounded-lg bg-muted/40 p-3">
-                        <div className="text-xs text-muted-foreground">{t('apiKey.stats.requestFailed')}</div>
-                        <div className="font-medium tabular-nums">
-                            {stats.request_failed.formatted.value}
-                            {stats.request_failed.formatted.unit}
-                        </div>
-                    </div>
+    return createPortal(
+        <>
+            <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 z-40 bg-black/40"
+                onClick={onClose}
+            />
+            <motion.div
+                layoutId={layoutId}
+                className="fixed left-1/2 top-1/2 z-50 w-[min(320px,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 flex flex-col bg-card p-5 rounded-3xl border border-border max-h-[80vh] overflow-auto"
+                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+            >
+                <div className="flex items-center justify-between gap-2 mb-3">
+                    <h3 className="text-sm font-semibold text-card-foreground line-clamp-1">
+                        {apiKey.name}
+                    </h3>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="size-8 flex items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors hover:bg-muted/80"
+                    >
+                        <X className="size-4" />
+                    </button>
                 </div>
-            )}
-        </motion.div>
+
+                {!stats ? (
+                    <div className="text-sm text-muted-foreground">{t('apiKey.stats.noData')}</div>
+                ) : (
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.inputToken')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.input_token.formatted.value}
+                                {stats.input_token.formatted.unit}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.outputToken')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.output_token.formatted.value}
+                                {stats.output_token.formatted.unit}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.inputCost')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.input_cost.formatted.value}
+                                {stats.input_cost.formatted.unit}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.outputCost')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.output_cost.formatted.value}
+                                {stats.output_cost.formatted.unit}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.requestSuccess')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.request_success.formatted.value}
+                                {stats.request_success.formatted.unit}
+                            </div>
+                        </div>
+                        <div className="rounded-lg bg-muted/40 p-3">
+                            <div className="text-xs text-muted-foreground">{t('apiKey.stats.requestFailed')}</div>
+                            <div className="font-medium tabular-nums">
+                                {stats.request_failed.formatted.value}
+                                {stats.request_failed.formatted.unit}
+                            </div>
+                        </div>
+                    </div>
+                )}
+            </motion.div>
+        </>,
+        document.body
+    
     );
 }
 


### PR DESCRIPTION
<img width="903" height="585" alt="image" src="https://github.com/user-attachments/assets/7213c18c-433e-422d-914f-db737a842547" />
