### PR TITLE
fix: add missing packages field to pnpm-workspace.yaml

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - '.'
+
 allowBuilds:
   '@swc/core': true
   sharp: true


### PR DESCRIPTION
**Problem**

运行 `scripts/build.sh` 时，在 `build_frontend()` 函数中执行 pnpm install 报错：
`ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty`