### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/internal/transformer/outbound/register.go
+++ b/internal/transformer/outbound/register.go
@@ -17,6 +17,7 @@ const (
 	OutboundTypeGemini
 	OutboundTypeVolcengine
 	OutboundTypeOpenAIEmbedding
+	OutboundTypeAstraflow
 )
 
 // EmbeddingChannelTypes 定义支持 embedding 请求的 channel 类型集合
@@ -31,6 +32,7 @@ var ChatChannelTypes = map[OutboundType]bool{
 	OutboundTypeAnthropic:      true,
 	OutboundTypeGemini:         true,
 	OutboundTypeVolcengine:     true,
+	OutboundTypeAstraflow:      true,
 }
 
 // IsEmbeddingChannelType 判断 channel 类型是否支持 embedding 请求
@@ -50,6 +52,7 @@ var outboundFactories = map[OutboundType]func() model.Outbound{
 	OutboundTypeAnthropic:       func() model.Outbound { return &authropic.MessageOutbound{} },
 	OutboundTypeGemini:          func() model.Outbound { return &gemini.MessagesOutbound{} },
 	OutboundTypeVolcengine:      func() model.Outbound { return &volcengine.ResponseOutbound{} },
+	OutboundTypeAstraflow:       func() model.Outbound { return &openai.ChatOutbound{} },
 }
 
 func Get(outboundType OutboundType) model.Outbound {

--- a/web/public/locale/en.json
+++ b/web/public/locale/en.json
@@ -533,6 +533,7 @@
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
             "typeVolcengine": "Volcengine",
+            "typeAstraflow": "Astraflow (UCloud)",
             "autoSync": "Auto Sync",
             "autoGroup": "Auto Group",
             "autoGroupNone": "None",

--- a/web/public/locale/zh_hans.json
+++ b/web/public/locale/zh_hans.json
@@ -533,6 +533,7 @@
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
             "typeVolcengine": "火山引擎",
+            "typeAstraflow": "Astraflow (UCloud)",
             "autoSync": "自动同步",
             "autoGroup": "自动分组",
             "autoGroupNone": "不自动分组",

--- a/web/public/locale/zh_hant.json
+++ b/web/public/locale/zh_hant.json
@@ -533,6 +533,7 @@
             "typeAnthropic": "Anthropic",
             "typeGemini": "Gemini",
             "typeVolcengine": "火山引擎",
+            "typeAstraflow": "Astraflow (UCloud)",
             "autoSync": "自動同步",
             "autoGroup": "自動分組",
             "autoGroupNone": "不自動分組",

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -13,6 +13,7 @@ export enum ChannelType {
     Gemini = 3,
     Volcengine = 4,
     OpenAIEmbedding = 5,
+    Astraflow = 6,
 }
 
 /**

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -256,6 +256,7 @@ export function ChannelForm({
                             <SelectItem className='rounded-xl' value={String(ChannelType.Gemini)}>{t('typeGemini')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.Volcengine)}>{t('typeVolcengine')}</SelectItem>
                             <SelectItem className='rounded-xl' value={String(ChannelType.OpenAIEmbedding)}>{t('typeOpenAIEmbedding')}</SelectItem>
+                            <SelectItem className='rounded-xl' value={String(ChannelType.Astraflow)}>{t('typeAstraflow')}</SelectItem>
                         </SelectContent>
                     </Select>
                 </div>


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a new channel type in Octopus.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI-compatible, this integration reuses the existing `openai.ChatOutbound` — no new SDK or subpackage is needed.

### Provider details
- **Global endpoint:** https://api-us-ca.umodelverse.ai/v1
- **China endpoint:** https://api.modelverse.cn/v1
- **Website:** https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)

### Changes

| File | What changed |
|------|-------------|
| `internal/transformer/outbound/register.go` | Added `OutboundTypeAstraflow = 6` constant; registered it in `ChatChannelTypes` map and `outboundFactories` map (backed by `openai.ChatOutbound`) |
| `web/src/api/endpoints/channel.ts` | Added `Astraflow = 6` to the `ChannelType` enum |
| `web/src/components/modules/channel/Form.tsx` | Added `<SelectItem>` for `ChannelType.Astraflow` in the channel-type dropdown |
| `web/public/locale/en.json` | Added `"typeAstraflow"` translation key |
| `web/public/locale/zh_hans.json` | Added `"typeAstraflow"` translation key |
| `web/public/locale/zh_hant.json` | Added `"typeAstraflow"` translation key |

### Usage

When creating a new channel, select **Astraflow (UCloud)** as the channel type and provide:
- **Base URL:** `https://api-us-ca.umodelverse.ai/v1` (global) or `https://api.modelverse.cn/v1` (China)
- **API Key:** obtained from https://astraflow.ucloud-global.com or https://astraflow.ucloud.cn
