### PR TITLE
fix：移除清理 ReasoningContent、Reasoning 兼容 MiMo 多轮回传要求

### DIFF
--- a/internal/transformer/model/model.go
+++ b/internal/transformer/model/model.go
@@ -329,7 +329,6 @@ func (r *InternalLLMRequest) fillMissingToolCallIDs() {
 	}
 }
 
-
 func (r *InternalLLMRequest) fillMissingToolCallIDsFromToolMessages() {
 	for msgIndex := 0; msgIndex < len(r.Messages); msgIndex++ {
 		msg := &r.Messages[msgIndex]
@@ -509,8 +508,6 @@ type Message struct {
 }
 
 func (m *Message) ClearHelpFields() {
-	m.ReasoningContent = nil
-	m.Reasoning = nil
 	m.ReasoningSignature = nil
 }
 


### PR DESCRIPTION
Message.ClearHelpFields 之前会在发往上游前清空 reasoning_content 与 reasoning字段。MiMo 在多轮对话中要求把上一轮 assistant的 reasoning_content [原样回传，否则在工具调用会出现场景会出现异常](https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content)。改为仅清理内部辅助字段ReasoningSignature，让推理内容按协议透传给上游。