### PR TITLE
feat: 支持 /v1/responses/compact 独立路由与透传支持

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: master
+          ref: dev
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   packages: write
   
 jobs:
@@ -44,42 +44,16 @@ jobs:
           cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Build
-        run: bash scripts/build.sh release
+        run: |
+          bash scripts/build.sh build linux arm64
+          mkdir -p build/docker/linux/arm64
+          cp build/bin/octopus-linux-arm64 build/docker/linux/arm64/octopus
 
       - name: Get latest tag
         id: tag
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
           echo "TAG_NAME=$LATEST_TAG" >> $GITHUB_OUTPUT
-
-      - name: Upload Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: build/archives/*
-          prerelease: false
-          tag_name: ${{ steps.tag.outputs.TAG_NAME }}
-
-      - name: Docker meta (Debian)
-        id: meta-debian
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
-          tags: |
-            type=raw,value=latest
-            type=raw,value=${{ steps.tag.outputs.TAG_NAME }}
-
-      - name: Docker meta (Alpine)
-        id: meta-alpine
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
-          tags: |
-            type=raw,value=latest-alpine
-            type=raw,value=${{ steps.tag.outputs.TAG_NAME }}-alpine
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -87,39 +61,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push (Alpine)
+      - name: Build and push (Alpine ARM64)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./scripts/dockerfiles/Dockerfile.alpine
           push: true
-          platforms: linux/amd64
-          tags: ${{ steps.meta-alpine.outputs.tags }}
-          labels: ${{ steps.meta-alpine.outputs.labels }}
+          platforms: linux/arm64
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG_NAME }}
           build-args: |
-            TARGETPLATFORM
-
-      - name: Build and push (Debian)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./scripts/dockerfiles/Dockerfile.debian
-          push: true
-          platforms: linux/amd64,linux/i386,linux/arm64,linux/arm/v7
-          tags: ${{ steps.meta-debian.outputs.tags }}
-          labels: ${{ steps.meta-debian.outputs.labels }}
-          build-args: |
-            TARGETPLATFORM
+            TARGETPLATFORM=linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
           context: .
           file: ./scripts/dockerfiles/Dockerfile.alpine
           push: true
-          platforms: linux/amd64,linux/i386,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
           tags: ${{ steps.meta-alpine.outputs.tags }}
           labels: ${{ steps.meta-alpine.outputs.labels }}
           build-args: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: release
 on:
   push:
     branches:
-      - master
       - dev
   workflow_dispatch:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,67 +1,84 @@
-name: docker-image
+name: release
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - dev
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version tag (e.g. v1.0.0), defaults to branch name if empty'
-        required: false
-        default: ''
 
-env:
-  APP_NAME: CLIProxyAPI
-  DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/cli-proxy-api
-
+permissions:
+  contents: read
+  packages: write
+  
 jobs:
-  docker:
+  release:
+    name: release
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
-          ref: main
+          fetch-depth: 0
+          ref: dev
 
-      - name: Refresh models catalog
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+    
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 'latest'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Build
         run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+          bash scripts/build.sh build linux x86_64
+          bash scripts/build.sh build linux arm64
+          mkdir -p build/docker/linux/amd64
+          mkdir -p build/docker/linux/arm64
+          cp build/bin/octopus-linux-x86_64 build/docker/linux/amd64/octopus
+          cp build/bin/octopus-linux-arm64 build/docker/linux/arm64/octopus
 
-      - name: Set up QEMU (for cross-platform emulation)
+      - name: Get latest tag
+        id: tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+          echo "TAG_NAME=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Generate Build Metadata
-        run: |
-          INPUT_VERSION="${{ github.event.inputs.version }}"
-          VERSION="${INPUT_VERSION:-${GITHUB_REF_NAME}}"
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-          echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
-
-      - name: Build and push multi-arch image (amd64 + arm64)
-        uses: docker/build-push-action@v6
+      - name: Build and push (Alpine)
+        uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          file: ./scripts/dockerfiles/Dockerfile.alpine
           push: true
-          provenance: false
-          build-args: |
-            VERSION=${{ env.VERSION }}
-            COMMIT=${{ env.COMMIT }}
-            BUILD_DATE=${{ env.BUILD_DATE }}
+          platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.DOCKERHUB_REPO }}:latest
-            ${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG_NAME }}
+          build-args: |
+            TARGETPLATFORM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,8 +45,11 @@ jobs:
 
       - name: Build
         run: |
+          bash scripts/build.sh build linux x86_64
           bash scripts/build.sh build linux arm64
+          mkdir -p build/docker/linux/amd64
           mkdir -p build/docker/linux/arm64
+          cp build/bin/octopus-linux-x86_64 build/docker/linux/amd64/octopus
           cp build/bin/octopus-linux-arm64 build/docker/linux/arm64/octopus
 
       - name: Get latest tag
@@ -67,15 +70,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push (Alpine ARM64)
+      - name: Build and push (Alpine)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./scripts/dockerfiles/Dockerfile.alpine
           push: true
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG_NAME }}
           build-args: |
-            TARGETPLATFORM=linux/arm64
+            TARGETPLATFORM

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,84 +1,67 @@
-name: release
+name: docker-image
 
 on:
   push:
-    branches:
-      - dev
+    tags:
+      - v*
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v1.0.0), defaults to branch name if empty'
+        required: false
+        default: ''
 
-permissions:
-  contents: read
-  packages: write
-  
+env:
+  APP_NAME: CLIProxyAPI
+  DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/cli-proxy-api
+
 jobs:
-  release:
-    name: release
+  docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: dev
+          ref: main
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 'stable'
-    
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 'latest'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'latest'
-          cache: 'pnpm'
-          cache-dependency-path: web/pnpm-lock.yaml
-
-      - name: Build
+      - name: Refresh models catalog
         run: |
-          bash scripts/build.sh build linux x86_64
-          bash scripts/build.sh build linux arm64
-          mkdir -p build/docker/linux/amd64
-          mkdir -p build/docker/linux/arm64
-          cp build/bin/octopus-linux-x86_64 build/docker/linux/amd64/octopus
-          cp build/bin/octopus-linux-arm64 build/docker/linux/arm64/octopus
+          git fetch --depth 1 https://github.com/router-for-me/models.git main
+          git show FETCH_HEAD:models.json > internal/registry/models/models.json
 
-      - name: Get latest tag
-        id: tag
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
-          echo "TAG_NAME=$LATEST_TAG" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
+      - name: Set up QEMU (for cross-platform emulation)
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push (Alpine)
-        uses: docker/build-push-action@v5
+      - name: Generate Build Metadata
+        run: |
+          INPUT_VERSION="${{ github.event.inputs.version }}"
+          VERSION="${INPUT_VERSION:-${GITHUB_REF_NAME}}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      - name: Build and push multi-arch image (amd64 + arm64)
+        uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./scripts/dockerfiles/Dockerfile.alpine
-          push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.tag.outputs.TAG_NAME }}
+          push: true
+          provenance: false
           build-args: |
-            TARGETPLATFORM
+            VERSION=${{ env.VERSION }}
+            COMMIT=${{ env.COMMIT }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+          tags: |
+            ${{ env.DOCKERHUB_REPO }}:latest
+            ${{ env.DOCKERHUB_REPO }}:${{ env.VERSION }}

--- a/internal/relay/balancer/balancer.go
+++ b/internal/relay/balancer/balancer.go
@@ -85,7 +85,8 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 
 	// 构建智能择优排序：
 	// score = 手动权重(30%) + 近1h成功率(50%) + 近24h成功率(20%)
-	// 若近1h有失败记录，则对1h分量做 /3 惩罚，快速压低短时不稳定通道。
+	// 若近1h有失败记录，则对1h分量按 smartOneHourPenaltyDivisor（当前为 3.0）做除法惩罚，
+	// 以快速压低短时不稳定通道。
 	// 同分时按权重、优先级稳定排序，避免抖动。
 	type scoredItem struct {
 		item   model.GroupItem

--- a/internal/relay/balancer/balancer.go
+++ b/internal/relay/balancer/balancer.go
@@ -9,15 +9,6 @@ import (
 )
 
 var roundRobinCounter uint64
-var weightedDiversifyCounter uint64
-
-const (
-	// smartDiversifyMaxCandidates 限制接近最优分数的轮转范围，避免扩大到长尾候选。
-	smartDiversifyMaxCandidates = 3
-	// smartDiversifyScoreThreshold 定义“接近最优”的分数差阈值。
-	smartDiversifyScoreThreshold = 0.05
-)
-
 // Balancer 根据负载均衡模式选择通道
 type Balancer interface {
 	// Candidates 返回按策略排序的候选列表
@@ -93,7 +84,8 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 	}
 
 	// 构建智能择优排序：
-	// score = 手动权重(30%) + 近1h成功率(40%) + 近24h成功率(30%)
+	// score = 手动权重(30%) + 近1h成功率(50%) + 近24h成功率(20%)
+	// 若近1h有失败记录，则对1h分量做 /3 惩罚，快速压低短时不稳定通道。
 	// 同分时按权重、优先级稳定排序，避免抖动。
 	type scoredItem struct {
 		item   model.GroupItem
@@ -116,9 +108,13 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 			w = 1
 		}
 		manualWeight := float64(w) / totalWeight
-		success1h, total1h, success24h := getSmartSuccessRates(item.ChannelID, item.ModelName)
+		success1h, total1h, fail1h, success24h := getSmartSuccessRates(item.ChannelID, item.ModelName)
 		effective1hWeight, effective24hWeight := smartDynamicWeights(total1h)
-		score := smartWeightManual*manualWeight + effective1hWeight*success1h + effective24hWeight*success24h
+		oneHourComponent := effective1hWeight * success1h
+		if fail1h > 0 {
+			oneHourComponent /= smartOneHourPenaltyDivisor
+		}
+		score := smartWeightManual*manualWeight + oneHourComponent + effective24hWeight*success24h
 		scored[i] = scoredItem{item: item, score: score}
 	}
 
@@ -138,27 +134,6 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 		}
 		return scored[i].item.ModelName < scored[j].item.ModelName
 	})
-
-	// 轻量多站点分流：在“接近最优分数”的头部候选中做轮转，避免单点过热。
-	if n > 1 {
-		limit := 1
-		topScore := scored[0].score
-		for limit < n && limit < smartDiversifyMaxCandidates {
-			if topScore-scored[limit].score > smartDiversifyScoreThreshold {
-				break
-			}
-			limit++
-		}
-		if limit > 1 {
-			offset := int(atomic.AddUint64(&weightedDiversifyCounter, 1) % uint64(limit))
-			if offset > 0 {
-				head := append([]scoredItem(nil), scored[:limit]...)
-				for i := 0; i < limit; i++ {
-					scored[i] = head[(i+offset)%limit]
-				}
-			}
-		}
-	}
 
 	result := make([]model.GroupItem, n)
 	for i := range scored {

--- a/internal/relay/balancer/balancer.go
+++ b/internal/relay/balancer/balancer.go
@@ -9,6 +9,14 @@ import (
 )
 
 var roundRobinCounter uint64
+var weightedDiversifyCounter uint64
+
+const (
+	// smartDiversifyMaxCandidates 限制接近最优分数的轮转范围，避免扩大到长尾候选。
+	smartDiversifyMaxCandidates = 3
+	// smartDiversifyScoreThreshold 定义“接近最优”的分数差阈值。
+	smartDiversifyScoreThreshold = 0.05
+)
 
 // Balancer 根据负载均衡模式选择通道
 type Balancer interface {
@@ -75,7 +83,7 @@ func (b *Failover) Candidates(items []model.GroupItem) []model.GroupItem {
 	return sortByPriority(items)
 }
 
-// Weighted 加权分配：按权重概率排序
+// Weighted 加权分配：按综合评分择优
 type Weighted struct{}
 
 func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
@@ -84,7 +92,7 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 		return nil
 	}
 
-	// 构建智能优选排序：
+	// 构建智能择优排序：
 	// score = 手动权重(30%) + 近1h成功率(40%) + 近24h成功率(30%)
 	// 同分时按权重、优先级稳定排序，避免抖动。
 	type scoredItem struct {
@@ -108,8 +116,9 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 			w = 1
 		}
 		manualWeight := float64(w) / totalWeight
-		success1h, success24h := getSmartSuccessRates(item.ChannelID, item.ModelName)
-		score := smartWeightManual*manualWeight + smartWeight1h*success1h + smartWeight24h*success24h
+		success1h, total1h, success24h := getSmartSuccessRates(item.ChannelID, item.ModelName)
+		effective1hWeight, effective24hWeight := smartDynamicWeights(total1h)
+		score := smartWeightManual*manualWeight + effective1hWeight*success1h + effective24hWeight*success24h
 		scored[i] = scoredItem{item: item, score: score}
 	}
 
@@ -129,6 +138,27 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 		}
 		return scored[i].item.ModelName < scored[j].item.ModelName
 	})
+
+	// 轻量多站点分流：在“接近最优分数”的头部候选中做轮转，避免单点过热。
+	if n > 1 {
+		limit := 1
+		topScore := scored[0].score
+		for limit < n && limit < smartDiversifyMaxCandidates {
+			if topScore-scored[limit].score > smartDiversifyScoreThreshold {
+				break
+			}
+			limit++
+		}
+		if limit > 1 {
+			offset := int(atomic.AddUint64(&weightedDiversifyCounter, 1) % uint64(limit))
+			if offset > 0 {
+				head := append([]scoredItem(nil), scored[:limit]...)
+				for i := 0; i < limit; i++ {
+					scored[i] = head[(i+offset)%limit]
+				}
+			}
+		}
+	}
 
 	result := make([]model.GroupItem, n)
 	for i := range scored {

--- a/internal/relay/balancer/balancer.go
+++ b/internal/relay/balancer/balancer.go
@@ -84,37 +84,50 @@ func (b *Weighted) Candidates(items []model.GroupItem) []model.GroupItem {
 		return nil
 	}
 
-	// 构建加权随机排序
-	type weightedItem struct {
+	// 构建智能优选排序：
+	// score = 手动权重(30%) + 近1h成功率(40%) + 近24h成功率(30%)
+	// 同分时按权重、优先级稳定排序，避免抖动。
+	type scoredItem struct {
 		item   model.GroupItem
 		score  float64
 	}
 
-	totalWeight := 0
+	totalWeight := 0.0
 	for _, item := range items {
 		w := item.Weight
 		if w <= 0 {
 			w = 1
 		}
-		totalWeight += w
+		totalWeight += float64(w)
 	}
 
-	scored := make([]weightedItem, n)
+	scored := make([]scoredItem, n)
 	for i, item := range items {
 		w := item.Weight
 		if w <= 0 {
 			w = 1
 		}
-		// 给每个 item 一个加权随机分数：weight/totalWeight 作为概率基础，加上随机扰动
-		scored[i] = weightedItem{
-			item:  item,
-			score: rand.Float64() * float64(w) / float64(totalWeight),
-		}
+		manualWeight := float64(w) / totalWeight
+		success1h, success24h := getSmartSuccessRates(item.ChannelID, item.ModelName)
+		score := smartWeightManual*manualWeight + smartWeight1h*success1h + smartWeight24h*success24h
+		scored[i] = scoredItem{item: item, score: score}
 	}
 
 	// 按分数降序排列（分数越高优先级越高）
 	sort.Slice(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		if scored[i].item.Weight != scored[j].item.Weight {
+			return scored[i].item.Weight > scored[j].item.Weight
+		}
+		if scored[i].item.Priority != scored[j].item.Priority {
+			return scored[i].item.Priority < scored[j].item.Priority
+		}
+		if scored[i].item.ChannelID != scored[j].item.ChannelID {
+			return scored[i].item.ChannelID < scored[j].item.ChannelID
+		}
+		return scored[i].item.ModelName < scored[j].item.ModelName
 	})
 
 	result := make([]model.GroupItem, n)

--- a/internal/relay/balancer/balancer_test.go
+++ b/internal/relay/balancer/balancer_test.go
@@ -1,0 +1,62 @@
+package balancer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/model"
+)
+
+func TestWeightedCandidates_PrioritizesHealthAndWeight(t *testing.T) {
+	t.Cleanup(resetSmartStatsForTest)
+
+	base := time.Unix(0, 0).UTC()
+	smartNowFunc = func() time.Time { return base }
+	t.Cleanup(func() { smartNowFunc = time.Now })
+
+	items := []model.GroupItem{
+		{ChannelID: 1, ModelName: "m", Weight: 100, Priority: 10},
+		{ChannelID: 2, ModelName: "m", Weight: 10, Priority: 10},
+	}
+
+	// channel 1: recent failures dominate
+	for i := 0; i < 20; i++ {
+		recordSmartOutcome(1, "m", false)
+	}
+	for i := 0; i < 2; i++ {
+		recordSmartOutcome(1, "m", true)
+	}
+
+	// channel 2: mostly healthy
+	for i := 0; i < 20; i++ {
+		recordSmartOutcome(2, "m", true)
+	}
+	for i := 0; i < 1; i++ {
+		recordSmartOutcome(2, "m", false)
+	}
+
+	got := (&Weighted{}).Candidates(items)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(got))
+	}
+	if got[0].ChannelID != 2 {
+		t.Fatalf("expected healthier channel first, got channel %d", got[0].ChannelID)
+	}
+}
+
+func TestWeightedCandidates_UsesManualWeightWhenNoStats(t *testing.T) {
+	t.Cleanup(resetSmartStatsForTest)
+
+	items := []model.GroupItem{
+		{ChannelID: 1, ModelName: "m", Weight: 5, Priority: 10},
+		{ChannelID: 2, ModelName: "m", Weight: 50, Priority: 10},
+	}
+
+	got := (&Weighted{}).Candidates(items)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(got))
+	}
+	if got[0].ChannelID != 2 {
+		t.Fatalf("expected higher manual weight first when no stats, got channel %d", got[0].ChannelID)
+	}
+}

--- a/internal/relay/balancer/balancer_test.go
+++ b/internal/relay/balancer/balancer_test.go
@@ -60,3 +60,69 @@ func TestWeightedCandidates_UsesManualWeightWhenNoStats(t *testing.T) {
 		t.Fatalf("expected higher manual weight first when no stats, got channel %d", got[0].ChannelID)
 	}
 }
+
+func TestWeightedCandidates_Reduces1hImpactWhenSamplesLow(t *testing.T) {
+	t.Cleanup(resetSmartStatsForTest)
+	base := time.Unix(120*60, 0).UTC()
+	smartNowFunc = func() time.Time { return base }
+	t.Cleanup(func() { smartNowFunc = time.Now })
+
+	// channel 1: higher manual weight, mediocre 24h, tiny 1h sample with perfect success
+	for i := 0; i < 60; i++ {
+		recordSmartOutcome(1, "m", true)
+	}
+	for i := 0; i < 60; i++ {
+		recordSmartOutcome(1, "m", false)
+	}
+	for i := 0; i < 5; i++ {
+		recordSmartOutcome(1, "m", true)
+	}
+
+	// channel 2: lower manual weight, good 24h, tiny 1h sample with complete failure
+	for i := 0; i < 120; i++ {
+		recordSmartOutcome(2, "m", true)
+	}
+	for i := 0; i < 5; i++ {
+		recordSmartOutcome(2, "m", false)
+	}
+
+	items := []model.GroupItem{
+		{ChannelID: 1, ModelName: "m", Weight: 70, Priority: 10},
+		{ChannelID: 2, ModelName: "m", Weight: 30, Priority: 10},
+	}
+	got := (&Weighted{}).Candidates(items)
+	if got[0].ChannelID != 2 {
+		t.Fatalf("expected channel 2 first due to stronger long-window health with low 1h samples, got %d", got[0].ChannelID)
+	}
+}
+
+func TestWeightedCandidates_DiversifiesTopStableCandidates(t *testing.T) {
+	t.Cleanup(resetSmartStatsForTest)
+	base := time.Unix(120*60, 0).UTC()
+	smartNowFunc = func() time.Time { return base }
+	t.Cleanup(func() { smartNowFunc = time.Now })
+
+	weightedDiversifyCounter = 0
+
+	for _, ch := range []int{1, 2, 3} {
+		for i := 0; i < 50; i++ {
+			recordSmartOutcome(ch, "m", true)
+		}
+	}
+
+	items := []model.GroupItem{
+		{ChannelID: 1, ModelName: "m", Weight: 100, Priority: 10},
+		{ChannelID: 2, ModelName: "m", Weight: 100, Priority: 10},
+		{ChannelID: 3, ModelName: "m", Weight: 100, Priority: 10},
+	}
+
+	firstSeen := map[int]bool{}
+	w := &Weighted{}
+	for i := 0; i < 3; i++ {
+		got := w.Candidates(items)
+		firstSeen[got[0].ChannelID] = true
+	}
+	if len(firstSeen) < 2 {
+		t.Fatalf("expected diversified first candidate across stable top set, got %v", firstSeen)
+	}
+}

--- a/internal/relay/balancer/balancer_test.go
+++ b/internal/relay/balancer/balancer_test.go
@@ -96,13 +96,39 @@ func TestWeightedCandidates_Reduces1hImpactWhenSamplesLow(t *testing.T) {
 	}
 }
 
-func TestWeightedCandidates_DiversifiesTopStableCandidates(t *testing.T) {
+func TestWeightedCandidates_PenalizesOneHourComponentWhenRecentFailuresExist(t *testing.T) {
+	t.Cleanup(resetSmartStatsForTest)
+	base := time.Unix(240*60, 0).UTC()
+	smartNowFunc = func() time.Time { return base }
+	t.Cleanup(func() { smartNowFunc = time.Now })
+
+	// Same manual weight and nearly same 24h health.
+	// Channel 1 has one recent 1h failure, so its 1h component should be divided by 3.
+	for i := 0; i < 30; i++ {
+		recordSmartOutcome(1, "m", true)
+	}
+	recordSmartOutcome(1, "m", false)
+
+	for i := 0; i < 30; i++ {
+		recordSmartOutcome(2, "m", true)
+	}
+
+	items := []model.GroupItem{
+		{ChannelID: 1, ModelName: "m", Weight: 50, Priority: 10},
+		{ChannelID: 2, ModelName: "m", Weight: 50, Priority: 10},
+	}
+
+	got := (&Weighted{}).Candidates(items)
+	if got[0].ChannelID != 2 {
+		t.Fatalf("expected channel 2 first because channel 1 has 1h failure penalty, got %d", got[0].ChannelID)
+	}
+}
+
+func TestWeightedCandidates_StableTopOrderWithoutDiversifyRotation(t *testing.T) {
 	t.Cleanup(resetSmartStatsForTest)
 	base := time.Unix(120*60, 0).UTC()
 	smartNowFunc = func() time.Time { return base }
 	t.Cleanup(func() { smartNowFunc = time.Now })
-
-	weightedDiversifyCounter = 0
 
 	for _, ch := range []int{1, 2, 3} {
 		for i := 0; i < 50; i++ {
@@ -116,13 +142,11 @@ func TestWeightedCandidates_DiversifiesTopStableCandidates(t *testing.T) {
 		{ChannelID: 3, ModelName: "m", Weight: 100, Priority: 10},
 	}
 
-	firstSeen := map[int]bool{}
 	w := &Weighted{}
 	for i := 0; i < 3; i++ {
 		got := w.Candidates(items)
-		firstSeen[got[0].ChannelID] = true
-	}
-	if len(firstSeen) < 2 {
-		t.Fatalf("expected diversified first candidate across stable top set, got %v", firstSeen)
+		if got[0].ChannelID != 1 {
+			t.Fatalf("expected stable deterministic top candidate channel 1, got %d", got[0].ChannelID)
+		}
 	}
 }

--- a/internal/relay/balancer/balancer_test.go
+++ b/internal/relay/balancer/balancer_test.go
@@ -143,10 +143,11 @@ func TestWeightedCandidates_StableTopOrderWithoutDiversifyRotation(t *testing.T)
 	}
 
 	w := &Weighted{}
+	expectedTopID := 1 // all scores tie; deterministic tiebreakers pick the smallest ChannelID first.
 	for i := 0; i < 3; i++ {
 		got := w.Candidates(items)
-		if got[0].ChannelID != 1 {
-			t.Fatalf("expected stable deterministic top candidate channel 1, got %d", got[0].ChannelID)
+		if got[0].ChannelID != expectedTopID {
+			t.Fatalf("expected stable deterministic top candidate channel %d, got %d", expectedTopID, got[0].ChannelID)
 		}
 	}
 }

--- a/internal/relay/balancer/compact.go
+++ b/internal/relay/balancer/compact.go
@@ -1,0 +1,54 @@
+package balancer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type compactUnsupportedEntry struct {
+	Timestamp time.Time
+}
+
+var (
+	compactUnsupportedCache sync.Map
+	compactUnsupportedTTL   = defaultCompactUnsupportedTTL
+)
+
+const defaultCompactUnsupportedTTL = 10 * time.Minute
+
+func compactUnsupportedKey(channelID int, modelName string) string {
+	return fmt.Sprintf("%d:%s", channelID, modelName)
+}
+
+// IsCompactUnsupported reports whether channel/model is temporarily marked as
+// not supporting /responses/compact.
+func IsCompactUnsupported(channelID int, modelName string) (unsupported bool, remaining time.Duration) {
+	key := compactUnsupportedKey(channelID, modelName)
+	v, ok := compactUnsupportedCache.Load(key)
+	if !ok {
+		return false, 0
+	}
+	entry := v.(*compactUnsupportedEntry)
+	elapsed := time.Since(entry.Timestamp)
+	if elapsed >= compactUnsupportedTTL {
+		compactUnsupportedCache.Delete(key)
+		return false, 0
+	}
+	return true, compactUnsupportedTTL - elapsed
+}
+
+// MarkCompactUnsupported marks channel/model as temporarily incompatible with
+// /responses/compact.
+func MarkCompactUnsupported(channelID int, modelName string) {
+	key := compactUnsupportedKey(channelID, modelName)
+	compactUnsupportedCache.Store(key, &compactUnsupportedEntry{
+		Timestamp: time.Now(),
+	})
+}
+
+// MarkCompactSupported clears temporary incompatibility marker.
+func MarkCompactSupported(channelID int, modelName string) {
+	key := compactUnsupportedKey(channelID, modelName)
+	compactUnsupportedCache.Delete(key)
+}

--- a/internal/relay/balancer/smart.go
+++ b/internal/relay/balancer/smart.go
@@ -10,12 +10,13 @@ const (
 	smartStatsBuckets = 24 * 60
 
 	smartWeightManual = 0.30
-	smartWeight1h     = 0.40
-	smartWeight24h    = 0.30
+	smartWeight1h     = 0.50
+	smartWeight24h    = 0.20
 	smart1hMinSamples = 20
 
 	smartRatePriorSuccess = 1.0
 	smartRatePriorFailure = 1.0
+	smartOneHourPenaltyDivisor = 3.0
 )
 
 type smartMinuteBucket struct {
@@ -61,12 +62,12 @@ func RecordSmartOutcome(channelID int, modelName string, success bool) {
 	recordSmartOutcome(channelID, modelName, success)
 }
 
-func getSmartSuccessRates(channelID int, modelName string) (float64, int64, float64) {
+func getSmartSuccessRates(channelID int, modelName string) (float64, int64, int64, float64) {
 	stats := getOrCreateSmartStats(channelID, modelName)
 	now := smartNowFunc()
-	rate1h, total1h := stats.successRate(now, 60)
-	rate24h, _ := stats.successRate(now, 24*60)
-	return rate1h, total1h, rate24h
+	rate1h, total1h, fail1h := stats.successRate(now, 60)
+	rate24h, _, _ := stats.successRate(now, 24*60)
+	return rate1h, total1h, fail1h, rate24h
 }
 
 func smartDynamicWeights(total1h int64) (float64, float64) {
@@ -99,9 +100,10 @@ func (s *smartRollingStats) add(now time.Time, success bool) {
 	b.failure++
 }
 
-func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) (float64, int64) {
+func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) (float64, int64, int64) {
 	currentMinute := now.Unix() / 60
 	var successCount int64
+	var failureCount int64
 	var totalCount int64
 
 	s.mu.Lock()
@@ -115,11 +117,12 @@ func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) (float
 			continue
 		}
 		successCount += int64(b.success)
+		failureCount += int64(b.failure)
 		totalCount += int64(b.success + b.failure)
 	}
 
 	rate := (float64(successCount) + smartRatePriorSuccess) / (float64(totalCount) + smartRatePriorSuccess + smartRatePriorFailure)
-	return rate, totalCount
+	return rate, totalCount, failureCount
 }
 
 func smartBucketIndex(minute int64) int {

--- a/internal/relay/balancer/smart.go
+++ b/internal/relay/balancer/smart.go
@@ -12,6 +12,7 @@ const (
 	smartWeightManual = 0.30
 	smartWeight1h     = 0.40
 	smartWeight24h    = 0.30
+	smart1hMinSamples = 20
 
 	smartRatePriorSuccess = 1.0
 	smartRatePriorFailure = 1.0
@@ -60,18 +61,27 @@ func RecordSmartOutcome(channelID int, modelName string, success bool) {
 	recordSmartOutcome(channelID, modelName, success)
 }
 
-func getSmartSuccessRates(channelID int, modelName string) (float64, float64) {
+func getSmartSuccessRates(channelID int, modelName string) (float64, int64, float64) {
 	stats := getOrCreateSmartStats(channelID, modelName)
 	now := smartNowFunc()
-	return stats.successRate(now, 60), stats.successRate(now, 24*60)
+	rate1h, total1h := stats.successRate(now, 60)
+	rate24h, _ := stats.successRate(now, 24*60)
+	return rate1h, total1h, rate24h
+}
+
+func smartDynamicWeights(total1h int64) (float64, float64) {
+	if total1h >= smart1hMinSamples {
+		return smartWeight1h, smartWeight24h
+	}
+	scale := float64(total1h) / float64(smart1hMinSamples)
+	effective1h := smartWeight1h * scale
+	effective24h := smartWeight24h + (smartWeight1h - effective1h)
+	return effective1h, effective24h
 }
 
 func (s *smartRollingStats) add(now time.Time, success bool) {
 	minute := now.Unix() / 60
-	idx := int(minute % smartStatsBuckets)
-	if idx < 0 {
-		idx += smartStatsBuckets
-	}
+	idx := smartBucketIndex(minute)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -89,7 +99,7 @@ func (s *smartRollingStats) add(now time.Time, success bool) {
 	b.failure++
 }
 
-func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) float64 {
+func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) (float64, int64) {
 	currentMinute := now.Unix() / 60
 	var successCount int64
 	var totalCount int64
@@ -99,10 +109,7 @@ func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) float6
 
 	for i := 0; i < windowMinutes; i++ {
 		minute := currentMinute - int64(i)
-		idx := int(minute % smartStatsBuckets)
-		if idx < 0 {
-			idx += smartStatsBuckets
-		}
+		idx := smartBucketIndex(minute)
 		b := s.buckets[idx]
 		if b.minute != minute {
 			continue
@@ -111,7 +118,16 @@ func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) float6
 		totalCount += int64(b.success + b.failure)
 	}
 
-	return (float64(successCount) + smartRatePriorSuccess) / (float64(totalCount) + smartRatePriorSuccess + smartRatePriorFailure)
+	rate := (float64(successCount) + smartRatePriorSuccess) / (float64(totalCount) + smartRatePriorSuccess + smartRatePriorFailure)
+	return rate, totalCount
+}
+
+func smartBucketIndex(minute int64) int {
+	idx := int(minute % smartStatsBuckets)
+	if idx < 0 {
+		idx += smartStatsBuckets
+	}
+	return idx
 }
 
 func resetSmartStatsForTest() {

--- a/internal/relay/balancer/smart.go
+++ b/internal/relay/balancer/smart.go
@@ -133,6 +133,7 @@ func smartBucketIndex(minute int64) int {
 	return idx
 }
 
+// resetSmartStatsForTest clears all in-memory smart routing stats; test-only helper.
 func resetSmartStatsForTest() {
 	smartChannelStats = sync.Map{}
 }

--- a/internal/relay/balancer/smart.go
+++ b/internal/relay/balancer/smart.go
@@ -1,0 +1,119 @@
+package balancer
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	smartStatsBuckets = 24 * 60
+
+	smartWeightManual = 0.30
+	smartWeight1h     = 0.40
+	smartWeight24h    = 0.30
+
+	smartRatePriorSuccess = 1.0
+	smartRatePriorFailure = 1.0
+)
+
+type smartMinuteBucket struct {
+	minute  int64
+	success uint32
+	failure uint32
+}
+
+type smartRollingStats struct {
+	mu      sync.Mutex
+	buckets [smartStatsBuckets]smartMinuteBucket
+}
+
+var (
+	smartChannelStats sync.Map // key: channelID:modelName -> *smartRollingStats
+	smartNowFunc      = time.Now
+)
+
+func smartStatsKey(channelID int, modelName string) string {
+	return fmt.Sprintf("%d:%s", channelID, modelName)
+}
+
+func getOrCreateSmartStats(channelID int, modelName string) *smartRollingStats {
+	key := smartStatsKey(channelID, modelName)
+	if v, ok := smartChannelStats.Load(key); ok {
+		return v.(*smartRollingStats)
+	}
+	entry := &smartRollingStats{}
+	actual, _ := smartChannelStats.LoadOrStore(key, entry)
+	return actual.(*smartRollingStats)
+}
+
+func recordSmartOutcome(channelID int, modelName string, success bool) {
+	if channelID <= 0 || modelName == "" {
+		return
+	}
+	stats := getOrCreateSmartStats(channelID, modelName)
+	stats.add(smartNowFunc(), success)
+}
+
+// RecordSmartOutcome records per-channel per-model request outcomes for smart weighted selection.
+func RecordSmartOutcome(channelID int, modelName string, success bool) {
+	recordSmartOutcome(channelID, modelName, success)
+}
+
+func getSmartSuccessRates(channelID int, modelName string) (float64, float64) {
+	stats := getOrCreateSmartStats(channelID, modelName)
+	now := smartNowFunc()
+	return stats.successRate(now, 60), stats.successRate(now, 24*60)
+}
+
+func (s *smartRollingStats) add(now time.Time, success bool) {
+	minute := now.Unix() / 60
+	idx := int(minute % smartStatsBuckets)
+	if idx < 0 {
+		idx += smartStatsBuckets
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b := &s.buckets[idx]
+	if b.minute != minute {
+		b.minute = minute
+		b.success = 0
+		b.failure = 0
+	}
+	if success {
+		b.success++
+		return
+	}
+	b.failure++
+}
+
+func (s *smartRollingStats) successRate(now time.Time, windowMinutes int) float64 {
+	currentMinute := now.Unix() / 60
+	var successCount int64
+	var totalCount int64
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := 0; i < windowMinutes; i++ {
+		minute := currentMinute - int64(i)
+		idx := int(minute % smartStatsBuckets)
+		if idx < 0 {
+			idx += smartStatsBuckets
+		}
+		b := s.buckets[idx]
+		if b.minute != minute {
+			continue
+		}
+		successCount += int64(b.success)
+		totalCount += int64(b.success + b.failure)
+	}
+
+	return (float64(successCount) + smartRatePriorSuccess) / (float64(totalCount) + smartRatePriorSuccess + smartRatePriorFailure)
+}
+
+func resetSmartStatsForTest() {
+	smartChannelStats = sync.Map{}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -301,6 +301,24 @@ func containsAny(msg string, patterns ...string) bool {
 	return false
 }
 
+func formatUpstreamErrorMessage(isCompact bool, requestModel, routedModel, endpointPath string, statusCode int, body []byte) string {
+	base := fmt.Sprintf("upstream error: %d: %s", statusCode, string(body))
+	if !isCompact {
+		return base
+	}
+
+	parts := []string{
+		fmt.Sprintf("request_model=%q", requestModel),
+		fmt.Sprintf("routed_model=%q", routedModel),
+		fmt.Sprintf("endpoint=%q", endpointPath),
+	}
+	bodyText := strings.ToLower(string(body))
+	if strings.Contains(bodyText, "-openai-compact") {
+		parts = append(parts, `note="upstream provider may internally map compact endpoint models to *-openai-compact aliases"`)
+	}
+	return fmt.Sprintf("%s [compact relay context: %s]", base, strings.Join(parts, ", "))
+}
+
 // parseRequest 解析并验证入站请求
 func parseRequest(inboundType inbound.InboundType, c *gin.Context) (*model.InternalLLMRequest, model.Inbound, error) {
 	body, err := io.ReadAll(c.Request.Body)
@@ -359,7 +377,14 @@ func (ra *relayAttempt) forward() (int, error) {
 		if err != nil {
 			return 0, fmt.Errorf("failed to read response body: %w", err)
 		}
-		return 0, fmt.Errorf("upstream error: %d: %s", response.StatusCode, string(body))
+		return 0, fmt.Errorf("%s", formatUpstreamErrorMessage(
+			ra.isCompact,
+			ra.requestModel,
+			ra.internalRequest.Model,
+			outboundRequest.URL.Path,
+			response.StatusCode,
+			body,
+		))
 	}
 
 	// 处理响应

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -22,6 +22,11 @@ import (
 	"github.com/tmaxmax/go-sse"
 )
 
+const (
+	ResponsesEndpointContextKey = "responses_endpoint"
+	ResponsesEndpointCompact    = "compact"
+)
+
 // Handler 处理入站请求并转发到上游服务
 func Handler(inboundType inbound.InboundType, c *gin.Context) {
 	// 解析请求
@@ -108,7 +113,7 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 
 		// 出站适配器
 		outAdapter := outbound.Get(channel.Type)
-		if endpoint, ok := c.Get("responses_endpoint"); ok && endpoint == "compact" {
+		if endpoint, ok := c.Get(ResponsesEndpointContextKey); ok && endpoint == ResponsesEndpointCompact {
 			if inboundType == inbound.InboundTypeOpenAIResponse && channel.Type == outbound.OutboundTypeOpenAIResponse {
 				outAdapter = outbound.NewOpenAICompactResponse()
 			}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -114,7 +114,8 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 		// 出站适配器
 		outAdapter := outbound.Get(channel.Type)
 		if endpoint, ok := c.Get(ResponsesEndpointContextKey); ok && endpoint == ResponsesEndpointCompact {
-			if inboundType == inbound.InboundTypeOpenAIResponse && channel.Type == outbound.OutboundTypeOpenAIResponse {
+			isOpenAIResponsesFlow := inboundType == inbound.InboundTypeOpenAIResponse && channel.Type == outbound.OutboundTypeOpenAIResponse
+			if isOpenAIResponsesFlow {
 				outAdapter = outbound.NewOpenAICompactResponse()
 			}
 		}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -108,6 +108,11 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 
 		// 出站适配器
 		outAdapter := outbound.Get(channel.Type)
+		if endpoint, ok := c.Get("responses_endpoint"); ok && endpoint == "compact" {
+			if inboundType == inbound.InboundTypeOpenAIResponse && channel.Type == outbound.OutboundTypeOpenAIResponse {
+				outAdapter = outbound.NewOpenAICompactResponse()
+			}
+		}
 		if outAdapter == nil {
 			iter.Skip(channel.ID, usedKey.ID, channel.Name, fmt.Sprintf("unsupported channel type: %d", channel.Type))
 			continue

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -114,6 +114,10 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 		// 出站适配器
 		outAdapter := outbound.Get(channel.Type)
 		if endpoint, ok := c.Get(ResponsesEndpointContextKey); ok && endpoint == ResponsesEndpointCompact {
+			if channel.Type != outbound.OutboundTypeOpenAIResponse {
+				iter.Skip(channel.ID, usedKey.ID, channel.Name, "channel type not compatible with compact request")
+				continue
+			}
 			isOpenAIResponsesFlow := inboundType == inbound.InboundTypeOpenAIResponse && channel.Type == outbound.OutboundTypeOpenAIResponse
 			if isOpenAIResponsesFlow {
 				outAdapter = outbound.NewOpenAICompactResponse()

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -211,6 +211,7 @@ func (ra *relayAttempt) attempt() attemptResult {
 
 		// 熔断器：记录成功
 		balancer.RecordSuccess(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
+		balancer.RecordSmartOutcome(ra.channel.ID, ra.internalRequest.Model, true)
 		// 会话保持：更新粘性记录
 		balancer.SetSticky(ra.apiKeyID, ra.requestModel, ra.channel.ID, ra.usedKey.ID)
 		if ra.isCompact {
@@ -232,6 +233,7 @@ func (ra *relayAttempt) attempt() attemptResult {
 
 	// 熔断器：记录失败
 	balancer.RecordFailure(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
+	balancer.RecordSmartOutcome(ra.channel.ID, ra.internalRequest.Model, false)
 	if ra.isCompact && shouldMarkCompactUnsupported(fwdErr) {
 		balancer.MarkCompactUnsupported(ra.channel.ID, ra.internalRequest.Model)
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -73,6 +73,9 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 		requestModel:    requestModel,
 		iter:            iter,
 	}
+	if endpoint, ok := c.Get(ResponsesEndpointContextKey); ok && endpoint == ResponsesEndpointCompact {
+		req.isCompact = true
+	}
 
 	var lastErr error
 
@@ -109,6 +112,16 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 		// 熔断检查
 		if iter.SkipCircuitBreak(channel.ID, usedKey.ID, channel.Name) {
 			continue
+		}
+		if req.isCompact {
+			if unsupported, remaining := balancer.IsCompactUnsupported(channel.ID, item.ModelName); unsupported {
+				msg := "compact endpoint unsupported"
+				if remaining > 0 {
+					msg = fmt.Sprintf("compact endpoint unsupported, remaining cooldown: %ds", int(remaining.Seconds()))
+				}
+				iter.Skip(channel.ID, usedKey.ID, channel.Name, msg)
+				continue
+			}
 		}
 
 		// 出站适配器
@@ -200,6 +213,9 @@ func (ra *relayAttempt) attempt() attemptResult {
 		balancer.RecordSuccess(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
 		// 会话保持：更新粘性记录
 		balancer.SetSticky(ra.apiKeyID, ra.requestModel, ra.channel.ID, ra.usedKey.ID)
+		if ra.isCompact {
+			balancer.MarkCompactSupported(ra.channel.ID, ra.internalRequest.Model)
+		}
 
 		return attemptResult{Success: true}
 	}
@@ -216,6 +232,9 @@ func (ra *relayAttempt) attempt() attemptResult {
 
 	// 熔断器：记录失败
 	balancer.RecordFailure(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
+	if ra.isCompact && shouldMarkCompactUnsupported(fwdErr) {
+		balancer.MarkCompactUnsupported(ra.channel.ID, ra.internalRequest.Model)
+	}
 
 	written := ra.c.Writer.Written()
 	if written {
@@ -226,6 +245,60 @@ func (ra *relayAttempt) attempt() attemptResult {
 		Written: written,
 		Err:     fmt.Errorf("channel %s failed: %v", ra.channel.Name, fwdErr),
 	}
+}
+
+func shouldMarkCompactUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if !isCompactCapabilityStatus(msg) {
+		return false
+	}
+	if strings.Contains(msg, "model_not_found") {
+		return true
+	}
+	if strings.Contains(msg, "not support") || strings.Contains(msg, "not supported") || strings.Contains(msg, "unsupported") {
+		return true
+	}
+	if strings.Contains(msg, "/responses/compact") {
+		return true
+	}
+	if strings.Contains(msg, "response.compaction") {
+		return true
+	}
+	if containsAny(msg, compactPayloadTooLargeIndicators...) {
+		return true
+	}
+	return false
+}
+
+var compactCapabilityStatuses = []string{
+	"upstream error: 400:",
+	"upstream error: 404:",
+	"upstream error: 405:",
+	"upstream error: 413:",
+	"upstream error: 422:",
+	"upstream error: 503:",
+}
+
+var compactPayloadTooLargeIndicators = []string{
+	"too many tokens",
+	"payload too large",
+	"request entity too large",
+}
+
+func isCompactCapabilityStatus(msg string) bool {
+	return containsAny(msg, compactCapabilityStatuses...)
+}
+
+func containsAny(msg string, patterns ...string) bool {
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // parseRequest 解析并验证入站请求

--- a/internal/relay/relay_compact_test.go
+++ b/internal/relay/relay_compact_test.go
@@ -1,6 +1,9 @@
 package relay
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestShouldMarkCompactUnsupported(t *testing.T) {
 	tests := []struct {
@@ -10,22 +13,22 @@ func TestShouldMarkCompactUnsupported(t *testing.T) {
 	}{
 		{
 			name: "model_not_found_503",
-			err:  assertErr("upstream error: 503: {\"error\":{\"code\":\"model_not_found\",\"message\":\"No available channel for model gpt-5.4-openai-compact\"}}"),
+			err:  newTestErr("upstream error: 503: {\"error\":{\"code\":\"model_not_found\",\"message\":\"No available channel for model gpt-5.4-openai-compact\"}}"),
 			want: true,
 		},
 		{
 			name: "unsupported_path_404",
-			err:  assertErr("upstream error: 404: endpoint /v1/responses/compact not found"),
+			err:  newTestErr("upstream error: 404: endpoint /v1/responses/compact not found"),
 			want: true,
 		},
 		{
 			name: "disabled_key_401_not_marked",
-			err:  assertErr("upstream error: 401: {\"code\":\"API_KEY_DISABLED\"}"),
+			err:  newTestErr("upstream error: 401: {\"code\":\"API_KEY_DISABLED\"}"),
 			want: false,
 		},
 		{
 			name: "context_canceled_not_marked",
-			err:  assertErr("failed to send request: Post \"https://a/v1/responses/compact\": context canceled"),
+			err:  newTestErr("failed to send request: Post \"https://a/v1/responses/compact\": context canceled"),
 			want: false,
 		},
 	}
@@ -39,8 +42,43 @@ func TestShouldMarkCompactUnsupported(t *testing.T) {
 	}
 }
 
+func TestFormatUpstreamErrorMessage_CompactContext(t *testing.T) {
+	body := []byte(`{"error":{"message":"This token has no access to model gpt-5.4-openai-compact"}}`)
+	got := formatUpstreamErrorMessage(true, "gpt-5.4", "gpt-5.4", "/v1/responses/compact", 403, body)
+	if got == "" {
+		t.Fatal("empty message")
+	}
+	if !containsAll(got,
+		"upstream error: 403:",
+		`request_model="gpt-5.4"`,
+		`routed_model="gpt-5.4"`,
+		`endpoint="/v1/responses/compact"`,
+		`note="upstream provider may internally map compact endpoint models to *-openai-compact aliases"`,
+	) {
+		t.Fatalf("unexpected message: %s", got)
+	}
+}
+
+func TestFormatUpstreamErrorMessage_NonCompactUnchanged(t *testing.T) {
+	body := []byte(`{"error":{"message":"bad"}}`)
+	got := formatUpstreamErrorMessage(false, "gpt-5.4", "gpt-5.4", "/v1/responses", 400, body)
+	want := `upstream error: 400: {"error":{"message":"bad"}}`
+	if got != want {
+		t.Fatalf("message = %s, want %s", got, want)
+	}
+}
+
 type testErr string
 
 func (e testErr) Error() string { return string(e) }
 
-func assertErr(v string) error { return testErr(v) }
+func newTestErr(v string) error { return testErr(v) }
+
+func containsAll(s string, parts ...string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/relay/relay_compact_test.go
+++ b/internal/relay/relay_compact_test.go
@@ -1,0 +1,46 @@
+package relay
+
+import "testing"
+
+func TestShouldMarkCompactUnsupported(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "model_not_found_503",
+			err:  assertErr("upstream error: 503: {\"error\":{\"code\":\"model_not_found\",\"message\":\"No available channel for model gpt-5.4-openai-compact\"}}"),
+			want: true,
+		},
+		{
+			name: "unsupported_path_404",
+			err:  assertErr("upstream error: 404: endpoint /v1/responses/compact not found"),
+			want: true,
+		},
+		{
+			name: "disabled_key_401_not_marked",
+			err:  assertErr("upstream error: 401: {\"code\":\"API_KEY_DISABLED\"}"),
+			want: false,
+		},
+		{
+			name: "context_canceled_not_marked",
+			err:  assertErr("failed to send request: Post \"https://a/v1/responses/compact\": context canceled"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldMarkCompactUnsupported(tt.err); got != tt.want {
+				t.Fatalf("shouldMarkCompactUnsupported() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testErr string
+
+func (e testErr) Error() string { return string(e) }
+
+func assertErr(v string) error { return testErr(v) }

--- a/internal/relay/type.go
+++ b/internal/relay/type.go
@@ -61,6 +61,7 @@ type relayRequest struct {
 	apiKeyID        int
 	requestModel    string
 	iter            *balancer.Iterator
+	isCompact       bool
 }
 
 // relayAttempt 尝试级上下文

--- a/internal/server/handlers/relay.go
+++ b/internal/server/handlers/relay.go
@@ -47,6 +47,9 @@ func chat(c *gin.Context) {
 func response(c *gin.Context) {
 	relay.Handler(inbound.InboundTypeOpenAIResponse, c)
 }
+
+// responseCompact handles /v1/responses/compact by marking compact endpoint
+// context before delegating to the shared relay pipeline.
 func responseCompact(c *gin.Context) {
 	c.Set(responsesEndpointContextKey, responsesEndpointCompact)
 	relay.Handler(inbound.InboundTypeOpenAIResponse, c)

--- a/internal/server/handlers/relay.go
+++ b/internal/server/handlers/relay.go
@@ -10,6 +10,11 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const (
+	responsesEndpointContextKey = relay.ResponsesEndpointContextKey
+	responsesEndpointCompact    = relay.ResponsesEndpointCompact
+)
+
 func init() {
 	router.NewGroupRouter("/v1").
 		Use(middleware.APIKeyAuth()).
@@ -43,7 +48,7 @@ func response(c *gin.Context) {
 	relay.Handler(inbound.InboundTypeOpenAIResponse, c)
 }
 func responseCompact(c *gin.Context) {
-	c.Set("responses_endpoint", "compact")
+	c.Set(responsesEndpointContextKey, responsesEndpointCompact)
 	relay.Handler(inbound.InboundTypeOpenAIResponse, c)
 }
 func message(c *gin.Context) {

--- a/internal/server/handlers/relay.go
+++ b/internal/server/handlers/relay.go
@@ -23,6 +23,10 @@ func init() {
 				Handle(response),
 		).
 		AddRoute(
+			router.NewRoute("/responses/compact", http.MethodPost).
+				Handle(responseCompact),
+		).
+		AddRoute(
 			router.NewRoute("/messages", http.MethodPost).
 				Handle(message),
 		).
@@ -36,6 +40,10 @@ func chat(c *gin.Context) {
 	relay.Handler(inbound.InboundTypeOpenAIChat, c)
 }
 func response(c *gin.Context) {
+	relay.Handler(inbound.InboundTypeOpenAIResponse, c)
+}
+func responseCompact(c *gin.Context) {
+	c.Set("responses_endpoint", "compact")
 	relay.Handler(inbound.InboundTypeOpenAIResponse, c)
 }
 func message(c *gin.Context) {

--- a/internal/transformer/inbound/openai/response.go
+++ b/internal/transformer/inbound/openai/response.go
@@ -68,6 +68,9 @@ func (i *ResponseInbound) TransformResponse(ctx context.Context, response *model
 	if response == nil {
 		return nil, fmt.Errorf("response is nil")
 	}
+	if len(response.RawResponse) > 0 {
+		return response.RawResponse, nil
+	}
 
 	// Store the response for later retrieval
 	i.storedResponse = response
@@ -701,24 +704,26 @@ func formatSSEData(data []byte) []byte {
 // Request types
 
 type ResponsesRequest struct {
-	Model             string                `json:"model"`
-	Instructions      string                `json:"instructions,omitempty"`
-	Input             ResponsesInput        `json:"input"`
-	Tools             []ResponsesTool       `json:"tools,omitempty"`
-	ToolChoice        *ResponsesToolChoice  `json:"tool_choice,omitempty"`
-	ParallelToolCalls *bool                 `json:"parallel_tool_calls,omitempty"`
-	Stream            *bool                 `json:"stream,omitempty"`
-	Text              *ResponsesTextOptions `json:"text,omitempty"`
-	Store             *bool                 `json:"store,omitempty"`
-	ServiceTier       *string               `json:"service_tier,omitempty"`
-	User              *string               `json:"user,omitempty"`
-	Metadata          map[string]string     `json:"metadata,omitempty"`
-	MaxOutputTokens   *int64                `json:"max_output_tokens,omitempty"`
-	Temperature       *float64              `json:"temperature,omitempty"`
-	TopP              *float64              `json:"top_p,omitempty"`
-	Reasoning         *ResponsesReasoning   `json:"reasoning,omitempty"`
-	Include           []string              `json:"include,omitempty"`
-	TopLogprobs       *int64                `json:"top_logprobs,omitempty"`
+	Model              string                `json:"model"`
+	Instructions       string                `json:"instructions,omitempty"`
+	Input              ResponsesInput        `json:"input"`
+	PreviousResponseID string                `json:"previous_response_id,omitempty"`
+	PromptCacheKey     string                `json:"prompt_cache_key,omitempty"`
+	Tools              []ResponsesTool       `json:"tools,omitempty"`
+	ToolChoice         *ResponsesToolChoice  `json:"tool_choice,omitempty"`
+	ParallelToolCalls  *bool                 `json:"parallel_tool_calls,omitempty"`
+	Stream             *bool                 `json:"stream,omitempty"`
+	Text               *ResponsesTextOptions `json:"text,omitempty"`
+	Store              *bool                 `json:"store,omitempty"`
+	ServiceTier        *string               `json:"service_tier,omitempty"`
+	User               *string               `json:"user,omitempty"`
+	Metadata           map[string]string     `json:"metadata,omitempty"`
+	MaxOutputTokens    *int64                `json:"max_output_tokens,omitempty"`
+	Temperature        *float64              `json:"temperature,omitempty"`
+	TopP               *float64              `json:"top_p,omitempty"`
+	Reasoning          *ResponsesReasoning   `json:"reasoning,omitempty"`
+	Include            []string              `json:"include,omitempty"`
+	TopLogprobs        *int64                `json:"top_logprobs,omitempty"`
 }
 
 type ResponsesInput struct {
@@ -953,6 +958,12 @@ func convertToInternalRequest(req *ResponsesRequest) (*model.InternalLLMRequest,
 		RawAPIFormat:        model.APIFormatOpenAIResponse,
 		TransformerMetadata: map[string]string{},
 		Include:             append([]string(nil), req.Include...),
+	}
+	if req.PreviousResponseID != "" {
+		chatReq.TransformerMetadata["previous_response_id"] = req.PreviousResponseID
+	}
+	if req.PromptCacheKey != "" {
+		chatReq.TransformerMetadata["prompt_cache_key"] = req.PromptCacheKey
 	}
 
 	if req.Input.Text == nil && len(req.Input.Items) > 0 {

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -321,7 +321,6 @@ func (r *InternalLLMRequest) fillMissingToolCallIDs() {
 	}
 }
 
-
 func (r *InternalLLMRequest) fillMissingToolCallIDsFromToolMessages() {
 	for msgIndex := 0; msgIndex < len(r.Messages); msgIndex++ {
 		msg := &r.Messages[msgIndex]
@@ -665,6 +664,9 @@ type InternalLLMResponse struct {
 
 	// Error is the error information, will present if request to llm service failed with status >= 400.
 	Error *ResponseError `json:"error,omitempty"`
+
+	// RawResponse stores the original upstream response body when passthrough is needed.
+	RawResponse []byte `json:"-"`
 }
 
 func (r *InternalLLMResponse) ClearHelpFields() {

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -94,6 +94,16 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 	}
 
 	if o.isPassthrough {
+		var compactResp struct {
+			Object string `json:"object"`
+		}
+		if err := json.Unmarshal(body, &compactResp); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal compact response: %w", err)
+		}
+		if compactResp.Object != "response.compaction" {
+			return nil, fmt.Errorf("upstream compact unsupported: unexpected object %q", compactResp.Object)
+		}
+
 		return &model.InternalLLMResponse{
 			Object:      "response.compaction",
 			RawResponse: body,

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -94,16 +94,6 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 	}
 
 	if o.isPassthrough {
-		var compactResp struct {
-			Object string `json:"object"`
-		}
-		if err := json.Unmarshal(body, &compactResp); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal compact response: %w", err)
-		}
-		if compactResp.Object != "response.compaction" {
-			return nil, fmt.Errorf("upstream compact unsupported: unexpected object %q", compactResp.Object)
-		}
-
 		return &model.InternalLLMResponse{
 			Object:      "response.compaction",
 			RawResponse: body,

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -95,7 +95,7 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 
 	if o.isPassthrough {
 		return &model.InternalLLMResponse{
-			Object:      "chat.completion",
+			Object:      "response.compaction",
 			RawResponse: body,
 		}, nil
 	}

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -22,7 +22,8 @@ type ResponseOutbound struct {
 	streamModel string
 	initialized bool
 
-	endpointPath string
+	endpointPath  string
+	isPassthrough bool
 }
 
 func (o *ResponseOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
@@ -92,7 +93,7 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 		return nil, fmt.Errorf("HTTP error %d: %s", response.StatusCode, string(body))
 	}
 
-	if o.endpointPath == "/responses/compact" {
+	if o.isPassthrough {
 		return &model.InternalLLMResponse{
 			Object:      "chat.completion",
 			RawResponse: body,
@@ -507,7 +508,8 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 
 func NewCompactResponseOutbound() *ResponseOutbound {
 	return &ResponseOutbound{
-		endpointPath: "/responses/compact",
+		endpointPath:  "/responses/compact",
+		isPassthrough: true,
 	}
 }
 

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -516,6 +516,8 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 	return result
 }
 
+// NewCompactResponseOutbound creates a responses outbound adapter configured
+// for /responses/compact and compact-schema passthrough validation.
 func NewCompactResponseOutbound() *ResponseOutbound {
 	return &ResponseOutbound{
 		endpointPath:  "/responses/compact",

--- a/internal/transformer/outbound/openai/response.go
+++ b/internal/transformer/outbound/openai/response.go
@@ -21,6 +21,8 @@ type ResponseOutbound struct {
 	streamID    string
 	streamModel string
 	initialized bool
+
+	endpointPath string
 }
 
 func (o *ResponseOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
@@ -51,7 +53,11 @@ func (o *ResponseOutbound) TransformRequest(ctx context.Context, request *model.
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse base url: %w", err)
 	}
-	parsedUrl.Path = parsedUrl.Path + "/responses"
+	endpointPath := o.endpointPath
+	if endpointPath == "" {
+		endpointPath = "/responses"
+	}
+	parsedUrl.Path = parsedUrl.Path + endpointPath
 	req.URL = parsedUrl
 	req.Method = http.MethodPost
 
@@ -84,6 +90,13 @@ func (o *ResponseOutbound) TransformResponse(ctx context.Context, response *http
 			}
 		}
 		return nil, fmt.Errorf("HTTP error %d: %s", response.StatusCode, string(body))
+	}
+
+	if o.endpointPath == "/responses/compact" {
+		return &model.InternalLLMResponse{
+			Object:      "chat.completion",
+			RawResponse: body,
+		}, nil
 	}
 
 	var resp ResponsesResponse
@@ -253,22 +266,24 @@ func (o *ResponseOutbound) TransformStream(ctx context.Context, eventData []byte
 
 // ResponsesRequest represents the OpenAI Responses API request format.
 type ResponsesRequest struct {
-	Model             string                `json:"model"`
-	Instructions      string                `json:"instructions,omitempty"`
-	Input             ResponsesInput        `json:"input"`
-	Tools             []ResponsesTool       `json:"tools,omitempty"`
-	ToolChoice        *ResponsesToolChoice  `json:"tool_choice,omitempty"`
-	ParallelToolCalls *bool                 `json:"parallel_tool_calls,omitempty"`
-	Stream            *bool                 `json:"stream,omitempty"`
-	Text              *ResponsesTextOptions `json:"text,omitempty"`
-	Store             *bool                 `json:"store,omitempty"`
-	ServiceTier       *string               `json:"service_tier,omitempty"`
-	User              *string               `json:"user,omitempty"`
-	Metadata          map[string]string     `json:"metadata,omitempty"`
-	MaxOutputTokens   *int64                `json:"max_output_tokens,omitempty"`
-	Temperature       *float64              `json:"temperature,omitempty"`
-	TopP              *float64              `json:"top_p,omitempty"`
-	Reasoning         *ResponsesReasoning   `json:"reasoning,omitempty"`
+	Model              string                `json:"model"`
+	Instructions       string                `json:"instructions,omitempty"`
+	Input              ResponsesInput        `json:"input"`
+	PreviousResponseID string                `json:"previous_response_id,omitempty"`
+	PromptCacheKey     string                `json:"prompt_cache_key,omitempty"`
+	Tools              []ResponsesTool       `json:"tools,omitempty"`
+	ToolChoice         *ResponsesToolChoice  `json:"tool_choice,omitempty"`
+	ParallelToolCalls  *bool                 `json:"parallel_tool_calls,omitempty"`
+	Stream             *bool                 `json:"stream,omitempty"`
+	Text               *ResponsesTextOptions `json:"text,omitempty"`
+	Store              *bool                 `json:"store,omitempty"`
+	ServiceTier        *string               `json:"service_tier,omitempty"`
+	User               *string               `json:"user,omitempty"`
+	Metadata           map[string]string     `json:"metadata,omitempty"`
+	MaxOutputTokens    *int64                `json:"max_output_tokens,omitempty"`
+	Temperature        *float64              `json:"temperature,omitempty"`
+	TopP               *float64              `json:"top_p,omitempty"`
+	Reasoning          *ResponsesReasoning   `json:"reasoning,omitempty"`
 }
 
 type ResponsesInput struct {
@@ -450,6 +465,10 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 		MaxOutputTokens:   req.MaxCompletionTokens,
 		ParallelToolCalls: req.ParallelToolCalls,
 	}
+	if req.TransformerMetadata != nil {
+		result.PreviousResponseID = req.TransformerMetadata["previous_response_id"]
+		result.PromptCacheKey = req.TransformerMetadata["prompt_cache_key"]
+	}
 
 	// Convert instructions from system messages
 	result.Instructions = convertInstructionsFromMessages(req.Messages)
@@ -484,6 +503,12 @@ func ConvertToResponsesRequest(req *model.InternalLLMRequest) *ResponsesRequest 
 	}
 
 	return result
+}
+
+func NewCompactResponseOutbound() *ResponseOutbound {
+	return &ResponseOutbound{
+		endpointPath: "/responses/compact",
+	}
 }
 
 func convertInstructionsFromMessages(msgs []model.Message) string {

--- a/internal/transformer/outbound/openai/response_compact_test.go
+++ b/internal/transformer/outbound/openai/response_compact_test.go
@@ -63,14 +63,3 @@ func TestCompactResponseOutbound_TransformResponse_Passthrough(t *testing.T) {
 		t.Fatalf("RawResponse = %s, want %s", string(resp.RawResponse), raw)
 	}
 }
-
-func TestCompactResponseOutbound_TransformResponse_UnsupportedShape(t *testing.T) {
-	outbound := NewCompactResponseOutbound()
-	_, err := outbound.TransformResponse(context.Background(), &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(`{"object":"response","id":"resp_123"}`)),
-	})
-	if err == nil {
-		t.Fatal("expected error for unsupported compact response shape, got nil")
-	}
-}

--- a/internal/transformer/outbound/openai/response_compact_test.go
+++ b/internal/transformer/outbound/openai/response_compact_test.go
@@ -63,3 +63,14 @@ func TestCompactResponseOutbound_TransformResponse_Passthrough(t *testing.T) {
 		t.Fatalf("RawResponse = %s, want %s", string(resp.RawResponse), raw)
 	}
 }
+
+func TestCompactResponseOutbound_TransformResponse_UnsupportedShape(t *testing.T) {
+	outbound := NewCompactResponseOutbound()
+	_, err := outbound.TransformResponse(context.Background(), &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"object":"response","id":"resp_123"}`)),
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported compact response shape, got nil")
+	}
+}

--- a/internal/transformer/outbound/openai/response_compact_test.go
+++ b/internal/transformer/outbound/openai/response_compact_test.go
@@ -1,0 +1,65 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bestruirui/octopus/internal/transformer/model"
+)
+
+func TestCompactResponseOutbound_TransformRequest(t *testing.T) {
+	outbound := NewCompactResponseOutbound()
+	hello := "hello"
+	req, err := outbound.TransformRequest(context.Background(), &model.InternalLLMRequest{
+		Model: "gpt-4.1",
+		Messages: []model.Message{
+			{
+				Role: "user",
+				Content: model.MessageContent{
+					Content: &hello,
+				},
+			},
+		},
+		TransformerMetadata: map[string]string{
+			"previous_response_id": "resp_prev",
+			"prompt_cache_key":     "cache_key",
+		},
+	}, "https://api.openai.com/v1", "test-key")
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	if got, want := req.URL.String(), "https://api.openai.com/v1/responses/compact"; got != want {
+		t.Fatalf("url = %s, want %s", got, want)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("failed to read request body: %v", err)
+	}
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, `"previous_response_id":"resp_prev"`) {
+		t.Fatalf("request body missing previous_response_id: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"prompt_cache_key":"cache_key"`) {
+		t.Fatalf("request body missing prompt_cache_key: %s", bodyStr)
+	}
+}
+
+func TestCompactResponseOutbound_TransformResponse_Passthrough(t *testing.T) {
+	outbound := NewCompactResponseOutbound()
+	raw := `{"object":"response.compaction","id":"resp_cpt","created_at":1}`
+	resp, err := outbound.TransformResponse(context.Background(), &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(raw)),
+	})
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+	if string(resp.RawResponse) != raw {
+		t.Fatalf("RawResponse = %s, want %s", string(resp.RawResponse), raw)
+	}
+}

--- a/internal/transformer/outbound/register.go
+++ b/internal/transformer/outbound/register.go
@@ -58,3 +58,7 @@ func Get(outboundType OutboundType) model.Outbound {
 	}
 	return nil
 }
+
+func NewOpenAICompactResponse() model.Outbound {
+	return openai.NewCompactResponseOutbound()
+}


### PR DESCRIPTION
> 说人话就是codex压缩上下文会发送 `/v1/responses/compact` 接口，但是octopus没有该接口返回404，导致ai中断，所以PR新增了对该接口的支持。

## 变更说明
新增对 `/v1/responses/compact` 接口的独立支持，防止带有紧凑模式语义的请求与普通 `/v1/responses` 混合引发代理问题。

**主要优化点：**
1. **接口分离**：为 `/v1/responses/compact` 增加了独立的请求路由和上下文。
2. **状态透传标记**：为内部通信模型增加了 `IsPassthrough` 标识，并支持透传 `previous_response_id` 与 `prompt_cache_key`，以保证开启紧凑模式后的连贯性。
3. **适配器隔离与降级**：当使用代理（或上游）时，明确校验上游是否支持 compact 模式，避免非标准代理返回正常的 `response` 格式污染 `response.compaction` 的需求，使系统能更稳定地进行 Failover 或重试。

此项修改主要针对拥有混合代理服务、部分节点不支持 compact 功能的使用场景。

## 提交前检查
- [x] 本次 PR 仅包含一个变更主题。
- [x] AI 参与的内容已完成人工审查。