### PR TITLE
fix: 提取模型名称中的后缀以支持更灵活的匹配 排除模型名称前的渠道商名称

### DIFF
--- a/web/src/lib/model-icons.tsx
+++ b/web/src/lib/model-icons.tsx
@@ -126,7 +126,10 @@ const DEFAULT_CONFIG = { Avatar: OpenAI.Avatar, color: '#10A37F' };
  * @returns Object containing Avatar component and brand color
  */
 export function getModelIcon(modelName: string): { Avatar: AvatarComponent; color: string } {
-    const lowerName = modelName.toLowerCase();
+    // Extract the part after the first '/' if it exists
+    // e.g., "qwen/gpt-5.2" -> "gpt-5.2"
+    const nameToMatch = modelName.includes('/') ? modelName.split('/')[1] : modelName;
+    const lowerName = nameToMatch.toLowerCase();
     for (const { prefixes, Avatar, color } of MODEL_ICON_PATTERNS) {
         if (prefixes.some(prefix => lowerName.startsWith(prefix))) {
             return { Avatar, color };


### PR DESCRIPTION
很多模型名称由第三方转发后一般会以渠道服务商带/开头的来分割模型名称，导致模型icon识别错误，因此 如果模型名称带/应该取/后的模型名称