### PR TITLE
feat: 添加活动热力图自定义日期范围选择功能

### DIFF
--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -128,7 +128,8 @@
             "period": {
                 "today": "Today",
                 "last7Days": "7 Days",
-                "last30Days": "30 Days"
+                "last30Days": "30 Days",
+                "customRange": "Custom Range"
             }
         },
         "rank": {

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -128,7 +128,8 @@
             "period": {
                 "today": "今天",
                 "last7Days": "7天",
-                "last30Days": "30天"
+                "last30Days": "30天",
+                "customRange": "自定义范围"
             }
         },
         "rank": {

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -128,7 +128,8 @@
             "period": {
                 "today": "今天",
                 "last7Days": "7天",
-                "last30Days": "30天"
+                "last30Days": "30天",
+                "customRange": "自訂範圍"
             }
         },
         "rank": {

--- a/web/src/components/modules/home/activity.tsx
+++ b/web/src/components/modules/home/activity.tsx
@@ -6,6 +6,7 @@ import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { Fragment } from 'react';
 import dayjs from 'dayjs';
+import { useHomeViewStore } from './store';
 
 interface StatsDailyData {
     dateStr: string;
@@ -29,6 +30,8 @@ export function Activity() {
     const { data: statsDailyFormatted, isLoading } = useStatsDaily();
     const scrollRef = useRef<HTMLDivElement>(null);
     const t = useTranslations('home.activity');
+    const dateRange = useHomeViewStore((state) => state.dateRange);
+    const setDateRange = useHomeViewStore((state) => state.setDateRange);
 
     const [tooltip, setTooltip] = useState<{ day: StatsDailyData; x: number; y: number; visible: boolean } | null>(null);
 
@@ -86,6 +89,27 @@ export function Activity() {
         return () => window.removeEventListener('resize', scrollToRight);
     }, [days, isLoading, checkScroll]);
 
+    const isDateInRange = useCallback((dateStr: string): 'none' | 'start' | 'range' => {
+        if (!dateRange.from) return 'none';
+        if (!dateRange.to) return dateStr === dateRange.from ? 'start' : 'none';
+        return dateStr >= dateRange.from && dateStr <= dateRange.to ? 'range' : 'none';
+    }, [dateRange]);
+
+    const handleCellClick = useCallback((dateStr: string, shiftKey: boolean) => {
+        if (shiftKey) {
+            const current = useHomeViewStore.getState().dateRange;
+            if (current.from) {
+                const from = dateStr < current.from ? dateStr : current.from;
+                const to = dateStr < current.from ? current.from : dateStr;
+                setDateRange({ from, to });
+            } else {
+                setDateRange({ from: dateStr, to: null });
+            }
+        } else {
+            setDateRange({ from: dateStr, to: null });
+        }
+    }, [setDateRange]);
+
     return (
         <div className="rounded-3xl bg-card border-card-border border text-card-foreground custom-shadow">
             <div
@@ -108,17 +132,32 @@ export function Activity() {
                             }
 
                             const level = getActivityLevel(day.formatted?.request_count.raw ?? 0);
+                            const rangeState = isDateInRange(day.dateStr);
 
                             return (
                                 <div
                                     key={day.dateStr}
                                     className="rounded-sm transition-all cursor-pointer hover:scale-150"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleCellClick(day.dateStr, e.shiftKey);
+                                    }}
                                     onMouseEnter={(e) => {
                                         const rect = e.currentTarget.getBoundingClientRect();
                                         setTooltip({ day, x: rect.left + rect.width / 2, y: rect.top, visible: true });
                                     }}
                                     onMouseLeave={() => setTooltip(prev => prev ? { ...prev, visible: false } : null)}
-                                    style={{ backgroundColor: level === 0 ? 'var(--muted)' : `color-mix(in oklch, var(--primary) ${level * 25}%, var(--muted))` }}
+                                    style={{
+                                        backgroundColor: level === 0 ? 'var(--muted)' : `color-mix(in oklch, var(--primary) ${level * 25}%, var(--muted))`,
+                                        ...(rangeState === 'start' && {
+                                            outline: '2px solid var(--primary)',
+                                            outlineOffset: '1px'
+                                        }),
+                                        ...(rangeState === 'range' && {
+                                            outline: '1.5px solid var(--primary)',
+                                            outlineOffset: '0.5px'
+                                        })
+                                    }}
                                 />
                             );
                         })}

