### PR TITLE
feat: 支持 OpenAI Images API 转发与流式 SSE 透传

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ All configuration options can be overridden via environment variables using the 
 | `OCTOPUS_LOG_LEVEL` | `log.level` |
 | `OCTOPUS_GITHUB_PAT` | For rate limiting when getting the latest version (optional) |
 | `OCTOPUS_RELAY_MAX_SSE_EVENT_SIZE` | Maximum SSE event size (optional) |
+| `OCTOPUS_IMAGES_BODY_MEMORY_THRESHOLD_MB` | Images request body in-memory threshold. If exceeded, it will be spooled to a temporary file (optional, default 16) |
+| `OCTOPUS_IMAGES_BODY_MAX_MB` | Images request body maximum size. Requests above this limit are rejected (optional, default 256) |
+| `OCTOPUS_IMAGES_BODY_TMP_DIR` | Images request body temporary directory (optional, default `./cache`) |
+| `OCTOPUS_IMAGES_BODY_TMP_CLEANUP_HOURS` | Startup cleanup threshold for temporary files (optional, default 24) |
 
 ## 📸 Screenshots
 
@@ -238,6 +242,7 @@ The program automatically appends API paths based on channel type. You only need
 |--------------|-------------------|----------|--------------------------|
 | OpenAI Chat | `/chat/completions` | `https://api.openai.com/v1` | `https://api.openai.com/v1/chat/completions` |
 | OpenAI Responses | `/responses` | `https://api.openai.com/v1` | `https://api.openai.com/v1/responses` |
+| OpenAI Images | `/images/generations`, `/images/edits`, `/images/variations` | `https://api.openai.com/v1` | `https://api.openai.com/v1/images/generations` |
 | Anthropic | `/messages` | `https://api.anthropic.com/v1` | `https://api.anthropic.com/v1/messages` |
 | Gemini | `/models/:model:generateContent` | `https://generativelanguage.googleapis.com/v1beta` | `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent` |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -170,6 +170,10 @@ http://localhost:3000
 | `OCTOPUS_LOG_LEVEL` | `log.level` |
 | `OCTOPUS_GITHUB_PAT` | 用于获取最新版本时的速率限制(可选) |
 | `OCTOPUS_RELAY_MAX_SSE_EVENT_SIZE` | 最大 SSE 事件大小(可选) |
+| `OCTOPUS_IMAGES_BODY_MEMORY_THRESHOLD_MB` | Images 请求体内存缓存阈值，超过阈值会落盘临时文件(可选，默认 16) |
+| `OCTOPUS_IMAGES_BODY_MAX_MB` | Images 请求体最大大小限制，超过限制将拒绝请求(可选，默认 256) |
+| `OCTOPUS_IMAGES_BODY_TMP_DIR` | Images 请求体临时文件目录(可选，默认 `./cache`) |
+| `OCTOPUS_IMAGES_BODY_TMP_CLEANUP_HOURS` | 启动时清理临时文件的时间阈值(可选，默认 24) |
 
 
 ## 📸 界面预览
@@ -239,6 +243,7 @@ http://localhost:3000
 |----------|-------------|----------|-----------------|
 | OpenAI Chat | `/chat/completions` | `https://api.openai.com/v1` | `https://api.openai.com/v1/chat/completions` |
 | OpenAI Responses | `/responses` | `https://api.openai.com/v1` | `https://api.openai.com/v1/responses` |
+| OpenAI Images | `/images/generations`、`/images/edits`、`/images/variations` | `https://api.openai.com/v1` | `https://api.openai.com/v1/images/generations` |
 | Anthropic | `/messages` | `https://api.anthropic.com/v1` | `https://api.anthropic.com/v1/messages` |
 | Gemini | `/models/:model:generateContent` | `https://generativelanguage.googleapis.com/v1beta` | `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent` |
 

