### PR TITLE
fix: preserve reasoning_content when forwarding requests to upstream

### DIFF
--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -123,6 +123,12 @@ func Handler(inboundType inbound.InboundType, c *gin.Context) {
 			continue
 		}
 
+		// Kimi K2.5 系列模型默认启用 thinking 模式，提前标记以便 outbound 处理
+		if strings.Contains(requestModel, "kimi-k2") && (internalRequest.EnableThinking == nil || !*internalRequest.EnableThinking) {
+			enableThinking := true
+			internalRequest.EnableThinking = &enableThinking
+		}
+
 		// 设置实际模型
 		internalRequest.Model = item.ModelName
 

--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -501,8 +501,6 @@ type Message struct {
 }
 
 func (m *Message) ClearHelpFields() {
-	m.ReasoningContent = nil
-	m.Reasoning = nil
 	m.ReasoningSignature = nil
 }
 

--- a/internal/transformer/outbound/openai/chat.go
+++ b/internal/transformer/outbound/openai/chat.go
@@ -16,6 +16,10 @@ import (
 type ChatOutbound struct{}
 
 func (o *ChatOutbound) TransformRequest(ctx context.Context, request *model.InternalLLMRequest, baseUrl, key string) (*http.Request, error) {
+	// Kimi K2.5 等模型在启用 thinking 模式时，要求 assistant 的 tool_calls 消息包含 reasoning_content 字段
+	// 这个处理必须在 ClearHelpFields 之前完成，因为我们需要保留原始请求信息
+	o.fillMissingReasoningContent(request)
+
 	request.ClearHelpFields()
 
 	// Convert developer role to system role for compatibility
@@ -55,6 +59,46 @@ func (o *ChatOutbound) TransformRequest(ctx context.Context, request *model.Inte
 	req.URL = parsedUrl
 	req.Method = http.MethodPost
 	return req, nil
+}
+
+// fillMissingReasoningContent 为 assistant 的 tool_calls 消息填充 reasoning_content 字段
+// 某些模型（如 Kimi K2.5）在启用 thinking 模式时，要求 assistant 的 tool_calls 消息必须包含 reasoning_content 字段
+func (o *ChatOutbound) fillMissingReasoningContent(request *model.InternalLLMRequest) {
+	// 只有启用了 thinking 模式时才需要处理（在 relay.go 中已根据原始模型名设置）
+	if request.EnableThinking == nil || !*request.EnableThinking {
+		return
+	}
+
+	// Kimi K2.5 在启用 thinking 模式时，tool_choice 不能为 "specified" 或 "required"
+	// 也不能指定特定工具（NamedToolChoice），需要将其改为 "auto"
+	// 这个限制适用于所有启用了 thinking 模式的模型
+	if request.ToolChoice != nil {
+		if request.ToolChoice.ToolChoice != nil {
+			choice := *request.ToolChoice.ToolChoice
+			if choice == "specified" || choice == "required" {
+				autoChoice := "auto"
+				request.ToolChoice.ToolChoice = &autoChoice
+			}
+		} else if request.ToolChoice.NamedToolChoice != nil {
+			// 如果指定了具体工具，也改为 auto
+			autoChoice := "auto"
+			request.ToolChoice.ToolChoice = &autoChoice
+			request.ToolChoice.NamedToolChoice = nil
+		}
+	}
+
+	for i := range request.Messages {
+		msg := &request.Messages[i]
+		// 只处理 assistant 角色的消息，且包含 tool_calls 的消息
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			// 如果 reasoning_content 为空，添加一个空格
+			// 注意：必须使用非空值，因为 omitempty 会省略空字符串
+			if msg.GetReasoningContent() == "" {
+				spaceStr := " "
+				msg.ReasoningContent = &spaceStr
+			}
+		}
+	}
 }
 
 func (o *ChatOutbound) TransformResponse(ctx context.Context, response *http.Response) (*model.InternalLLMResponse, error) {


### PR DESCRIPTION
## Problem

When using Kimi K2.5 with thinking mode enabled, the following errors occur:

1. `Message.ClearHelpFields()` incorrectly clears `ReasoningContent` and `Reasoning`, which are real message fields used by upstreams like DeepSeek, Kimi and OpenRouter.

2. Kimi K2.5 requires `reasoning_content` to be present on assistant messages that contain `tool_calls`. When the field is missing, it causes:
> thinking is enabled but reasoning_content is missing in assistant tool call message at index N

3. Kimi K2.5 with thinking enabled does not support `tool_choice: 'specified'`, `tool_choice: 'required'`, or specific tool selection (NamedToolChoice).

## Fix

1. **ClearHelpFields()**: Only clear `ReasoningSignature` (which is truly an internal help field for the Anthropic adapter), stop over-clearing `ReasoningContent` / `Reasoning`.

2. **Relay Handler**: Auto-enable thinking mode for kimi-k2 models before model name mapping.

3. **OpenAI Outbound**: 
   - Fill missing `reasoning_content` with a space character (to avoid omitempty) for assistant messages with tool_calls
   - Convert incompatible `tool_choice` values (`specified`, `required`, NamedToolChoice) to `auto`

## Related

- Fixes #188
- Related #200