--- a/web/src/components/modules/home/chart.tsx
+++ b/web/src/components/modules/home/chart.tsx
@@ -21,6 +21,7 @@ export function StatsChart() {
     const setChartMetricType = useHomeViewStore((state) => state.setChartMetricType);
     const period = useHomeViewStore((state) => state.chartPeriod);
     const setChartPeriod = useHomeViewStore((state) => state.setChartPeriod);
+    const dateRange = useHomeViewStore((state) => state.dateRange);
 
     const sortedDaily = useMemo(() => {
         if (!statsDaily) return [];
@@ -33,6 +34,21 @@ export function StatsChart() {
 
     const chartData = useMemo(() => {
         const dataKey = getChartDataKey(chartMetricType);
+
+        if (dateRange.from && dateRange.to) {
+            const filteredDaily = sortedDaily.filter((stat) => {
+                return stat.date >= dateRange.from! && stat.date <= dateRange.to!;
+            });
+            return filteredDaily.map((stat) => ({
+                date: dayjs(stat.date).format('MM/DD'),
+                [dataKey]: chartMetricType === 'cost'
+                    ? stat.total_cost.raw
+                    : chartMetricType === 'count'
+                        ? (stat.request_success.raw + stat.request_failed.raw)
+                        : (stat.input_token.raw + stat.output_token.raw),
+            }));
+        }
+
         if (period === '1') {
             if (!statsHourly) return [];
             return statsHourly.map((stat) => ({
@@ -54,32 +70,34 @@ export function StatsChart() {
                         : (stat.input_token.raw + stat.output_token.raw),
             }));
         }
-    }, [sortedDaily, statsHourly, period, chartMetricType]);
+    }, [sortedDaily, statsHourly, period, chartMetricType, dateRange]);
 
     const totals = useMemo(() => {
+        if (dateRange.from && dateRange.to) {
+            const filteredDaily = sortedDaily.filter((stat) => {
+                return stat.date >= dateRange.from! && stat.date <= dateRange.to!;
+            });
+            const requests = filteredDaily.reduce((acc, stat) => acc + stat.request_success.raw + stat.request_failed.raw, 0);
+            const cost = filteredDaily.reduce((acc, stat) => acc + stat.total_cost.raw, 0);
+            const tokens = filteredDaily.reduce((acc, stat) => acc + stat.input_token.raw + stat.output_token.raw, 0);
+            return { requests, cost, tokens };
+        }
+
         if (period === '1') {
             if (!statsHourly) return { requests: 0, cost: 0, tokens: 0 };
             const requests = statsHourly.reduce((acc, stat) => acc + stat.request_count.raw, 0);
             const cost = statsHourly.reduce((acc, stat) => acc + stat.total_cost.raw, 0);
             const tokens = statsHourly.reduce((acc, stat) => acc + stat.input_token.raw + stat.output_token.raw, 0);
-            return {
-                requests,
-                cost,
-                tokens,
-            };
+            return { requests, cost, tokens };
         } else {
             const days = Number(period);
             const recentStats = sortedDaily.slice(-days);
             const requests = recentStats.reduce((acc, stat) => acc + stat.request_success.raw + stat.request_failed.raw, 0);
             const cost = recentStats.reduce((acc, stat) => acc + stat.total_cost.raw, 0);
             const tokens = recentStats.reduce((acc, stat) => acc + stat.input_token.raw + stat.output_token.raw, 0);
-            return {
-                requests,
-                cost,
-                tokens,
-            };
+            return { requests, cost, tokens };
         }
-    }, [sortedDaily, statsHourly, period]);
+    }, [sortedDaily, statsHourly, period, dateRange]);
 
     const chartConfig = useMemo(() => {
         const dataKey = getChartDataKey(chartMetricType);
@@ -93,7 +111,12 @@ export function StatsChart() {
         };
     }, [chartMetricType, t]);
 
+    const hasDateRange = !!(dateRange.from && dateRange.to);
+
     const getPeriodLabel = (p: ChartPeriod) => {
+        if (hasDateRange) {
+            return t('period.customRange');
+        }
         const labels = {
             '1': t('period.today'),
             '7': t('period.last7Days'),
@@ -164,8 +187,8 @@ export function StatsChart() {
                         </div>
                     </div>
                     <div
-                        className="flex gap-2 text-sm cursor-pointer hover:opacity-80 transition-opacity"
-                        onClick={handlePeriodClick}
+                        className={`flex gap-2 text-sm transition-opacity ${hasDateRange ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:opacity-80'}`}
+                        onClick={hasDateRange ? undefined : handlePeriodClick}
                     >
                         <div>
                             <div className="text-xs text-muted-foreground">{t('timePeriod')}</div>

--- a/web/src/components/modules/home/store.ts
+++ b/web/src/components/modules/home/store.ts
@@ -7,13 +7,20 @@ export type RankSortMode = 'cost' | 'count' | 'tokens';
 export type ChartMetricType = 'cost' | 'count' | 'tokens';
 export type ChartPeriod = '1' | '7' | '30';
 
+export type DateRange = {
+    from: string | null; // YYYYMMDD format
+    to: string | null;   // YYYYMMDD format
+};
+
 interface HomeViewState {
     rankSortMode: RankSortMode;
     chartMetricType: ChartMetricType;
     chartPeriod: ChartPeriod;
+    dateRange: DateRange;
     setRankSortMode: (value: RankSortMode) => void;
     setChartMetricType: (value: ChartMetricType) => void;
     setChartPeriod: (value: ChartPeriod) => void;
+    setDateRange: (value: DateRange) => void;
 }
 
 export const useHomeViewStore = create<HomeViewState>()(
@@ -22,9 +29,11 @@ export const useHomeViewStore = create<HomeViewState>()(
             rankSortMode: 'cost',
             chartMetricType: 'cost',
             chartPeriod: '1',
+            dateRange: { from: null, to: null },
             setRankSortMode: (value) => set({ rankSortMode: value }),
             setChartMetricType: (value) => set({ chartMetricType: value }),
             setChartPeriod: (value) => set({ chartPeriod: value }),
+            setDateRange: (value) => set({ dateRange: value }),
         }),
         {
             name: 'home-view-options-storage',

--- a/web/src/components/modules/home/total.tsx
+++ b/web/src/components/modules/home/total.tsx
@@ -14,14 +14,54 @@ import {
     FastForward
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useStatsTotal } from '@/api/endpoints/stats';
+import { useMemo } from 'react';
+import { useStatsTotal, useStatsDaily } from '@/api/endpoints/stats';
+import type { StatsTotalFormatted } from '@/api/endpoints/stats';
 import { AnimatedNumber } from '@/components/common/AnimatedNumber';
 import { EASING } from '@/lib/animations/fluid-transitions';
+import { formatCount, formatMoney, formatTime } from '@/lib/utils';
+import { useHomeViewStore } from '@/components/modules/home/store';
 
 
 export function Total() {
     const { data: statsTotalFormatted } = useStatsTotal();
+    const { data: statsDaily } = useStatsDaily();
+    const dateRange = useHomeViewStore((state) => state.dateRange);
     const t = useTranslations('home.total');
+
+    const displayData: StatsTotalFormatted | undefined = useMemo(() => {
+        if (!dateRange.from) return statsTotalFormatted;
+        if (!statsDaily) return statsTotalFormatted;
+
+        const filtered = dateRange.to
+            ? statsDaily.filter((s) => s.date >= dateRange.from! && s.date <= dateRange.to!)
+            : statsDaily.filter((s) => s.date === dateRange.from!);
+
+        if (filtered.length === 0) return statsTotalFormatted;
+
+        const raw = {
+            request_success: filtered.reduce((a, s) => a + s.request_success.raw, 0),
+            request_failed: filtered.reduce((a, s) => a + s.request_failed.raw, 0),
+            input_token: filtered.reduce((a, s) => a + s.input_token.raw, 0),
+            output_token: filtered.reduce((a, s) => a + s.output_token.raw, 0),
+            input_cost: filtered.reduce((a, s) => a + s.input_cost.raw, 0),
+            output_cost: filtered.reduce((a, s) => a + s.output_cost.raw, 0),
+            wait_time: filtered.reduce((a, s) => a + s.wait_time.raw, 0),
+        };
+
+        return {
+            request_count: formatCount(raw.request_success + raw.request_failed),
+            request_success: formatCount(raw.request_success),
+            request_failed: formatCount(raw.request_failed),
+            total_token: formatCount(raw.input_token + raw.output_token),
+            input_token: formatCount(raw.input_token),
+            output_token: formatCount(raw.output_token),
+            total_cost: formatMoney(raw.input_cost + raw.output_cost),
+            input_cost: formatMoney(raw.input_cost),
+            output_cost: formatMoney(raw.output_cost),
+            wait_time: formatTime(raw.wait_time),
+        };
+    }, [dateRange, statsDaily, statsTotalFormatted]);
 
     const cards = [
         {
@@ -30,19 +70,19 @@ export function Total() {
             items: [
                 {
                     label: t('requestCount'),
-                    value: statsTotalFormatted?.request_count.formatted.value,
+                    value: displayData?.request_count.formatted.value,
                     icon: MessageSquare,
                     color: 'text-primary',
                     bgColor: 'bg-primary/10',
-                    unit: statsTotalFormatted?.request_count.formatted.unit
+                    unit: displayData?.request_count.formatted.unit
                 },
                 {
                     label: t('timeConsumed'),
-                    value: statsTotalFormatted?.wait_time.formatted.value,
+                    value: displayData?.wait_time.formatted.value,
                     icon: Clock,
                     color: 'text-primary',
                     bgColor: 'bg-accent/10',
-                    unit: statsTotalFormatted?.wait_time.formatted.unit
+                    unit: displayData?.wait_time.formatted.unit
                 }
             ]
         },
@@ -52,19 +92,19 @@ export function Total() {
             items: [
                 {
                     label: t('totalToken'),
-                    value: statsTotalFormatted?.total_token.formatted.value,
+                    value: displayData?.total_token.formatted.value,
                     icon: Bot,
                     color: 'text-primary',
                     bgColor: 'bg-chart-1/10',
-                    unit: statsTotalFormatted?.total_token.formatted.unit
+                    unit: displayData?.total_token.formatted.unit
                 },
                 {
                     label: t('totalCost'),
-                    value: statsTotalFormatted?.total_cost.formatted.value,
+                    value: displayData?.total_cost.formatted.value,
                     icon: DollarSign,
                     color: 'text-primary',
                     bgColor: 'bg-chart-2/10',
-                    unit: statsTotalFormatted?.total_cost.formatted.unit
+                    unit: displayData?.total_cost.formatted.unit
                 }
             ]
         },
@@ -74,19 +114,19 @@ export function Total() {
             items: [
                 {
                     label: t('inputTokens'),
-                    value: statsTotalFormatted?.input_token.formatted.value,
+                    value: displayData?.input_token.formatted.value,
                     icon: Rewind,
                     color: 'text-primary',
                     bgColor: 'bg-chart-3/10',
-                    unit: statsTotalFormatted?.input_token.formatted.unit
+                    unit: displayData?.input_token.formatted.unit
                 },
                 {
                     label: t('inputCost'),
-                    value: statsTotalFormatted?.input_cost.formatted.value,
+                    value: displayData?.input_cost.formatted.value,
                     icon: DollarSign,
                     color: 'text-primary',
                     bgColor: 'bg-chart-3/10',
-                    unit: statsTotalFormatted?.input_cost.formatted.unit
+                    unit: displayData?.input_cost.formatted.unit
                 }
             ]
         },
@@ -96,19 +136,19 @@ export function Total() {
             items: [
                 {
                     label: t('outputTokens'),
-                    value: statsTotalFormatted?.output_token.formatted.value,
+                    value: displayData?.output_token.formatted.value,
                     icon: FastForward,
                     color: 'text-primary',
                     bgColor: 'bg-chart-4/10',
-                    unit: statsTotalFormatted?.output_token.formatted.unit
+                    unit: displayData?.output_token.formatted.unit
                 },
                 {
                     label: t('outputCost'),
-                    value: statsTotalFormatted?.output_cost.formatted.value,
+                    value: displayData?.output_cost.formatted.value,
                     icon: DollarSign,
                     color: 'text-primary',
                     bgColor: 'bg-chart-4/10',
-                    unit: statsTotalFormatted?.output_cost.formatted.unit
+                    unit: displayData?.output_cost.formatted.unit
                 }
             ]
         }


### PR DESCRIPTION
• 在活动热力图中支持通过点击和Shift+点击选择自定义日期范围
• 图表和总计组件现在会根据所选日期范围动态过滤和显示数据
• 按shift键+单击可以多选

主要技术变更包括在store中新增dateRange状态，扩展Activity组件支持范围选择交互，并修改Chart和Total组件的数据过滤逻辑以支持自定义日期范围。

效果如下：
<img width="1663" height="905" alt="PixPin_2026-04-17_14-50-33" src="https://github.com/user-attachments/assets/53c02c59-6cc3-4294-b31b-abffd9dd7ae7" />


