### PR TITLE
fix: saveLog early return prevents relay logs from being persisted (#273 regression)

### DIFF
--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -166,27 +166,25 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 		reqJSON, jsonErr := json.Marshal(m.InternalRequest)
 		if jsonErr != nil {
 			relayLog.RequestContent = string(reqJSON)
-			return
-		}
-		if m.ParamOverride == "" {
-			relayLog.RequestContent = string(reqJSON)
-			return
-		}
-		var reqMap map[string]any
-		if err := json.Unmarshal(reqJSON, &reqMap); err != nil {
-			relayLog.RequestContent = string(reqJSON)
-			return
-		}
-		var override map[string]any
-		if err := json.Unmarshal([]byte(m.ParamOverride), &override); err != nil {
-			relayLog.RequestContent = string(reqJSON)
-			return
-		}
-		maps.Copy(reqMap, override)
-		if finalJSON, err := json.Marshal(reqMap); err != nil {
+		} else if m.ParamOverride == "" {
 			relayLog.RequestContent = string(reqJSON)
 		} else {
-			relayLog.RequestContent = string(finalJSON)
+			var reqMap map[string]any
+			if err := json.Unmarshal(reqJSON, &reqMap); err != nil {
+				relayLog.RequestContent = string(reqJSON)
+			} else {
+				var override map[string]any
+				if err := json.Unmarshal([]byte(m.ParamOverride), &override); err != nil {
+					relayLog.RequestContent = string(reqJSON)
+				} else {
+					maps.Copy(reqMap, override)
+					if finalJSON, err := json.Marshal(reqMap); err != nil {
+						relayLog.RequestContent = string(reqJSON)
+					} else {
+						relayLog.RequestContent = string(finalJSON)
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Commit c21e1e1 (#273) introduced early `return` statements in `saveLog()` that cause the function to exit before reaching `op.RelayLogAdd()`, meaning relay logs are never written to the database.
- The most impactful branch is `m.ParamOverride == ""` — since most requests have no parameter override, this `return` fires for nearly all requests, effectively disabling all relay log persistence.
- Replace the early-return pattern with `if/else if/else` chains so that setting `RequestContent` no longer short-circuits the rest of the function.

## Fix

Removed 4 erroneous `return` statements in the `InternalRequest` processing block of `saveLog()` (`internal/relay/metrics.go`), restructuring the logic into nested `if/else` branches that fall through to `ResponseContent`, `Error`, and `op.RelayLogAdd()` as intended.