--- a/internal/relay/bodycache/body_cache.go
+++ b/internal/relay/bodycache/body_cache.go
@@ -1,0 +1,356 @@
+package bodycache
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// 默认最大请求体大小：256MB
+	DefaultBodyMaxMB = 256
+	// 默认内存缓存阈值：16MB
+	DefaultMemoryThresholdMB = 16
+	// 默认临时目录：./cache
+	DefaultTmpDir = "./cache"
+	// 默认启动清理阈值：24小时
+	DefaultTmpCleanupHours = 24
+
+	// 临时文件名前缀：用于清理
+	TmpFilePrefix = "octopus-images-"
+)
+
+const (
+	envBodyMaxMB             = "OCTOPUS_IMAGES_BODY_MAX_MB"
+	envMemoryThresholdMB     = "OCTOPUS_IMAGES_BODY_MEMORY_THRESHOLD_MB"
+	envTmpDir                = "OCTOPUS_IMAGES_BODY_TMP_DIR"
+	envTmpCleanupHours       = "OCTOPUS_IMAGES_BODY_TMP_CLEANUP_HOURS"
+	bytesPerMB         int64 = 1024 * 1024
+)
+
+// BodyTooLargeError 表示读取请求体时超过最大限制。
+// 上层可以通过 errors.As 判断该错误，用于返回 413 等逻辑。
+type BodyTooLargeError struct {
+	MaxBytes    int64
+	ActualBytes int64
+}
+
+func (e *BodyTooLargeError) Error() string {
+	return fmt.Sprintf("images body too large: max=%d actual=%d", e.MaxBytes, e.ActualBytes)
+}
+
+// BodyCache 是一个可重放的请求体缓存对象：小体积缓存内存，大体积落盘临时文件。
+// 该对象需要 Close 释放资源并删除临时文件（若存在）。
+type BodyCache struct {
+	mu     sync.Mutex
+	closed bool
+
+	size int64
+
+	// 仅当 isFile=false 时使用
+	mem []byte
+
+	// 仅当 isFile=true 时使用
+	tmpPath string
+}
+
+// New 从 r 读取完整 body 并缓存（内存或临时文件）。
+// - 最大限制默认 256MB，可由环境变量 OCTOPUS_IMAGES_BODY_MAX_MB 覆盖
+// - 内存阈值默认 16MB，可由环境变量 OCTOPUS_IMAGES_BODY_MEMORY_THRESHOLD_MB 覆盖
+// - 临时目录默认 ./cache，可由环境变量 OCTOPUS_IMAGES_BODY_TMP_DIR 覆盖
+func New(r io.ReadCloser) (*BodyCache, error) {
+	if r == nil {
+		return nil, errors.New("nil body reader")
+	}
+	defer r.Close()
+
+	maxBytes := BodyMaxBytesFromEnv()
+	thresholdBytes := MemoryThresholdBytesFromEnv()
+	tmpDir := TmpDirFromEnv()
+
+	// 使用 maxBytes+1 的限制读取，用于准确判断是否超限。
+	limited := io.LimitReader(r, maxBytes+1)
+
+	sw := &spillWriter{
+		thresholdBytes: thresholdBytes,
+		tmpDir:         tmpDir,
+		prefix:         TmpFilePrefix,
+	}
+
+	n, err := io.Copy(sw, limited)
+	if err != nil {
+		// 出错时确保清理已创建的临时文件
+		_ = sw.Close()
+		return nil, err
+	}
+
+	if n > maxBytes {
+		_ = sw.Close()
+		return nil, &BodyTooLargeError{
+			MaxBytes:    maxBytes,
+			ActualBytes: n,
+		}
+	}
+
+	bc := &BodyCache{
+		size:    n,
+		mem:     sw.Bytes(),
+		tmpPath: sw.TmpPath(),
+	}
+	// spillWriter.Close 只负责关闭文件句柄，不删除文件；删除由 BodyCache.Close 负责。
+	if cerr := sw.Close(); cerr != nil {
+		_ = bc.Close()
+		return nil, cerr
+	}
+	return bc, nil
+}
+
+// NewReader 每次调用返回一个新的 reader，用于多次重试重放请求体。
+func (b *BodyCache) NewReader() (io.ReadCloser, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return nil, errors.New("body cache closed")
+	}
+
+	if b.tmpPath != "" {
+		f, err := os.Open(b.tmpPath)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	}
+
+	// 内存模式：每次新建 bytes.Reader
+	return io.NopCloser(bytes.NewReader(b.mem)), nil
+}
+
+// Size 返回缓存的 body 大小（字节）。
+func (b *BodyCache) Size() int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.size
+}
+
+// IsFile 表示是否落盘到临时文件。
+func (b *BodyCache) IsFile() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.tmpPath != ""
+}
+
+// TmpPath 返回临时文件路径（仅在 IsFile=true 时有效）。
+func (b *BodyCache) TmpPath() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.tmpPath
+}
+
+// Close 释放资源并删除临时文件（若存在）。可重复调用。
+func (b *BodyCache) Close() error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+
+	tmpPath := b.tmpPath
+	b.tmpPath = ""
+	b.mem = nil
+	b.size = 0
+	b.mu.Unlock()
+
+	if tmpPath != "" {
+		// 删除失败时把错误返回给上层；上层可记录日志但不阻断流程。
+		if err := os.Remove(tmpPath); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// CleanupOldTmpFiles 删除 dir 目录下：文件名匹配 prefix 且 mtime 早于 olderThan 的文件。
+func CleanupOldTmpFiles(dir string, prefix string, olderThan time.Duration) error {
+	if strings.TrimSpace(dir) == "" {
+		return errors.New("empty dir")
+	}
+	if olderThan <= 0 {
+		return errors.New("olderThan must be positive")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// 目录不存在时不视为错误（首次启动可能尚未产生缓存文件）
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	deadline := time.Now().Add(-olderThan)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			// 读取 info 失败时跳过，不阻断整体清理
+			continue
+		}
+		if info.ModTime().Before(deadline) {
+			_ = os.Remove(filepath.Join(dir, name))
+		}
+	}
+	return nil
+}
+
+// BodyMaxBytesFromEnv 返回最大请求体大小（字节）。
+func BodyMaxBytesFromEnv() int64 {
+	mb := envInt(envBodyMaxMB, DefaultBodyMaxMB)
+	if mb <= 0 {
+		mb = DefaultBodyMaxMB
+	}
+	return int64(mb) * bytesPerMB
+}
+
+// MemoryThresholdBytesFromEnv 返回内存阈值（字节）。
+func MemoryThresholdBytesFromEnv() int64 {
+	mb := envInt(envMemoryThresholdMB, DefaultMemoryThresholdMB)
+	if mb <= 0 {
+		mb = DefaultMemoryThresholdMB
+	}
+	return int64(mb) * bytesPerMB
+}
+
+// TmpDirFromEnv 返回临时目录路径。
+func TmpDirFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv(envTmpDir)); v != "" {
+		return v
+	}
+	return DefaultTmpDir
+}
+
+// TmpCleanupOlderThanFromEnv 返回启动清理阈值时长。
+func TmpCleanupOlderThanFromEnv() time.Duration {
+	h := envInt(envTmpCleanupHours, DefaultTmpCleanupHours)
+	if h <= 0 {
+		h = DefaultTmpCleanupHours
+	}
+	return time.Duration(h) * time.Hour
+}
+
+func envInt(name string, def int) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// spillWriter 在超过阈值时将数据从内存溢写到临时文件。
+type spillWriter struct {
+	thresholdBytes int64
+	tmpDir         string
+	prefix         string
+
+	size int64
+
+	buf bytes.Buffer
+
+	f       *os.File
+	tmpPath string
+}
+
+func (w *spillWriter) Write(p []byte) (int, error) {
+	// 先判断是否需要落盘
+	if w.f == nil && w.size+int64(len(p)) > w.thresholdBytes {
+		if err := w.ensureFile(); err != nil {
+			return 0, err
+		}
+	}
+
+	var n int
+	var err error
+	if w.f != nil {
+		n, err = w.f.Write(p)
+	} else {
+		n, err = w.buf.Write(p)
+	}
+	w.size += int64(n)
+	return n, err
+}
+
+func (w *spillWriter) ensureFile() error {
+	dir := w.tmpDir
+	if strings.TrimSpace(dir) == "" {
+		dir = DefaultTmpDir
+	}
+
+	// 确保临时目录存在
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	f, err := os.CreateTemp(dir, w.prefix+"*")
+	if err != nil {
+		return err
+	}
+	w.f = f
+	w.tmpPath = f.Name()
+
+	// 把 buffer 内容写入文件
+	if w.buf.Len() > 0 {
+		if _, err := w.f.Write(w.buf.Bytes()); err != nil {
+			_ = w.f.Close()
+			_ = os.Remove(w.tmpPath)
+			w.f = nil
+			w.tmpPath = ""
+			return err
+		}
+		w.buf.Reset()
+	}
+	return nil
+}
+
+// Bytes 返回内存缓存的数据（仅在未落盘时有效）。
+func (w *spillWriter) Bytes() []byte {
+	if w.f != nil {
+		return nil
+	}
+	// 复制一份，避免外部修改内部 buffer
+	out := make([]byte, w.buf.Len())
+	copy(out, w.buf.Bytes())
+	return out
+}
+
+// TmpPath 返回临时文件路径（仅在已落盘时有效）。
+func (w *spillWriter) TmpPath() string {
+	return w.tmpPath
+}
+
+// Close 关闭文件句柄（不删除文件）。
+func (w *spillWriter) Close() error {
+	if w.f == nil {
+		return nil
+	}
+	err := w.f.Close()
+	w.f = nil
+	return err
+}

