### PR TITLE
fix: :bug: 剔除 Gemini 不支持的 JSON Schema 关键字以适配 Claude Code

### DIFF
--- a/internal/transformer/outbound/gemini/messages.go
+++ b/internal/transformer/outbound/gemini/messages.go
@@ -868,7 +868,9 @@ func (t *geminiSchemaTransformer) transform(schemaNode any) {
 			"title", "$schema", "$ref", "strict",
 			"exclusiveMaximum", "exclusiveMinimum",
 			"additionalProperties", "oneOf", "default",
-			"$defs",
+			"$defs", "propertyNames", "pattern", "minLength",
+			"maxLength", "minimum", "maximum", "maxItems", "minItems",
+			"uniqueItems", "multipleOf",
 		} {
 			delete(node, k)
 		}


### PR DESCRIPTION
根据 Google 的文档（https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Schema），Gemini 不支持 propertyNames字段。
在 Gemini API 的工具定义转换逻辑中补全了 propertyNames 等不支持的关键字剔除，解决 Claude Code 场景下因 Schema 校验导致的 400 INVALID_ARGUMENT 错误。