### PR TITLE
feat: 加入embeddings、rerank

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\vbkkk\\\\Documents\\\\GitHub\\\\octopus\" -Force)",
+      "Bash(Select-Object Name, PSIsContainer)",
+      "Bash(xargs wc -l)",
+      "Bash(go doc *)",
+      "Bash(findstr /i \"Rerank rerank RequestType Format\")",
+      "Bash(dir \"C:\\\\Users\\\\vbkkk\\\\Documents\\\\GitHub\\\\\" 2>&1)",
+      "Bash(go build *)"
+    ]
+  }
+}

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -1,0 +1,13 @@
+package db
+
+import "strings"
+
+func IsDuplicateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "duplicate entry") ||
+		strings.Contains(msg, "duplicate key value")
+}

--- a/internal/relay/rerank.go
+++ b/internal/relay/rerank.go
@@ -1,0 +1,215 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/helper"
+	dbmodel "github.com/bestruirui/octopus/internal/model"
+	"github.com/bestruirui/octopus/internal/op"
+	"github.com/bestruirui/octopus/internal/relay/balancer"
+	"github.com/bestruirui/octopus/internal/server/resp"
+	"github.com/bestruirui/octopus/internal/utils/log"
+	"github.com/gin-gonic/gin"
+	"github.com/looplj/axonhub/llm/transformer"
+)
+
+func RerankHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		body, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			resp.Error(c, http.StatusBadRequest, "failed to read request body")
+			return
+		}
+
+		var req struct {
+			Model string `json:"model"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil || req.Model == "" {
+			resp.Error(c, http.StatusBadRequest, "missing or invalid model field")
+			return
+		}
+
+		group, err := op.GroupGetEnabledMap(req.Model, c.Request.Context())
+		if err != nil {
+			resp.Error(c, http.StatusNotFound, "model not found")
+			return
+		}
+
+		apiKeyID := c.GetInt("api_key_id")
+		iter := balancer.NewIterator(group, apiKeyID, req.Model)
+		if iter.Len() == 0 {
+			resp.Error(c, http.StatusServiceUnavailable, "no available channel")
+			return
+		}
+		startTime := time.Now()
+		ctx := c.Request.Context()
+		var lastErr error
+
+		for iter.Next() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			item := iter.Item()
+			channel, err := op.ChannelGet(item.ChannelID, ctx)
+			if err != nil {
+				iter.Skip(item.ChannelID, 0, fmt.Sprintf("channel_%d", item.ChannelID), fmt.Sprintf("channel not found: %v", err))
+				lastErr = err
+				continue
+			}
+			if !channel.Enabled {
+				iter.Skip(channel.ID, 0, channel.Name, "channel disabled")
+				continue
+			}
+
+			usedKey := channel.GetChannelKey()
+			if usedKey.ChannelKey == "" {
+				iter.Skip(channel.ID, 0, channel.Name, "no available key")
+				continue
+			}
+			if iter.SkipCircuitBreak(channel.ID, usedKey.ID, channel.Name) {
+				continue
+			}
+
+			span := iter.StartAttempt(channel.ID, usedKey.ID, channel.Name)
+
+			statusCode, fwdErr := rerankForward(ctx, c, channel, usedKey, item.ModelName, req.Model, body)
+			if fwdErr == nil {
+				usedKey.StatusCode = statusCode
+				usedKey.LastUseTimeStamp = time.Now().Unix()
+				op.ChannelKeyUpdate(usedKey)
+				span.End(dbmodel.AttemptSuccess, "")
+				op.StatsChannelUpdate(channel.ID, dbmodel.StatsMetrics{
+					WaitTime:       span.Duration().Milliseconds(),
+					RequestSuccess: 1,
+				})
+				balancer.RecordSuccess(channel.ID, usedKey.ID, req.Model)
+				saveRerankMetrics(ctx, apiKeyID, req.Model, item.ModelName, startTime, true, nil, iter.Attempts(), channel.ID)
+				return
+			}
+
+			usedKey.StatusCode = statusCode
+			usedKey.LastUseTimeStamp = time.Now().Unix()
+			op.ChannelKeyUpdate(usedKey)
+			span.End(dbmodel.AttemptFailed, fwdErr.Error())
+			op.StatsChannelUpdate(channel.ID, dbmodel.StatsMetrics{
+				WaitTime:      span.Duration().Milliseconds(),
+				RequestFailed: 1,
+			})
+			balancer.RecordFailure(channel.ID, usedKey.ID, req.Model)
+			lastErr = fmt.Errorf("channel %s failed: %v", channel.Name, fwdErr)
+		}
+
+		if lastErr == nil {
+			lastErr = errors.New("all channels failed")
+		}
+		saveRerankMetrics(ctx, apiKeyID, req.Model, req.Model, startTime, false, lastErr, iter.Attempts(), 0)
+		resp.Error(c, http.StatusBadGateway, lastErr.Error())
+	}
+}
+
+func rerankForward(ctx context.Context, c *gin.Context, channel *dbmodel.Channel, usedKey dbmodel.ChannelKey, upstreamModel, requestModel string, body []byte) (int, error) {
+	httpClient, err := helper.ChannelHttpClient(channel)
+	if err != nil {
+		return 0, err
+	}
+
+	outBody := body
+	if upstreamModel != requestModel {
+		var bodyMap map[string]any
+		if err := json.Unmarshal(body, &bodyMap); err == nil {
+			bodyMap["model"] = upstreamModel
+			if modified, err := json.Marshal(bodyMap); err == nil {
+				outBody = modified
+			}
+		}
+	}
+
+	baseURL := transformer.NormalizeBaseURL(channel.GetBaseUrl(), "v1")
+	upstreamURL := baseURL + "/rerank"
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(outBody))
+	if err != nil {
+		return 0, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+usedKey.ChannelKey)
+	for _, h := range channel.CustomHeader {
+		if h.HeaderKey != "" {
+			httpReq.Header.Set(h.HeaderKey, h.HeaderValue)
+		}
+	}
+
+	upstream, err := httpClient.Do(httpReq)
+	if err != nil {
+		return 0, err
+	}
+	defer upstream.Body.Close()
+
+	if upstream.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(upstream.Body)
+		return upstream.StatusCode, fmt.Errorf("upstream returned %d: %s", upstream.StatusCode, string(respBody))
+	}
+
+	for key, values := range upstream.Header {
+		for _, v := range values {
+			c.Header(key, v)
+		}
+	}
+	c.Status(upstream.StatusCode)
+	_, _ = io.Copy(c.Writer, upstream.Body)
+	return upstream.StatusCode, nil
+}
+
+func saveRerankMetrics(ctx context.Context, apiKeyID int, requestModel, actualModel string, startTime time.Time, success bool, err error, attempts []dbmodel.ChannelAttempt, channelID int) {
+	duration := time.Since(startTime)
+	globalStats := dbmodel.StatsMetrics{
+		WaitTime: duration.Milliseconds(),
+	}
+	if success {
+		globalStats.RequestSuccess = 1
+	} else {
+		globalStats.RequestFailed = 1
+	}
+
+	op.StatsTotalUpdate(globalStats)
+	op.StatsHourlyUpdate(globalStats)
+	op.StatsDailyUpdate(context.Background(), globalStats)
+	op.StatsAPIKeyUpdate(apiKeyID, globalStats)
+
+	log.Infof("rerank relay complete: model=%s, success=%t, duration=%dms, attempts=%d",
+		requestModel, success, duration.Milliseconds(), len(attempts))
+
+	relayLog := dbmodel.RelayLog{
+		Time:             startTime.Unix(),
+		RequestModelName: requestModel,
+		ActualModelName:  actualModel,
+		UseTime:          int(duration.Milliseconds()),
+		Attempts:         attempts,
+		TotalAttempts:    len(attempts),
+	}
+	if apiKey, getErr := op.APIKeyGet(apiKeyID, ctx); getErr == nil {
+		relayLog.RequestAPIKeyName = apiKey.Name
+	}
+	if channelID > 0 {
+		if ch, chErr := op.ChannelGet(channelID, ctx); chErr == nil {
+			relayLog.ChannelName = ch.Name
+			relayLog.ChannelId = channelID
+		}
+	}
+	if err != nil {
+		relayLog.Error = err.Error()
+	}
+	if logErr := op.RelayLogAdd(context.WithoutCancel(ctx), relayLog); logErr != nil {
+		log.Warnf("failed to save rerank relay log: %v", logErr)
+	}
+}

--- a/internal/relay/transformers.go
+++ b/internal/relay/transformers.go
@@ -46,7 +46,6 @@ func newOutbound(channelType llm.APIFormat, request *llm.Request, baseURL, key s
 	case llm.RequestTypeEmbedding:
 		switch channelType {
 		case llm.APIFormatOpenAIChatCompletion,
-			llm.APIFormatOpenAIResponse,
 			llm.APIFormatOpenAIEmbedding:
 			return openai.NewOutboundTransformer(baseURL, key)
 		case llm.APIFormatGeminiContents:

--- a/internal/server/handlers/channel.go
+++ b/internal/server/handlers/channel.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bestruirui/octopus/internal/db"
 	"github.com/bestruirui/octopus/internal/helper"
 	"github.com/bestruirui/octopus/internal/model"
 	"github.com/bestruirui/octopus/internal/op"
@@ -77,6 +78,10 @@ func createChannel(c *gin.Context) {
 		return
 	}
 	if err := op.ChannelCreate(&channel, c.Request.Context()); err != nil {
+		if db.IsDuplicateError(err) {
+			resp.Error(c, http.StatusConflict, resp.ErrDuplicateResource)
+			return
+		}
 		resp.Error(c, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -102,6 +107,10 @@ func updateChannel(c *gin.Context) {
 	}
 	channel, err := op.ChannelUpdate(&req, c.Request.Context())
 	if err != nil {
+		if db.IsDuplicateError(err) {
+			resp.Error(c, http.StatusConflict, resp.ErrDuplicateResource)
+			return
+		}
 		resp.Error(c, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/handlers/group.go
+++ b/internal/server/handlers/group.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/bestruirui/octopus/internal/db"
 	"github.com/bestruirui/octopus/internal/model"
 	"github.com/bestruirui/octopus/internal/op"
 	"github.com/bestruirui/octopus/internal/server/middleware"
@@ -62,6 +63,10 @@ func createGroup(c *gin.Context) {
 		}
 	}
 	if err := op.GroupCreate(&group, c.Request.Context()); err != nil {
+		if db.IsDuplicateError(err) {
+			resp.Error(c, http.StatusConflict, resp.ErrDuplicateResource)
+			return
+		}
 		resp.Error(c, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -83,6 +88,10 @@ func updateGroup(c *gin.Context) {
 	}
 	group, err := op.GroupUpdate(&req, c.Request.Context())
 	if err != nil {
+		if db.IsDuplicateError(err) {
+			resp.Error(c, http.StatusConflict, resp.ErrDuplicateResource)
+			return
+		}
 		resp.Error(c, http.StatusInternalServerError, err.Error())
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,6 +60,7 @@ func registerRelayRoutes(r *gin.Engine) {
 	v1.POST("/responses", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIResponse))
 	v1.POST("/messages", middleware.RequireJSON(), relay.Handler(llm.APIFormatAnthropicMessage))
 	v1.POST("/embeddings", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIEmbedding))
+	v1.POST("/rerank", middleware.RequireJSON(), relay.RerankHandler())
 	v1.POST("/images/generations", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIImageGeneration))
 	v1.POST("/images/edits", relay.Handler(llm.APIFormatOpenAIImageEdit))
 	v1.POST("/images/variations", relay.Handler(llm.APIFormatOpenAIImageVariation))


### PR DESCRIPTION
  1. Embedding 502 修复 (internal/relay/transformers.go)
  - 从 embedding 兼容列表中移除了 openai_response 类型。openai_response 的 outbound transformer 会构造错误的 URL 路径，导致上游必定失败。 ──- 需要将 LM Studio embedding 渠道的类型改为 openai_embedding 或 openai_chat_completion，这样 outbound transformer
  才能正确构造 /v1/embeddings 请求路径。

  2. /v1/rerank 支持 (internal/relay/rerank.go + internal/server/server.go)
  - 新增了 Jina/Cohere 格式的 rerank 透传 handler，复用现有的 group/balancer/metrics 基础设施。
  - 支持负载均衡、熔断、重试、自定义 header、代理等所有渠道特性。
  - 使用方式：创建一个渠道指向 rerank 服务（如 Jina），创建分组映射模型名，然后通过 POST /v1/rerank 调用。

  3. 分组/渠道重名错误优化 (internal/db/errors.go + handlers)
  - 新增 IsDuplicateError 工具函数，检测 SQLite/MySQL/PostgreSQL 的 UNIQUE 约束错误。
  - 创建分组或渠道时如果名称重复，现在返回 HTTP 409 + "Resource already exists"，而不是原始的数据库错误信息。