### PR TITLE
fix: 修复关闭历史日志时日志缓存内存延迟释放导致占用过高问题

### DIFF
--- a/internal/op/log.go
+++ b/internal/op/log.go
@@ -134,9 +134,12 @@ func RelayLogAdd(ctx context.Context, relayLog model.RelayLog) error {
 			return relayLogFlushToDB(ctx)
 		}
 		// 如果未启用日志保存，移除最旧的日志，保留最新的日志用于实时查询
+		// 重建底层数组而不是 reslice，避免数组持续引用旧日志的 Request/ResponseContent 导致内存无法回收
 		keepSize := maxSize / 2
 		if len(relayLogCache) > keepSize {
-			relayLogCache = relayLogCache[len(relayLogCache)-keepSize:]
+			newCache := make([]model.RelayLog, keepSize, maxSize)
+			copy(newCache, relayLogCache[len(relayLogCache)-keepSize:])
+			relayLogCache = newCache
 		}
 	}
 	relayLogCacheLock.Unlock()
@@ -165,7 +168,9 @@ func RelayLogSaveDBTask(ctx context.Context) error {
 	relayLogCacheLock.Lock()
 	if len(relayLogCache) > relayLogMaxSizeNoDB {
 		keepSize := relayLogMaxSizeNoDB / 2
-		relayLogCache = relayLogCache[len(relayLogCache)-keepSize:]
+		newCache := make([]model.RelayLog, keepSize, relayLogMaxSizeNoDB)
+		copy(newCache, relayLogCache[len(relayLogCache)-keepSize:])
+		relayLogCache = newCache
 	}
 	relayLogCacheLock.Unlock()
 


### PR DESCRIPTION
## 问题

  当 **日志设置 - 启用历史日志** 为 `false` 时，日志只写内存，逻辑上每超过 100 条会裁剪到 50 条：

  ```go
  relayLogCache = relayLogCache[len(relayLogCache)-keepSize:]
  ```

  但这样处理底层数组并未释放，被裁掉的 50 条 Log仍被数组持有，必须等下次触发slice扩容才会被 GC，存在明显的延迟释放窗 口。

  我连续发送 1000 条 MOCK 请求做压测，内存占用达到 100+ MB：

  <img width="691" height="42" alt="问题描述截图" src="https://github.com/user-attachments/assets/c8b8a672-2573-4908-a858-3752ac4ac2fe" />

  在并发较高，或单次请求/响应体较大（例如使用 Claude Code ）的场景下，这个延迟释放会让内存峰值过高，甚至打穿容器内存限额。例如我的服务器中设置octopus内存限制为256M，在大概三个Claudecode窗口并行执行任务的时候就会出现内存过大导致处理缓慢和超时。

  ## 我的修复方法

  将 nodb 路径下的两处裁剪（`RelayLogAdd` 与 `RelayLogSaveDBTask`）从 reslice 改为 `make + copy` 显式重建底层数组：旧数组立刻失去引用，可被 GC