--- a/internal/relay/images.go
+++ b/internal/relay/images.go
@@ -1,0 +1,955 @@
+package relay
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/helper"
+	"github.com/bestruirui/octopus/internal/model"
+	"github.com/bestruirui/octopus/internal/op"
+	"github.com/bestruirui/octopus/internal/price"
+	"github.com/bestruirui/octopus/internal/relay/balancer"
+	"github.com/bestruirui/octopus/internal/relay/bodycache"
+	"github.com/bestruirui/octopus/internal/server/resp"
+	"github.com/bestruirui/octopus/internal/transformer/outbound"
+	"github.com/bestruirui/octopus/internal/utils/log"
+	"github.com/gin-gonic/gin"
+)
+
+const imagesUpstreamErrorBodyLimit = 16 * 1024
+
+// ImagesHandler 是 OpenAI Images API 的统一 relay 入口。
+// endpoint 形如：/images/generations、/images/edits、/images/variations（不含 /v1 前缀）。
+func ImagesHandler(endpoint string, c *gin.Context) {
+	ctx := c.Request.Context()
+
+	apiKeyID := c.GetInt("api_key_id")
+
+	// 缓存请求体，支持多次重试重放
+	bc, err := bodycache.New(c.Request.Body)
+	if err != nil {
+		var tooLarge *bodycache.BodyTooLargeError
+		if errors.As(err, &tooLarge) {
+			resp.Error(c, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		resp.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer func() {
+		if cerr := bc.Close(); cerr != nil {
+			log.Warnf("failed to close images body cache: %v", cerr)
+		}
+	}()
+
+	contentType := c.GetHeader("Content-Type")
+	isMultipart := strings.Contains(strings.ToLower(contentType), "multipart/form-data")
+
+	// 解析 requestModel 与 stream（严格模式：model 必填）
+	var (
+		requestModel string
+		stream       bool
+		boundary     string
+		jsonPayload  map[string]any
+	)
+	if isMultipart {
+		_, params, perr := mime.ParseMediaType(contentType)
+		if perr != nil {
+			resp.Error(c, http.StatusBadRequest, "invalid multipart content-type")
+			return
+		}
+		boundary = strings.TrimSpace(params["boundary"])
+		if boundary == "" {
+			resp.Error(c, http.StatusBadRequest, "invalid multipart boundary")
+			return
+		}
+		m, s, perr := parseMultipartModelAndStream(bc, boundary)
+		if perr != nil {
+			resp.Error(c, http.StatusBadRequest, perr.Error())
+			return
+		}
+		requestModel = m
+		stream = s
+	} else {
+		payload, m, s, perr := parseJSONModelAndStream(bc)
+		if perr != nil {
+			resp.Error(c, http.StatusBadRequest, perr.Error())
+			return
+		}
+		jsonPayload = payload
+		requestModel = m
+		stream = s
+	}
+
+	// supported_models 校验（复用 APIKeyAuth 注入）
+	supportedModels := strings.TrimSpace(c.GetString("supported_models"))
+	if supportedModels != "" {
+		supportedModelsArray := strings.Split(supportedModels, ",")
+		if !slices.Contains(supportedModelsArray, requestModel) {
+			resp.Error(c, http.StatusBadRequest, "model not supported")
+			return
+		}
+	}
+
+	// 获取通道分组
+	group, err := op.GroupGetEnabledMap(requestModel, ctx)
+	if err != nil {
+		resp.Error(c, http.StatusNotFound, "model not found")
+		return
+	}
+
+	// 创建迭代器（策略排序 + 粘性优先）
+	iter := balancer.NewIterator(group, apiKeyID, requestModel)
+	if iter.Len() == 0 {
+		resp.Error(c, http.StatusServiceUnavailable, "no available channel")
+		return
+	}
+
+	// 初始化 Metrics（Images 独立，避免 b64_json 内存膨胀）
+	metrics := newImagesRelayMetrics(apiKeyID, requestModel)
+	metrics.RequestContent = buildImagesRequestContentForLog(isMultipart, bc, jsonPayload)
+
+	var lastErr error
+
+	for iter.Next() {
+		select {
+		case <-ctx.Done():
+			log.Infof("request context canceled, stopping retry")
+			metrics.Save(ctx, false, context.Canceled, iter.Attempts())
+			return
+		default:
+		}
+
+		item := iter.Item()
+
+		// 获取通道
+		channel, err := op.ChannelGet(item.ChannelID, ctx)
+		if err != nil {
+			log.Warnf("failed to get channel %d: %v", item.ChannelID, err)
+			iter.Skip(item.ChannelID, 0, fmt.Sprintf("channel_%d", item.ChannelID), fmt.Sprintf("channel not found: %v", err))
+			lastErr = err
+			continue
+		}
+		if !channel.Enabled {
+			iter.Skip(channel.ID, 0, channel.Name, "channel disabled")
+			continue
+		}
+
+		// channel.Type 限制：仅 OpenAI Chat/Responses
+		if channel.Type != outbound.OutboundTypeOpenAIChat && channel.Type != outbound.OutboundTypeOpenAIResponse {
+			iter.Skip(channel.ID, 0, channel.Name, fmt.Sprintf("unsupported channel type: %d", channel.Type))
+			continue
+		}
+
+		usedKey := channel.GetChannelKey()
+		if usedKey.ChannelKey == "" {
+			iter.Skip(channel.ID, 0, channel.Name, "no available key")
+			continue
+		}
+
+		// 熔断检查（熔断 key 使用 actualModel=item.ModelName）
+		if iter.SkipCircuitBreak(channel.ID, usedKey.ID, channel.Name) {
+			continue
+		}
+
+		log.Infof("images request model %s, mode: %d, forwarding to channel: %s model: %s (attempt %d/%d, sticky=%t, stream=%t)",
+			requestModel, group.Mode, channel.Name, item.ModelName,
+			iter.Index()+1, iter.Len(), iter.IsSticky(), stream)
+
+		span := iter.StartAttempt(channel.ID, usedKey.ID, channel.Name)
+
+		// 尝试一次转发
+		statusCode, written, usage, upstreamCT, fwdErr := imagesAttempt(ctx, endpoint, c, bc, isMultipart, boundary, jsonPayload, stream, channel, usedKey.ChannelKey, group.FirstTokenTimeOut, metrics, item.ModelName)
+
+		// 更新 channel key 状态
+		usedKey.StatusCode = statusCode
+		usedKey.LastUseTimeStamp = time.Now().Unix()
+
+		if fwdErr == nil {
+			// ====== 成功 ======
+			metrics.ActualModel = item.ModelName
+			if usage != nil {
+				metrics.SetUsageFromImages(item.ModelName, *usage)
+			}
+			metrics.ResponseContent = buildImagesResponseContentForLog(stream, upstreamCT, usage)
+
+			usedKey.TotalCost += metrics.Stats.InputCost + metrics.Stats.OutputCost
+			op.ChannelKeyUpdate(usedKey)
+
+			span.End(model.AttemptSuccess, statusCode, "")
+
+			// Channel 维度统计
+			op.StatsChannelUpdate(channel.ID, model.StatsMetrics{
+				WaitTime:       span.Duration().Milliseconds(),
+				RequestSuccess: 1,
+			})
+
+			// 熔断器：记录成功
+			balancer.RecordSuccess(channel.ID, usedKey.ID, item.ModelName)
+			// 会话保持：更新粘性记录
+			balancer.SetSticky(apiKeyID, requestModel, channel.ID, usedKey.ID)
+
+			metrics.Save(ctx, true, nil, iter.Attempts())
+			return
+		}
+
+		// ====== 失败 ======
+		op.ChannelKeyUpdate(usedKey)
+		span.End(model.AttemptFailed, statusCode, fwdErr.Error())
+
+		// Channel 维度统计
+		op.StatsChannelUpdate(channel.ID, model.StatsMetrics{
+			WaitTime:      span.Duration().Milliseconds(),
+			RequestFailed: 1,
+		})
+
+		// 熔断器：记录失败
+		balancer.RecordFailure(channel.ID, usedKey.ID, item.ModelName)
+
+		if written || c.Writer.Written() {
+			metrics.Save(ctx, false, fwdErr, iter.Attempts())
+			return
+		}
+
+		lastErr = fmt.Errorf("channel %s failed: %v", channel.Name, fwdErr)
+	}
+
+	// 所有通道都失败
+	metrics.Save(ctx, false, lastErr, iter.Attempts())
+	resp.Error(c, http.StatusBadGateway, "all channels failed")
+}
+
+type imagesUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+type imagesRelayMetrics struct {
+	APIKeyID     int
+	RequestModel string
+	ActualModel  string
+	StartTime    time.Time
+	FirstToken   time.Time
+
+	Stats model.StatsMetrics
+
+	RequestContent  string
+	ResponseContent string
+}
+
+func newImagesRelayMetrics(apiKeyID int, requestModel string) *imagesRelayMetrics {
+	return &imagesRelayMetrics{
+		APIKeyID:     apiKeyID,
+		RequestModel: requestModel,
+		StartTime:    time.Now(),
+	}
+}
+
+func (m *imagesRelayMetrics) SetFirstTokenTime(t time.Time) {
+	if m.FirstToken.IsZero() {
+		m.FirstToken = t
+	}
+}
+
+func (m *imagesRelayMetrics) SetUsageFromImages(actualModel string, u imagesUsage) {
+	m.ActualModel = actualModel
+	m.Stats.InputToken = int64(u.InputTokens)
+	m.Stats.OutputToken = int64(u.OutputTokens)
+
+	modelPrice := price.GetLLMPrice(actualModel)
+	if modelPrice == nil {
+		return
+	}
+
+	m.Stats.InputCost = float64(u.InputTokens) * modelPrice.Input * 1e-6
+	m.Stats.OutputCost = float64(u.OutputTokens) * modelPrice.Output * 1e-6
+}
+
+func (m *imagesRelayMetrics) Save(ctx context.Context, success bool, err error, attempts []model.ChannelAttempt) {
+	duration := time.Since(m.StartTime)
+
+	globalStats := model.StatsMetrics{
+		WaitTime:    duration.Milliseconds(),
+		InputToken:  m.Stats.InputToken,
+		OutputToken: m.Stats.OutputToken,
+		InputCost:   m.Stats.InputCost,
+		OutputCost:  m.Stats.OutputCost,
+	}
+	if success {
+		globalStats.RequestSuccess = 1
+	} else {
+		globalStats.RequestFailed = 1
+	}
+
+	channelID, channelName := finalChannel(attempts)
+	op.StatsTotalUpdate(globalStats)
+	op.StatsHourlyUpdate(globalStats)
+	op.StatsDailyUpdate(context.Background(), globalStats)
+	op.StatsAPIKeyUpdate(m.APIKeyID, globalStats)
+	op.StatsChannelUpdate(channelID, globalStats)
+
+	log.Infof("images relay complete: model=%s, channel=%d(%s), success=%t, duration=%dms, input_token=%d, output_token=%d, input_cost=%f, output_cost=%f, total_cost=%f, attempts=%d",
+		m.RequestModel, channelID, channelName, success, duration.Milliseconds(),
+		m.Stats.InputToken, m.Stats.OutputToken,
+		m.Stats.InputCost, m.Stats.OutputCost, m.Stats.InputCost+m.Stats.OutputCost,
+		len(attempts))
+
+	m.saveLog(ctx, err, duration, attempts, channelID, channelName)
+}
+
+func (m *imagesRelayMetrics) saveLog(ctx context.Context, err error, duration time.Duration, attempts []model.ChannelAttempt, channelID int, channelName string) {
+	actualModel := m.ActualModel
+	if actualModel == "" {
+		actualModel = m.RequestModel
+	}
+
+	relayLog := model.RelayLog{
+		Time:             m.StartTime.Unix(),
+		RequestModelName: m.RequestModel,
+		ChannelName:      channelName,
+		ChannelId:        channelID,
+		ActualModelName:  actualModel,
+		UseTime:          int(duration.Milliseconds()),
+		Attempts:         attempts,
+		TotalAttempts:    len(attempts),
+		RequestContent:   m.RequestContent,
+		ResponseContent:  m.ResponseContent,
+	}
+
+	if apiKey, getErr := op.APIKeyGet(m.APIKeyID, ctx); getErr == nil {
+		relayLog.RequestAPIKeyName = apiKey.Name
+	}
+
+	// 首字时间
+	if !m.FirstToken.IsZero() {
+		relayLog.Ftut = int(m.FirstToken.Sub(m.StartTime).Milliseconds())
+	}
+
+	// Usage
+	if m.Stats.InputToken > 0 || m.Stats.OutputToken > 0 {
+		relayLog.InputTokens = int(m.Stats.InputToken)
+		relayLog.OutputTokens = int(m.Stats.OutputToken)
+		relayLog.Cost = m.Stats.InputCost + m.Stats.OutputCost
+	}
+
+	if err != nil {
+		relayLog.Error = err.Error()
+	}
+
+	if logErr := op.RelayLogAdd(ctx, relayLog); logErr != nil {
+		log.Warnf("failed to save relay log: %v", logErr)
+	}
+}
+
+func buildImagesRequestContentForLog(isMultipart bool, bc *bodycache.BodyCache, jsonPayload map[string]any) string {
+	if isMultipart {
+		// multipart 可能包含图片文件，避免落库
+		return fmt.Sprintf(`{"content_type":"multipart/form-data","size_bytes":%d,"note":"multipart request content omitted for storage"}`, bc.Size())
+	}
+	if jsonPayload == nil {
+		return ""
+	}
+	b, err := json.Marshal(jsonPayload)
+	if err != nil {
+		return ""
+	}
+	return truncateString(string(b), 8*1024)
+}
+
+func buildImagesResponseContentForLog(stream bool, upstreamCT string, usage *imagesUsage) string {
+	if usage == nil {
+		return ""
+	}
+	// 不记录 b64_json，仅记录 usage
+	type respForLog struct {
+		Stream      bool        `json:"stream"`
+		ContentType string      `json:"content_type,omitempty"`
+		Usage       *imagesUsage `json:"usage,omitempty"`
+		Note        string      `json:"note,omitempty"`
+	}
+	obj := respForLog{
+		Stream:      stream,
+		ContentType: upstreamCT,
+		Usage:       usage,
+		Note:        "image data omitted for storage",
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func truncateString(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "...(truncated)"
+}
+
+func parseJSONModelAndStream(bc *bodycache.BodyCache) (payload map[string]any, modelName string, stream bool, err error) {
+	r, err := bc.NewReader()
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer r.Close()
+
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, "", false, errors.New("empty body")
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, "", false, errors.New("invalid json")
+	}
+
+	rawModel, ok := m["model"]
+	if !ok {
+		return nil, "", false, errors.New("model is required")
+	}
+	modelStr, ok := rawModel.(string)
+	if !ok || strings.TrimSpace(modelStr) == "" {
+		return nil, "", false, errors.New("model is required")
+	}
+
+	stream = false
+	if v, ok := m["stream"]; ok {
+		switch vv := v.(type) {
+		case bool:
+			stream = vv
+		case string:
+			stream = strings.EqualFold(strings.TrimSpace(vv), "true")
+		case float64:
+			stream = vv != 0
+		}
+	}
+
+	return m, strings.TrimSpace(modelStr), stream, nil
+}
+
+func parseMultipartModelAndStream(bc *bodycache.BodyCache, boundary string) (modelName string, stream bool, err error) {
+	r, err := bc.NewReader()
+	if err != nil {
+		return "", false, err
+	}
+	defer r.Close()
+
+	mr := multipart.NewReader(r, boundary)
+
+	stream = false
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return "", false, err
+		}
+
+		name := part.FormName()
+		if name == "" {
+			_, _ = io.Copy(io.Discard, part)
+			_ = part.Close()
+			continue
+		}
+
+		switch name {
+		case "model":
+			b, _ := io.ReadAll(io.LimitReader(part, 1024))
+			modelName = strings.TrimSpace(string(b))
+		case "stream":
+			b, _ := io.ReadAll(io.LimitReader(part, 16))
+			stream = strings.EqualFold(strings.TrimSpace(string(b)), "true")
+		default:
+			_, _ = io.Copy(io.Discard, part)
+		}
+		_ = part.Close()
+	}
+
+	if strings.TrimSpace(modelName) == "" {
+		return "", false, errors.New("model is required")
+	}
+	return modelName, stream, nil
+}
+
+func imagesAttempt(
+	ctx context.Context,
+	endpoint string,
+	c *gin.Context,
+	bc *bodycache.BodyCache,
+	isMultipart bool,
+	boundary string,
+	jsonPayload map[string]any,
+	stream bool,
+	channel *model.Channel,
+	channelKey string,
+	firstTokenTimeOutSec int,
+	metrics *imagesRelayMetrics,
+	actualModel string,
+) (statusCode int, written bool, usage *imagesUsage, upstreamCT string, err error) {
+	// 构建 URL（baseUrl.Path 后追加 endpoint）
+	baseURL := channel.GetBaseUrl()
+	parsedURL, err := url.Parse(strings.TrimSuffix(baseURL, "/"))
+	if err != nil {
+		return 0, false, nil, "", fmt.Errorf("failed to parse base url: %w", err)
+	}
+	parsedURL.Path = parsedURL.Path + endpoint
+
+	var bodyReader io.Reader
+	var contentType string
+
+	if isMultipart {
+		pr, pw := io.Pipe()
+		mw := multipart.NewWriter(pw)
+		contentType = mw.FormDataContentType()
+		bodyReader = pr
+
+		go func() {
+			src, err := bc.NewReader()
+			if err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			defer src.Close()
+
+			if err := copyMultipartReplaceModel(src, boundary, mw, actualModel); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			// 先关闭 multipart.Writer 写入结束 boundary，再关闭 pipe writer
+			if err := mw.Close(); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+			_ = pw.Close()
+		}()
+	} else {
+		// JSON：仅改写 model 字段，其余保持不变
+		// 注意：每次尝试都重新 marshal 生成 body，确保可重试重建
+		if jsonPayload == nil {
+			return 0, false, nil, "", errors.New("nil json payload")
+		}
+		jsonPayload["model"] = actualModel
+		b, err := json.Marshal(jsonPayload)
+		if err != nil {
+			return 0, false, nil, "", fmt.Errorf("failed to marshal json: %w", err)
+		}
+		bodyReader = bytes.NewReader(b)
+		contentType = "application/json"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", bodyReader)
+	if err != nil {
+		return 0, false, nil, "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.URL = parsedURL
+	req.Method = http.MethodPost
+
+	// Header 透传：复制下游 header，过滤 hop-by-hop 与鉴权相关
+	copyHeadersToUpstream(req, c, channel, channelKey, contentType, stream)
+
+	// 发送请求
+	httpClient, err := helper.ChannelHttpClient(channel)
+	if err != nil {
+		return 0, false, nil, "", err
+	}
+
+	respUp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, false, nil, "", fmt.Errorf("failed to send request: %w", err)
+	}
+	defer respUp.Body.Close()
+
+	upstreamCT = respUp.Header.Get("Content-Type")
+
+	// stream=true：逐行解析 event/data/空行边界透传
+	if stream {
+		if respUp.StatusCode < 200 || respUp.StatusCode >= 300 {
+			b, _ := io.ReadAll(io.LimitReader(respUp.Body, imagesUpstreamErrorBodyLimit))
+			return respUp.StatusCode, false, nil, upstreamCT, fmt.Errorf("upstream error: %d: %s", respUp.StatusCode, string(b))
+		}
+		u, w, err := proxySSE(ctx, c, respUp, firstTokenTimeOutSec, metrics)
+		return respUp.StatusCode, w, u, upstreamCT, err
+	}
+
+	// 非流式：2xx 透传，否则读取限长错误体用于错误信息与重试判定
+	if respUp.StatusCode < 200 || respUp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(respUp.Body, imagesUpstreamErrorBodyLimit))
+		return respUp.StatusCode, false, nil, upstreamCT, fmt.Errorf("upstream error: %d: %s", respUp.StatusCode, string(b))
+	}
+
+	u, w, err := proxyNonStream(c, respUp)
+	return respUp.StatusCode, w, u, upstreamCT, err
+}
+
+func copyHeadersToUpstream(req *http.Request, c *gin.Context, channel *model.Channel, channelKey string, contentType string, stream bool) {
+	for k, values := range c.Request.Header {
+		if hopByHopHeaders[strings.ToLower(k)] {
+			continue
+		}
+		for _, v := range values {
+			req.Header.Add(k, v)
+		}
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	} else if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+channelKey)
+
+	if len(channel.CustomHeader) > 0 {
+		for _, h := range channel.CustomHeader {
+			req.Header.Set(h.HeaderKey, h.HeaderValue)
+		}
+	}
+}
+
+func copyMultipartReplaceModel(src io.Reader, boundary string, dst *multipart.Writer, newModel string) error {
+	mr := multipart.NewReader(src, boundary)
+
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		hdr := make(textproto.MIMEHeader, len(part.Header))
+		for k, vv := range part.Header {
+			cp := make([]string, len(vv))
+			copy(cp, vv)
+			hdr[k] = cp
+		}
+
+		pw, err := dst.CreatePart(hdr)
+		if err != nil {
+			_ = part.Close()
+			return err
+		}
+
+		if part.FormName() == "model" && part.FileName() == "" {
+			// 丢弃原值，写入替换后的 model（继续复制后续 part）
+			_, _ = io.Copy(io.Discard, part)
+			_, werr := io.WriteString(pw, newModel)
+			_ = part.Close()
+			if werr != nil {
+				return werr
+			}
+			continue
+		}
+
+		_, err = io.Copy(pw, part)
+		_ = part.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// proxyNonStream 将上游非流式响应原样透传到下游，同时尽量提取 usage（避免解析巨大 b64_json）。
+func proxyNonStream(c *gin.Context, respUp *http.Response) (*imagesUsage, bool, error) {
+	ct := respUp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "application/json"
+	}
+	c.Header("Content-Type", ct)
+	c.Status(respUp.StatusCode)
+
+	scanner := newUsageScanner()
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := respUp.Body.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			scanner.Feed(chunk)
+			if _, werr := c.Writer.Write(chunk); werr != nil {
+				return scanner.Usage(), true, werr
+			}
+		}
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				break
+			}
+			return scanner.Usage(), c.Writer.Written(), rerr
+		}
+	}
+
+	return scanner.Usage(), c.Writer.Written(), nil
+}
+
+// proxySSE 将上游 SSE 逐行解析 event/data/空行并透传到下游；首事件计为 FirstTokenTime；支持 FirstTokenTimeOut 切换。
+func proxySSE(ctx context.Context, c *gin.Context, respUp *http.Response, firstTokenTimeOutSec int, metrics *imagesRelayMetrics) (*imagesUsage, bool, error) {
+	if ct := respUp.Header.Get("Content-Type"); ct != "" && !strings.Contains(strings.ToLower(ct), "text/event-stream") {
+		b, _ := io.ReadAll(io.LimitReader(respUp.Body, imagesUpstreamErrorBodyLimit))
+		return nil, false, fmt.Errorf("upstream returned non-SSE content-type %q for stream request: %s", ct, string(b))
+	}
+
+	// 设置 SSE 响应头
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+
+	type lineResult struct {
+		line []byte
+		err  error
+		eof  bool
+	}
+
+	results := make(chan lineResult, 1)
+	go func() {
+		defer close(results)
+		br := bufio.NewReaderSize(respUp.Body, 64*1024)
+		for {
+			line, err := readLineLimited(br, maxSSEEventSize)
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					results <- lineResult{eof: true}
+					return
+				}
+				results <- lineResult{err: err}
+				return
+			}
+			results <- lineResult{line: line}
+		}
+	}()
+
+	var firstTokenTimer *time.Timer
+	var firstTokenC <-chan time.Time
+	if firstTokenTimeOutSec > 0 {
+		firstTokenTimer = time.NewTimer(time.Duration(firstTokenTimeOutSec) * time.Second)
+		firstTokenC = firstTokenTimer.C
+		defer func() {
+			if firstTokenTimer != nil {
+				firstTokenTimer.Stop()
+			}
+		}()
+	}
+
+	var (
+		firstWrite      = true
+		currentEvent    string
+		completedScanner = newUsageScanner()
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Infof("client disconnected, stopping stream")
+			return completedScanner.Usage(), c.Writer.Written(), nil
+
+		case <-firstTokenC:
+			log.Warnf("first token timeout (%ds), switching channel", firstTokenTimeOutSec)
+			_ = respUp.Body.Close()
+			return completedScanner.Usage(), c.Writer.Written(), fmt.Errorf("first token timeout (%ds)", firstTokenTimeOutSec)
+
+		case r, ok := <-results:
+			if !ok {
+				return completedScanner.Usage(), c.Writer.Written(), nil
+			}
+			if r.eof {
+				return completedScanner.Usage(), c.Writer.Written(), nil
+			}
+			if r.err != nil {
+				return completedScanner.Usage(), c.Writer.Written(), fmt.Errorf("failed to read stream line: %w", r.err)
+			}
+
+			line := r.line
+			trimmed := bytes.TrimRight(line, "\r\n")
+			if len(trimmed) == 0 {
+				// 空行：事件边界
+				currentEvent = ""
+			} else if bytes.HasPrefix(trimmed, []byte("event:")) {
+				currentEvent = strings.TrimSpace(string(trimmed[len("event:"):]))
+			} else if bytes.HasPrefix(trimmed, []byte("data:")) {
+				// 仅在 completed 事件上尝试提取 usage（避免解析/分配巨大 b64_json）
+				payload := bytes.TrimSpace(trimmed[len("data:"):])
+				if currentEvent == "image_generation.completed" || bytes.Contains(payload, []byte(`"type":"image_generation.completed"`)) {
+					completedScanner.Feed(payload)
+				}
+			}
+
+			if _, werr := c.Writer.Write(line); werr != nil {
+				return completedScanner.Usage(), true, werr
+			}
+			c.Writer.Flush()
+
+			if firstWrite {
+				metrics.SetFirstTokenTime(time.Now())
+				firstWrite = false
+				if firstTokenTimer != nil {
+					if !firstTokenTimer.Stop() {
+						select {
+						case <-firstTokenTimer.C:
+						default:
+						}
+					}
+					firstTokenTimer = nil
+					firstTokenC = nil
+				}
+			}
+		}
+	}
+}
+
+func readLineLimited(br *bufio.Reader, limit int) ([]byte, error) {
+	var out []byte
+	for {
+		part, err := br.ReadSlice('\n')
+		out = append(out, part...)
+		if len(out) > limit {
+			return nil, fmt.Errorf("sse line exceeds limit %d bytes", limit)
+		}
+		if err == nil {
+			return out, nil
+		}
+		if errors.Is(err, bufio.ErrBufferFull) {
+			continue
+		}
+		// 允许返回已读部分 + err（调用方按 err 处理）
+		return out, err
+	}
+}
+
+type usageScanner struct {
+	matchIdx       int
+	waitForObject  bool
+	collecting     bool
+	braceDepth     int
+	inString       bool
+	escape         bool
+	buf            bytes.Buffer
+	usage          *imagesUsage
+	done           bool
+	maxCollectSize int
+}
+
+func newUsageScanner() *usageScanner {
+	return &usageScanner{maxCollectSize: 64 * 1024}
+}
+
+// Feed 逐字节扫描输入，定位 "usage":{...} 并仅解析 usage 子对象。
+// 该实现用于避免整体 json.Unmarshal 造成 b64_json 巨大内存分配。
+func (s *usageScanner) Feed(p []byte) {
+	if s.done || len(p) == 0 {
+		return
+	}
+	const pat = `"usage":`
+
+	for _, b := range p {
+		if s.done {
+			return
+		}
+
+		if s.collecting {
+			if s.buf.Len() >= s.maxCollectSize {
+				s.collecting = false
+				s.done = true
+				return
+			}
+			s.buf.WriteByte(b)
+
+			if s.inString {
+				if s.escape {
+					s.escape = false
+				} else if b == '\\' {
+					s.escape = true
+				} else if b == '"' {
+					s.inString = false
+				}
+				continue
+			}
+
+			if b == '"' {
+				s.inString = true
+				continue
+			}
+
+			switch b {
+			case '{':
+				s.braceDepth++
+			case '}':
+				s.braceDepth--
+				if s.braceDepth == 0 {
+					var u imagesUsage
+					if err := json.Unmarshal(s.buf.Bytes(), &u); err == nil {
+						s.usage = &u
+					}
+					s.done = true
+					s.collecting = false
+					return
+				}
+			}
+			continue
+		}
+
+		if s.waitForObject {
+			if b == '{' {
+				s.collecting = true
+				s.braceDepth = 1
+				s.buf.Reset()
+				s.buf.WriteByte('{')
+				s.inString = false
+				s.escape = false
+				s.waitForObject = false
+				continue
+			}
+			// 跳过空白，遇到其他字符则放弃
+			if b == ' ' || b == '\t' || b == '\n' || b == '\r' {
+				continue
+			}
+			s.waitForObject = false
+			continue
+		}
+
+		// 匹配 "usage":
+		if b == pat[s.matchIdx] {
+			s.matchIdx++
+			if s.matchIdx == len(pat) {
+				s.waitForObject = true
+				s.matchIdx = 0
+			}
+			continue
+		}
+
+		// 失败回退：若当前字符可能是 pat[0]，则 matchIdx=1
+		if b == pat[0] {
+			s.matchIdx = 1
+		} else {
+			s.matchIdx = 0
+		}
+	}
+}
+
+func (s *usageScanner) Usage() *imagesUsage {
+	return s.usage
+}

