### PR TITLE
fix(api): sort model names in GET /v1/models

### DIFF
--- a/internal/op/group.go
+++ b/internal/op/group.go
@@ -3,6 +3,7 @@ package op
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/bestruirui/octopus/internal/db"
 	"github.com/bestruirui/octopus/internal/model"
@@ -23,10 +24,13 @@ func GroupList(ctx context.Context) ([]model.Group, error) {
 }
 
 func GroupListModel(ctx context.Context) ([]string, error) {
-	models := []string{}
+	models := make([]string, 0, groupCache.Len())
 	for _, group := range groupCache.GetAll() {
 		models = append(models, group.Name)
 	}
+	// groupCache.GetAll() returns a map; sort so /v1/models and API key
+	// model listings are stable and easy to scan.
+	sort.Strings(models)
 	return models, nil
 }
 

--- a/internal/op/group_list_model_test.go
+++ b/internal/op/group_list_model_test.go
@@ -1,0 +1,36 @@
+package op
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/bestruirui/octopus/internal/model"
+)
+
+func TestGroupListModelReturnsSortedNames(t *testing.T) {
+	// Snapshot and restore package cache so this test does not leak into others.
+	prev := groupCache.GetAll()
+	t.Cleanup(func() {
+		groupCache.Clear()
+		for id, group := range prev {
+			groupCache.Set(id, group)
+		}
+	})
+
+	groupCache.Clear()
+	// Insert in non-sorted order to prove ordering comes from GroupListModel.
+	groupCache.Set(3, model.Group{ID: 3, Name: "zeta-model"})
+	groupCache.Set(1, model.Group{ID: 1, Name: "alpha-model"})
+	groupCache.Set(2, model.Group{ID: 2, Name: "mid-model"})
+
+	got, err := GroupListModel(context.Background())
+	if err != nil {
+		t.Fatalf("GroupListModel returned error: %v", err)
+	}
+
+	want := []string{"alpha-model", "mid-model", "zeta-model"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("GroupListModel order = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `GroupListModel` previously iterated `groupCache.GetAll()` (a Go map), so `GET /v1/models` returned model names in an unstable order that could change between requests.
- Sort model names lexicographically before returning so downstream clients get a stable, scannable list.
- Adds a unit test that inserts groups out of order and asserts the returned slice is sorted.

This only affects list presentation. Relay routing still resolves models by group name and is unchanged.

## Test plan

- [x] `go test ./internal/op/ -run TestGroupListModelReturnsSortedNames`
- [ ] Call `GET /v1/models` twice and confirm the `data` order is identical and lexicographically sorted
- [ ] Confirm chat/completions still routes by model name as before