--- a/internal/server/handlers/images.go
+++ b/internal/server/handlers/images.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/bestruirui/octopus/internal/relay"
+	"github.com/bestruirui/octopus/internal/server/middleware"
+	"github.com/bestruirui/octopus/internal/server/router"
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	router.NewGroupRouter("/v1/images").
+		Use(middleware.APIKeyAuth()).
+		AddRoute(
+			router.NewRoute("/generations", http.MethodPost).
+				Handle(generations),
+		).
+		AddRoute(
+			router.NewRoute("/edits", http.MethodPost).
+				Handle(edits),
+		).
+		AddRoute(
+			router.NewRoute("/variations", http.MethodPost).
+				Handle(variations),
+		)
+}
+
+func generations(c *gin.Context) {
+	relay.ImagesHandler("/images/generations", c)
+}
+
+func edits(c *gin.Context) {
+	relay.ImagesHandler("/images/edits", c)
+}
+
+func variations(c *gin.Context) {
+	relay.ImagesHandler("/images/variations", c)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/bestruirui/octopus/internal/conf"
+	"github.com/bestruirui/octopus/internal/relay/bodycache"
 	_ "github.com/bestruirui/octopus/internal/server/handlers"
 	"github.com/bestruirui/octopus/internal/server/middleware"
 	"github.com/bestruirui/octopus/internal/server/resp"
@@ -21,6 +22,13 @@ func Start() error {
 		gin.SetMode(gin.DebugMode)
 	} else {
 		gin.SetMode(gin.ReleaseMode)
+	}
+
+	// 启动时清理 Images 请求体临时文件（失败仅告警，不阻断启动）
+	tmpDir := bodycache.TmpDirFromEnv()
+	olderThan := bodycache.TmpCleanupOlderThanFromEnv()
+	if err := bodycache.CleanupOldTmpFiles(tmpDir, bodycache.TmpFilePrefix, olderThan); err != nil {
+		log.Warnf("cleanup images tmp files failed: dir=%s prefix=%s olderThan=%s err=%v", tmpDir, bodycache.TmpFilePrefix, olderThan, err)
 	}
 
 	r := gin.New()


### PR DESCRIPTION
- 新增 /v1/images 路由组与三端点（generations/edits/variations），仅使用 APIKeyAuth
- 实现 Images 专用 relay：多渠道重试、熔断记录、统计与日志落库
- 支持 JSON 与 multipart 请求，严格要求 model 字段；multipart 重建请求体以替换上游 model
- 支持 stream=true：逐行解析并透传 SSE event/data；首事件超时触发切换渠道
- 引入请求体缓存（内存→落盘）与启动时临时文件清理，避免大请求/重试时内存膨胀
- usage 仅解析 usage 子对象（避免 b64_json 造成内存问题），并映射到现有 token/cost 口径
- 补充单测覆盖：usage 扫描、JSON/multipart 解析、SSE 行读取限制、bodycache 行为
- 更新文档：端点与环境变量说明、Images 转发行为约束、设计方案