### PR TITLE
feat: add OpenAI Responses native passthrough

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/samber/lo v1.52.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/tidwall/sjson v1.2.5
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.49.0
 	golang.org/x/net v0.52.0
@@ -84,7 +85,6 @@ require (
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tmaxmax/go-sse v0.11.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect

--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -18,22 +18,23 @@ const (
 const ChannelTypeDoubao llm.APIFormat = "doubao"
 
 type Channel struct {
-	ID            int            `json:"id" gorm:"primaryKey"`
-	Name          string         `json:"name" gorm:"unique;not null"`
-	Type          llm.APIFormat  `json:"type"`
-	Enabled       bool           `json:"enabled" gorm:"default:true"`
-	BaseUrls      []BaseUrl      `json:"base_urls" gorm:"serializer:json"`
-	Keys          []ChannelKey   `json:"keys" gorm:"foreignKey:ChannelID"`
-	Model         string         `json:"model"`
-	CustomModel   string         `json:"custom_model"`
-	Proxy         bool           `json:"proxy" gorm:"default:false"`
-	AutoSync      bool           `json:"auto_sync" gorm:"default:false"`
-	AutoGroup     AutoGroupType  `json:"auto_group" gorm:"default:0"`
-	CustomHeader  []CustomHeader `json:"custom_header" gorm:"serializer:json"`
-	ParamOverride *string        `json:"param_override"`
-	ChannelProxy  *string        `json:"channel_proxy"`
-	Stats         *StatsChannel  `json:"stats,omitempty" gorm:"foreignKey:ChannelID"`
-	MatchRegex    *string        `json:"match_regex"`
+	ID                int            `json:"id" gorm:"primaryKey"`
+	Name              string         `json:"name" gorm:"unique;not null"`
+	Type              llm.APIFormat  `json:"type"`
+	Enabled           bool           `json:"enabled" gorm:"default:true"`
+	BaseUrls          []BaseUrl      `json:"base_urls" gorm:"serializer:json"`
+	Keys              []ChannelKey   `json:"keys" gorm:"foreignKey:ChannelID"`
+	Model             string         `json:"model"`
+	CustomModel       string         `json:"custom_model"`
+	Proxy             bool           `json:"proxy" gorm:"default:false"`
+	AutoSync          bool           `json:"auto_sync" gorm:"default:false"`
+	AutoGroup         AutoGroupType  `json:"auto_group" gorm:"default:0"`
+	CustomHeader      []CustomHeader `json:"custom_header" gorm:"serializer:json"`
+	ParamOverride     *string        `json:"param_override"`
+	NativePassthrough bool           `json:"native_passthrough" gorm:"default:false"`
+	ChannelProxy      *string        `json:"channel_proxy"`
+	Stats             *StatsChannel  `json:"stats,omitempty" gorm:"foreignKey:ChannelID"`
+	MatchRegex        *string        `json:"match_regex"`
 }
 
 type BaseUrl struct {
@@ -59,20 +60,21 @@ type ChannelKey struct {
 
 // ChannelUpdateRequest 渠道更新请求 - 仅包含变更的数据
 type ChannelUpdateRequest struct {
-	ID            int             `json:"id" binding:"required"`
-	Name          *string         `json:"name,omitempty"`
-	Type          *llm.APIFormat  `json:"type,omitempty"`
-	Enabled       *bool           `json:"enabled,omitempty"`
-	BaseUrls      *[]BaseUrl      `json:"base_urls,omitempty"`
-	Model         *string         `json:"model,omitempty"`
-	CustomModel   *string         `json:"custom_model,omitempty"`
-	Proxy         *bool           `json:"proxy,omitempty"`
-	AutoSync      *bool           `json:"auto_sync,omitempty"`
-	AutoGroup     *AutoGroupType  `json:"auto_group,omitempty"`
-	CustomHeader  *[]CustomHeader `json:"custom_header,omitempty"`
-	ChannelProxy  *string         `json:"channel_proxy,omitempty"`
-	ParamOverride *string         `json:"param_override,omitempty"`
-	MatchRegex    *string         `json:"match_regex,omitempty"`
+	ID                int             `json:"id" binding:"required"`
+	Name              *string         `json:"name,omitempty"`
+	Type              *llm.APIFormat  `json:"type,omitempty"`
+	Enabled           *bool           `json:"enabled,omitempty"`
+	BaseUrls          *[]BaseUrl      `json:"base_urls,omitempty"`
+	Model             *string         `json:"model,omitempty"`
+	CustomModel       *string         `json:"custom_model,omitempty"`
+	Proxy             *bool           `json:"proxy,omitempty"`
+	AutoSync          *bool           `json:"auto_sync,omitempty"`
+	AutoGroup         *AutoGroupType  `json:"auto_group,omitempty"`
+	CustomHeader      *[]CustomHeader `json:"custom_header,omitempty"`
+	ChannelProxy      *string         `json:"channel_proxy,omitempty"`
+	ParamOverride     *string         `json:"param_override,omitempty"`
+	NativePassthrough *bool           `json:"native_passthrough,omitempty"`
+	MatchRegex        *string         `json:"match_regex,omitempty"`
 
 	KeysToAdd    []ChannelKeyAddRequest    `json:"keys_to_add,omitempty"`
 	KeysToUpdate []ChannelKeyUpdateRequest `json:"keys_to_update,omitempty"`

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -171,6 +171,10 @@ func ChannelUpdate(req *model.ChannelUpdateRequest, ctx context.Context) (*model
 		selectFields = append(selectFields, "param_override")
 		updates.ParamOverride = req.ParamOverride
 	}
+	if req.NativePassthrough != nil {
+		selectFields = append(selectFields, "native_passthrough")
+		updates.NativePassthrough = *req.NativePassthrough
+	}
 	if req.MatchRegex != nil {
 		selectFields = append(selectFields, "match_regex")
 		updates.MatchRegex = req.MatchRegex

--- a/internal/relay/metrics.go
+++ b/internal/relay/metrics.go
@@ -25,10 +25,13 @@ type RelayMetrics struct {
 	// 请求和最终响应体；InternalResponse 保存实际写回客户端或流式聚合后的 body，不再强制转换成 llm.Response。
 	InternalRequest  *llm.Request
 	InternalResponse []byte
+	RawRequestBody   []byte
 
 	// 统计指标
-	ActualModel string
-	Stats       model.StatsMetrics
+	ActualModel    string
+	Stats          model.StatsMetrics
+	CachedToken    int64
+	ReasoningToken int64
 
 	// 参数覆盖
 	ParamOverride string
@@ -42,14 +45,18 @@ func (m *RelayMetrics) RecordUsage(usage *llm.Usage) {
 	// usage 已由 axonhub/llm 标准化；octopus 仍使用本地模型价格表计算成本，所以这里只做用量落点和价格换算。
 	m.Stats.InputToken = usage.PromptTokens
 	m.Stats.OutputToken = usage.CompletionTokens
+	tokenDetails := usage.PromptTokensDetails
+	if tokenDetails == nil {
+		tokenDetails = &llm.PromptTokensDetails{}
+	}
+	m.CachedToken = tokenDetails.CachedTokens
+	if usage.CompletionTokensDetails != nil {
+		m.ReasoningToken = usage.CompletionTokensDetails.ReasoningTokens
+	}
 
 	modelPrice := price.GetLLMPrice(m.ActualModel)
 	if modelPrice == nil {
 		return
-	}
-	tokenDetails := usage.PromptTokensDetails
-	if tokenDetails == nil {
-		tokenDetails = &llm.PromptTokensDetails{}
 	}
 	// 缓存读、缓存写和普通输入的单价不同；如果上游返回的缓存明细超过总输入 token，就退回按全部输入 token 计费，避免出现负成本。
 	nonCachedTokens := usage.PromptTokens - tokenDetails.CachedTokens - tokenDetails.WriteCachedTokens
@@ -161,6 +168,9 @@ func (m *RelayMetrics) saveLog(ctx context.Context, err error, duration time.Dur
 }
 
 func (m *RelayMetrics) requestContent() string {
+	if len(m.RawRequestBody) > 0 {
+		return string(m.RawRequestBody)
+	}
 	if m.InternalRequest == nil {
 		return ""
 	}

--- a/internal/relay/passthrough.go
+++ b/internal/relay/passthrough.go
@@ -1,0 +1,501 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/helper"
+	"github.com/bestruirui/octopus/internal/server/resp"
+	"github.com/gin-gonic/gin"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/looplj/axonhub/llm/transformer"
+	"github.com/tidwall/sjson"
+)
+
+// PassthroughOptions controls a raw JSON relay endpoint. Only routing fields are
+// inspected; all other request fields and response bytes remain opaque.
+type PassthroughOptions struct {
+	UpstreamPath string
+	ExtractModel bool
+	RewriteModel bool
+}
+
+// PassthroughHandler creates an OpenAI Responses-compatible raw relay endpoint.
+func PassthroughHandler(options PassthroughOptions) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		run, err := newRelayRun(c, llm.APIFormatOpenAIResponse, nil, &options)
+		if err != nil {
+			return
+		}
+		run.run()
+	}
+}
+
+type routingEnvelope struct {
+	Model string `json:"model"`
+}
+
+func parseRoutingRequest(c *gin.Context, extractModel bool) (*httpclient.Request, string, error) {
+	rawRequest, err := httpclient.ReadHTTPRequest(c.Request)
+	if err != nil {
+		resp.Error(c, http.StatusBadRequest, err.Error())
+		return nil, "", err
+	}
+	if !extractModel {
+		return rawRequest, "", nil
+	}
+
+	var envelope routingEnvelope
+	if err := json.Unmarshal(rawRequest.Body, &envelope); err != nil {
+		resp.Error(c, http.StatusBadRequest, resp.ErrInvalidJSON)
+		return nil, "", err
+	}
+	if strings.TrimSpace(envelope.Model) == "" {
+		err := errors.New("model is required")
+		resp.Error(c, http.StatusBadRequest, err.Error())
+		return nil, "", err
+	}
+	return rawRequest, envelope.Model, nil
+}
+
+func (ra *relayAttempt) forwardPassthrough() (int, error) {
+	ctx := ra.c.Request.Context()
+	request, err := ra.buildPassthroughRequest(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	httpClient, err := helper.ChannelHttpClient(ra.channel)
+	if err != nil {
+		return 0, err
+	}
+	upstreamResponse, err := httpClient.Do(request)
+	if err != nil {
+		return 0, err
+	}
+	defer upstreamResponse.Body.Close()
+
+	if upstreamResponse.StatusCode < http.StatusOK || upstreamResponse.StatusCode >= http.StatusMultipleChoices {
+		body, readErr := io.ReadAll(upstreamResponse.Body)
+		if readErr != nil {
+			return upstreamResponse.StatusCode, fmt.Errorf("upstream returned %d and response read failed: %w", upstreamResponse.StatusCode, readErr)
+		}
+		return upstreamResponse.StatusCode, &passthroughUpstreamError{
+			StatusCode: upstreamResponse.StatusCode,
+			Body:       body,
+		}
+	}
+
+	contentType := strings.ToLower(upstreamResponse.Header.Get("Content-Type"))
+	if strings.Contains(contentType, "text/event-stream") {
+		return upstreamResponse.StatusCode, ra.forwardPassthroughSSE(ctx, upstreamResponse)
+	}
+	return upstreamResponse.StatusCode, ra.forwardPassthroughResponse(upstreamResponse)
+}
+
+func (ra *relayAttempt) buildPassthroughRequest(ctx context.Context) (*http.Request, error) {
+	if ra.rawRequest == nil {
+		return nil, errors.New("missing raw request")
+	}
+	options := PassthroughOptions{
+		UpstreamPath: "/responses",
+		ExtractModel: true,
+		RewriteModel: true,
+	}
+	if ra.passthrough != nil {
+		options = *ra.passthrough
+	}
+
+	body := append([]byte(nil), ra.rawRequest.Body...)
+	if options.RewriteModel {
+		rewrittenBody, rewriteErr := sjson.SetBytes(body, "model", ra.upstreamModel)
+		if rewriteErr != nil {
+			return nil, fmt.Errorf("failed to rewrite model: %w", rewriteErr)
+		}
+		body = rewrittenBody
+	}
+
+	headers := cloneHeaders(ra.rawRequest.Headers)
+	removeHopByHopHeaders(headers)
+	headers.Del("Authorization")
+	headers.Del("X-Api-Key")
+	headers.Del("Host")
+	headers.Del("Content-Length")
+
+	requestOptions := &httpclient.Request{
+		Headers:     headers,
+		Body:        body,
+		ContentType: headers.Get("Content-Type"),
+	}
+	ra.applyChannelRequestOptions(requestOptions)
+	body = requestOptions.Body
+	headers = requestOptions.Headers
+	headers.Set("Authorization", "Bearer "+ra.usedKey.ChannelKey)
+	headers.Del("Content-Length")
+
+	upstreamURL, err := buildPassthroughURL(channelBaseURL(ra.channel.GetBaseUrl()), options.UpstreamPath, ra.c.Request.URL.Query())
+	if err != nil {
+		return nil, err
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	request.Header = headers
+	ra.metrics.RawRequestBody = append(ra.metrics.RawRequestBody[:0], body...)
+	return request, nil
+}
+
+func channelBaseURL(baseURL string) string {
+	return strings.TrimSpace(baseURL)
+}
+
+func buildPassthroughURL(baseURL, upstreamPath string, query url.Values) (string, error) {
+	if baseURL == "" {
+		return "", errors.New("channel base URL is empty")
+	}
+	if !strings.HasPrefix(upstreamPath, "/") {
+		return "", fmt.Errorf("upstream path must start with /: %s", upstreamPath)
+	}
+
+	var target string
+	if strings.HasSuffix(baseURL, "##") {
+		target = strings.TrimSuffix(baseURL, "##")
+		parsed, err := url.Parse(target)
+		if err != nil {
+			return "", err
+		}
+		if !strings.HasSuffix(strings.TrimRight(parsed.Path, "/"), upstreamPath) {
+			return "", fmt.Errorf("raw channel URL does not match passthrough path %s", upstreamPath)
+		}
+	} else {
+		target = transformer.NormalizeBaseURL(baseURL, "v1") + upstreamPath
+	}
+
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return "", err
+	}
+	upstreamQuery := parsed.Query()
+	for key, values := range query {
+		for _, value := range values {
+			upstreamQuery.Add(key, value)
+		}
+	}
+	parsed.RawQuery = upstreamQuery.Encode()
+	return parsed.String(), nil
+}
+
+func (ra *relayAttempt) forwardPassthroughResponse(upstream *http.Response) error {
+	body, err := io.ReadAll(upstream.Body)
+	if err != nil {
+		return err
+	}
+	observer := newPassthroughObserver()
+	observer.observeJSON(body)
+	ra.recordPassthroughObservation(observer, body)
+	copyResponseHeaders(ra.c.Writer.Header(), upstream.Header)
+	ra.c.Data(upstream.StatusCode, upstream.Header.Get("Content-Type"), body)
+	return nil
+}
+
+func (ra *relayAttempt) forwardPassthroughSSE(ctx context.Context, upstream *http.Response) error {
+	firstChunk, err := readFirstChunk(ctx, upstream.Body, ra.group.FirstTokenTimeOut)
+	if err != nil {
+		return err
+	}
+
+	copyResponseHeaders(ra.c.Writer.Header(), upstream.Header)
+	ra.c.Writer.Header().Del("Content-Length")
+	ra.c.Writer.WriteHeader(upstream.StatusCode)
+	ra.metrics.FirstTokenTime = time.Now()
+
+	observer := newPassthroughObserver()
+	writer := &passthroughStreamWriter{writer: ra.c.Writer, observer: observer}
+	if _, err := writer.Write(firstChunk); err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(writer, upstream.Body)
+	observer.finish()
+	ra.recordPassthroughObservation(observer, nil)
+	if copyErr != nil {
+		return fmt.Errorf("upstream stream interrupted: %w", copyErr)
+	}
+	if observer.sawFailed {
+		return errors.New("upstream emitted response.failed")
+	}
+	if strings.HasSuffix(ra.passthroughPath(), "/responses") && !observer.sawCompleted {
+		return errors.New("upstream stream closed before response.completed")
+	}
+	return nil
+}
+
+func (ra *relayAttempt) passthroughPath() string {
+	if ra.passthrough != nil {
+		return ra.passthrough.UpstreamPath
+	}
+	return "/responses"
+}
+
+func readFirstChunk(ctx context.Context, reader io.Reader, timeoutSeconds int) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	results := make(chan result, 1)
+	go func() {
+		buffer := make([]byte, 32*1024)
+		n, err := reader.Read(buffer)
+		results <- result{data: buffer[:n], err: err}
+	}()
+
+	var timer *time.Timer
+	var timeout <-chan time.Time
+	if timeoutSeconds > 0 {
+		timer = time.NewTimer(time.Duration(timeoutSeconds) * time.Second)
+		timeout = timer.C
+		defer timer.Stop()
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-timeout:
+		return nil, fmt.Errorf("first token timeout (%ds)", timeoutSeconds)
+	case result := <-results:
+		if len(result.data) == 0 {
+			if result.err == nil {
+				return nil, errors.New("upstream stream returned no bytes")
+			}
+			return nil, fmt.Errorf("upstream stream returned no bytes: %w", result.err)
+		}
+		if result.err != nil && !errors.Is(result.err, io.EOF) {
+			return nil, result.err
+		}
+		return result.data, nil
+	}
+}
+
+type passthroughStreamWriter struct {
+	writer   gin.ResponseWriter
+	observer *passthroughObserver
+}
+
+func (w *passthroughStreamWriter) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	w.observer.Write(data)
+	n, err := w.writer.Write(data)
+	w.writer.Flush()
+	return n, err
+}
+
+type passthroughUsage struct {
+	InputTokens       int64 `json:"input_tokens"`
+	OutputTokens      int64 `json:"output_tokens"`
+	TotalTokens       int64 `json:"total_tokens"`
+	InputTokenDetails struct {
+		CachedTokens     int64 `json:"cached_tokens"`
+		CacheWriteTokens int64 `json:"cache_write_tokens"`
+	} `json:"input_tokens_details"`
+	OutputTokenDetails struct {
+		ReasoningTokens int64 `json:"reasoning_tokens"`
+	} `json:"output_tokens_details"`
+}
+
+func (u *passthroughUsage) toLLMUsage() *llm.Usage {
+	if u == nil {
+		return nil
+	}
+	return &llm.Usage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      u.TotalTokens,
+		PromptTokensDetails: &llm.PromptTokensDetails{
+			CachedTokens:      u.InputTokenDetails.CachedTokens,
+			WriteCachedTokens: u.InputTokenDetails.CacheWriteTokens,
+		},
+		CompletionTokensDetails: &llm.CompletionTokensDetails{
+			ReasoningTokens: u.OutputTokenDetails.ReasoningTokens,
+		},
+	}
+}
+
+type passthroughObserver struct {
+	buffer        []byte
+	usage         *llm.Usage
+	completedData []byte
+	lastData      []byte
+	sawCompleted  bool
+	sawFailed     bool
+}
+
+func newPassthroughObserver() *passthroughObserver {
+	return &passthroughObserver{buffer: make([]byte, 0, 4096)}
+}
+
+func (o *passthroughObserver) Write(data []byte) {
+	o.buffer = append(o.buffer, data...)
+	for {
+		index, separatorLength := nextSSEFrame(o.buffer)
+		if index < 0 {
+			return
+		}
+		frame := append([]byte(nil), o.buffer[:index]...)
+		o.buffer = o.buffer[index+separatorLength:]
+		o.observeSSEFrame(frame)
+	}
+}
+
+func (o *passthroughObserver) finish() {
+	if len(bytes.TrimSpace(o.buffer)) > 0 {
+		o.observeSSEFrame(o.buffer)
+	}
+	o.buffer = nil
+}
+
+func nextSSEFrame(data []byte) (int, int) {
+	lf := bytes.Index(data, []byte("\n\n"))
+	crlf := bytes.Index(data, []byte("\r\n\r\n"))
+	switch {
+	case lf < 0:
+		return crlf, 4
+	case crlf < 0:
+		return lf, 2
+	case lf < crlf:
+		return lf, 2
+	default:
+		return crlf, 4
+	}
+}
+
+func (o *passthroughObserver) observeSSEFrame(frame []byte) {
+	lines := strings.Split(strings.ReplaceAll(string(frame), "\r\n", "\n"), "\n")
+	dataLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+	if len(dataLines) == 0 {
+		return
+	}
+	payload := []byte(strings.Join(dataLines, "\n"))
+	if bytes.Equal(bytes.TrimSpace(payload), []byte("[DONE]")) {
+		return
+	}
+	o.lastData = append(o.lastData[:0], payload...)
+
+	var event struct {
+		Type     string `json:"type"`
+		Response struct {
+			Usage *passthroughUsage `json:"usage"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil {
+		return
+	}
+	switch event.Type {
+	case "response.completed":
+		o.sawCompleted = true
+		o.completedData = append(o.completedData[:0], payload...)
+		o.usage = event.Response.Usage.toLLMUsage()
+	case "response.failed", "response.incomplete":
+		o.sawFailed = true
+	}
+}
+
+func (o *passthroughObserver) observeJSON(body []byte) {
+	var response struct {
+		Usage    *passthroughUsage `json:"usage"`
+		Response *struct {
+			Usage *passthroughUsage `json:"usage"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return
+	}
+	usage := response.Usage
+	if usage == nil && response.Response != nil {
+		usage = response.Response.Usage
+	}
+	o.usage = usage.toLLMUsage()
+}
+
+func (ra *relayAttempt) recordPassthroughObservation(observer *passthroughObserver, fallback []byte) {
+	if observer == nil {
+		return
+	}
+	ra.metrics.RecordUsage(observer.usage)
+	switch {
+	case len(observer.completedData) > 0:
+		ra.metrics.InternalResponse = append(ra.metrics.InternalResponse[:0], observer.completedData...)
+	case len(fallback) > 0:
+		ra.metrics.InternalResponse = append(ra.metrics.InternalResponse[:0], fallback...)
+	case len(observer.lastData) > 0:
+		ra.metrics.InternalResponse = append(ra.metrics.InternalResponse[:0], observer.lastData...)
+	}
+}
+
+type passthroughUpstreamError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *passthroughUpstreamError) Error() string {
+	body := strings.TrimSpace(string(e.Body))
+	if body == "" {
+		return fmt.Sprintf("upstream returned HTTP %d", e.StatusCode)
+	}
+	return fmt.Sprintf("upstream returned HTTP %d: %s", e.StatusCode, body)
+}
+
+func cloneHeaders(source http.Header) http.Header {
+	result := make(http.Header, len(source))
+	for key, values := range source {
+		result[key] = append([]string(nil), values...)
+	}
+	return result
+}
+
+func removeHopByHopHeaders(headers http.Header) {
+	for _, value := range headers.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			headers.Del(strings.TrimSpace(token))
+		}
+	}
+	for _, key := range []string{
+		"Connection",
+		"Keep-Alive",
+		"Proxy-Authenticate",
+		"Proxy-Authorization",
+		"Proxy-Connection",
+		"Te",
+		"Trailer",
+		"Transfer-Encoding",
+		"Upgrade",
+	} {
+		headers.Del(key)
+	}
+}
+
+func copyResponseHeaders(destination, source http.Header) {
+	filtered := cloneHeaders(source)
+	removeHopByHopHeaders(filtered)
+	for key, values := range filtered {
+		destination.Del(key)
+		for _, value := range values {
+			destination.Add(key, value)
+		}
+	}
+}

--- a/internal/relay/passthrough_test.go
+++ b/internal/relay/passthrough_test.go
@@ -1,0 +1,312 @@
+package relay
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"github.com/gin-gonic/gin"
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativePassthroughOrdinaryResponsesPreservesUnknownFieldsAndMapsModel(t *testing.T) {
+	requestBody := []byte(`{
+  "model": "gpt-test",
+  "stream": false,
+  "input": [{"type":"future_unknown_item","foo":{"bar":1}}],
+  "metadata": {"trace":"kept"},
+  "prompt_cache_key": "cache-key"
+}`)
+	responseBody := []byte(`{"id":"resp_1","object":"response","created_at":1700000000,"output":[],"usage":{"input_tokens":12,"input_tokens_details":{"cached_tokens":5},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":2},"total_tokens":15}}`)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/responses", r.URL.Path)
+		require.Equal(t, "Bearer upstream-secret", r.Header.Get("Authorization"))
+		require.Equal(t, "codex-test", r.Header.Get("X-Openai-Subagent"))
+		require.Empty(t, r.Header.Get("Connection"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var actual map[string]any
+		require.NoError(t, json.Unmarshal(body, &actual))
+		assert.Equal(t, "upstream-model", actual["model"])
+		assert.Equal(t, []any{map[string]any{
+			"type": "future_unknown_item",
+			"foo":  map[string]any{"bar": float64(1)},
+		}}, actual["input"])
+		assert.Equal(t, map[string]any{"trace": "kept"}, actual["metadata"])
+		assert.Equal(t, "cache-key", actual["prompt_cache_key"])
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Codex-Turn-State", "turn-state")
+		_, _ = w.Write(responseBody)
+	}))
+	defer upstream.Close()
+
+	attempt, recorder := newNativeTestAttempt(t, upstream.URL, "/responses", requestBody)
+	attempt.rawRequest.Headers.Set("Authorization", "Bearer client-octopus-key")
+	attempt.rawRequest.Headers.Set("X-OpenAI-Subagent", "codex-test")
+	attempt.rawRequest.Headers.Set("Connection", "keep-alive")
+	status, err := attempt.forwardPassthrough()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, responseBody, recorder.Body.Bytes())
+	assert.Equal(t, "turn-state", recorder.Header().Get("X-Codex-Turn-State"))
+	assert.EqualValues(t, 12, attempt.metrics.Stats.InputToken)
+	assert.EqualValues(t, 3, attempt.metrics.Stats.OutputToken)
+}
+
+func TestNativePassthroughRemoteCompactionV2AndUnknownSSEEvent(t *testing.T) {
+	requestBody := []byte(`{
+  "model":"test-model",
+  "stream":true,
+  "input":[
+    {"role":"user","content":"remember A17"},
+    {"type":"compaction_trigger"}
+  ]
+}`)
+	sse := "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_compact\",\"created_at\":1700000000}}\n\n" +
+		"event: response.future_event\ndata: {\"type\":\"response.future_event\",\"future\":{\"kept\":true}}\n\n" +
+		"data: {\"type\":\"response.output_item.done\",\"sequence_number\":1,\"item\":{\"id\":\"cmp_1\",\"type\":\"compaction\",\"encrypted_content\":\"TEST\"}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{\"id\":\"resp_compact\",\"created_at\":1700000000,\"output\":[{\"id\":\"cmp_1\",\"type\":\"compaction\",\"encrypted_content\":\"TEST\"}],\"usage\":{\"input_tokens\":100,\"input_tokens_details\":{\"cached_tokens\":40},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":6},\"total_tokens\":108}}}\n\n"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var request struct {
+			Input []map[string]any `json:"input"`
+		}
+		require.NoError(t, json.Unmarshal(body, &request))
+		require.Equal(t, "compaction_trigger", request.Input[len(request.Input)-1]["type"])
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, sse)
+	}))
+	defer upstream.Close()
+
+	attempt, recorder := newNativeTestAttempt(t, upstream.URL, "/responses", requestBody)
+	status, err := attempt.forwardPassthrough()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, sse, recorder.Body.String())
+	assert.Contains(t, recorder.Body.String(), `"type":"compaction","encrypted_content":"TEST"`)
+	assert.Contains(t, recorder.Body.String(), `"type":"response.future_event"`)
+	assert.EqualValues(t, 100, attempt.metrics.Stats.InputToken)
+	assert.EqualValues(t, 8, attempt.metrics.Stats.OutputToken)
+	assert.EqualValues(t, 40, attempt.metrics.CachedToken)
+	assert.EqualValues(t, 6, attempt.metrics.ReasoningToken)
+	assert.False(t, attempt.metrics.FirstTokenTime.IsZero())
+}
+
+func TestNativePassthroughAlphaSearch(t *testing.T) {
+	requestBody := []byte(`{"id":"session","model":"gpt-test","commands":{"weather":[{"location":"US, CA, San Francisco"}]},"settings":{"external_web_access":true}}`)
+	responseBody := []byte(`{"encrypted_output":"ciphertext","output":"sunny","results":[{"type":"weather_result","future_field":true}]}`)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/alpha/search", r.URL.Path)
+		require.Equal(t, "turn-metadata", r.Header.Get("X-Codex-Turn-Metadata"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var actual map[string]any
+		require.NoError(t, json.Unmarshal(body, &actual))
+		assert.Equal(t, "upstream-model", actual["model"])
+		assert.NotNil(t, actual["commands"])
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(responseBody)
+	}))
+	defer upstream.Close()
+
+	attempt, recorder := newNativeTestAttempt(t, upstream.URL, "/alpha/search", requestBody)
+	attempt.rawRequest.Headers.Set("X-Codex-Turn-Metadata", "turn-metadata")
+	status, err := attempt.forwardPassthrough()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, responseBody, recorder.Body.Bytes())
+}
+
+func TestNativePassthroughLegacyResponsesCompact(t *testing.T) {
+	requestBody := []byte(`{"model":"gpt-test","input":[{"role":"user","content":"remember A17"}],"unknown_option":{"kept":true}}`)
+	responseBody := []byte(`{"id":"cmp_resp","object":"response.compaction","output":[{"type":"compaction","encrypted_content":"LEGACY"}]}`)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/responses/compact", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), `"unknown_option":{"kept":true}`)
+		assert.Contains(t, string(body), `"model":"upstream-model"`)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(responseBody)
+	}))
+	defer upstream.Close()
+
+	attempt, recorder := newNativeTestAttempt(t, upstream.URL, "/responses/compact", requestBody)
+	status, err := attempt.forwardPassthrough()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Equal(t, responseBody, recorder.Body.Bytes())
+}
+
+func TestNativePassthroughFailoverBeforeStreamStarts(t *testing.T) {
+	requestBody := []byte(`{"model":"gpt-test","stream":true,"input":"hello"}`)
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "temporary failure", http.StatusBadGateway)
+	}))
+	defer first.Close()
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_b\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n")
+	}))
+	defer second.Close()
+
+	attemptA, recorder := newNativeTestAttempt(t, first.URL, "/responses", requestBody)
+	_, err := attemptA.forwardPassthrough()
+	require.Error(t, err)
+	assert.False(t, attemptA.c.Writer.Written())
+
+	attemptB := cloneNativeAttemptForUpstream(attemptA, second.URL)
+	_, err = attemptB.forwardPassthrough()
+	require.NoError(t, err)
+	assert.True(t, attemptB.c.Writer.Written())
+	assert.Contains(t, recorder.Body.String(), `"id":"resp_b"`)
+}
+
+func TestNativePassthroughDoesNotFailoverAfterStreamStarts(t *testing.T) {
+	requestBody := []byte(`{"model":"gpt-test","stream":true,"input":"hello"}`)
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_a\"}}\n\n")
+	}))
+	defer first.Close()
+	var secondCalls atomic.Int64
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		secondCalls.Add(1)
+		_, _ = fmt.Fprint(w, `{"id":"resp_b"}`)
+	}))
+	defer second.Close()
+
+	attemptA, recorder := newNativeTestAttempt(t, first.URL, "/responses", requestBody)
+	_, err := attemptA.forwardPassthrough()
+	require.Error(t, err)
+	assert.True(t, attemptA.c.Writer.Written())
+
+	if !attemptA.c.Writer.Written() {
+		attemptB := cloneNativeAttemptForUpstream(attemptA, second.URL)
+		_, _ = attemptB.forwardPassthrough()
+	}
+	assert.Zero(t, secondCalls.Load())
+	assert.Contains(t, recorder.Body.String(), `"id":"resp_a"`)
+	assert.NotContains(t, recorder.Body.String(), `"id":"resp_b"`)
+}
+
+func TestNativePassthroughRequiresResponsesChannelOptIn(t *testing.T) {
+	run := &relayRun{inboundType: llm.APIFormatOpenAIResponse}
+	assert.False(t, run.nativePassthroughEnabled(&model.Channel{
+		Type:              llm.APIFormatOpenAIResponse,
+		NativePassthrough: false,
+	}))
+	assert.False(t, run.nativePassthroughEnabled(&model.Channel{
+		Type:              llm.APIFormatAnthropicMessage,
+		NativePassthrough: true,
+	}))
+	assert.True(t, run.nativePassthroughEnabled(&model.Channel{
+		Type:              llm.APIFormatOpenAIResponse,
+		NativePassthrough: true,
+	}))
+}
+
+func TestNativePassthroughUnknownResponseItemIsPreserved(t *testing.T) {
+	body := []byte(`{"model":"gpt-test","input":[{"type":"future_unknown_item","foo":{"bar":1}}]}`)
+	attempt, _ := newNativeTestAttempt(t, "http://127.0.0.1:1", "/responses", body)
+	request, err := attempt.buildPassthroughRequest(t.Context())
+	require.NoError(t, err)
+	encoded, err := io.ReadAll(request.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"model":"upstream-model","input":[{"type":"future_unknown_item","foo":{"bar":1}}]}`, string(encoded))
+}
+
+func TestNativePassthroughUnknownSSEEventIsByteTransparent(t *testing.T) {
+	stream := "event: response.future_event\r\ndata: {\"type\":\"response.future_event\",\"opaque\":true}\r\n\r\n"
+	observer := newPassthroughObserver()
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	writer := &passthroughStreamWriter{writer: context.Writer, observer: observer}
+
+	n, err := writer.Write([]byte(stream))
+	require.NoError(t, err)
+	assert.Equal(t, len(stream), n)
+	assert.Equal(t, stream, recorder.Body.String())
+}
+
+func TestNativePassthroughUsageObserverRecordsCachedAndReasoningTokens(t *testing.T) {
+	observer := newPassthroughObserver()
+	observer.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":20,\"input_tokens_details\":{\"cached_tokens\":7},\"output_tokens\":4,\"output_tokens_details\":{\"reasoning_tokens\":3},\"total_tokens\":24}}}\n\n"))
+
+	require.NotNil(t, observer.usage)
+	assert.EqualValues(t, 20, observer.usage.PromptTokens)
+	assert.EqualValues(t, 7, observer.usage.PromptTokensDetails.CachedTokens)
+	assert.EqualValues(t, 4, observer.usage.CompletionTokens)
+	assert.EqualValues(t, 3, observer.usage.CompletionTokensDetails.ReasoningTokens)
+}
+
+func newNativeTestAttempt(t *testing.T, upstreamURL, path string, body []byte) (*relayAttempt, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	request := httptest.NewRequest(http.MethodPost, "/v1"+path, bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	context.Request = request
+	rawRequest, err := httpclient.ReadHTTPRequest(request)
+	require.NoError(t, err)
+
+	var options *PassthroughOptions
+	if path != "/responses" {
+		options = &PassthroughOptions{UpstreamPath: path, ExtractModel: true, RewriteModel: true}
+	}
+	internalRequest := &llm.Request{Model: "gpt-test", RequestType: llm.RequestTypeChat, RawRequest: rawRequest}
+	run := &relayRun{
+		c:               context,
+		inboundType:     llm.APIFormatOpenAIResponse,
+		internalRequest: internalRequest,
+		rawRequest:      rawRequest,
+		requestModel:    "gpt-test",
+		passthrough:     options,
+		group:           model.Group{FirstTokenTimeOut: 2},
+		metrics: &RelayMetrics{
+			RequestModel:    "gpt-test",
+			ActualModel:     "upstream-model",
+			StartTime:       time.Now(),
+			InternalRequest: internalRequest,
+			RawRequestBody:  append([]byte(nil), body...),
+		},
+	}
+	attempt := &relayAttempt{
+		relayRun: run,
+		channel: &model.Channel{
+			ID:                1,
+			Name:              "test-channel",
+			Type:              llm.APIFormatOpenAIResponse,
+			NativePassthrough: true,
+			BaseUrls:          []model.BaseUrl{{URL: upstreamURL + "/v1"}},
+		},
+		usedKey:       model.ChannelKey{ID: 1, ChannelID: 1, ChannelKey: "upstream-secret"},
+		native:        true,
+		upstreamModel: "upstream-model",
+	}
+	return attempt, recorder
+}
+
+func cloneNativeAttemptForUpstream(source *relayAttempt, upstreamURL string) *relayAttempt {
+	clone := *source
+	channel := *source.channel
+	channel.BaseUrls = []model.BaseUrl{{URL: upstreamURL + "/v1"}}
+	clone.channel = &channel
+	return &clone
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -30,7 +30,7 @@ import (
 func Handler(inboundType llm.APIFormat) gin.HandlerFunc {
 	inAdapter := newInbound(inboundType)
 	return func(c *gin.Context) {
-		run, err := newRelayRun(c, inboundType, inAdapter)
+		run, err := newRelayRun(c, inboundType, inAdapter, nil)
 		if err != nil {
 			return
 		}
@@ -38,44 +38,78 @@ func Handler(inboundType llm.APIFormat) gin.HandlerFunc {
 	}
 }
 
-func newRelayRun(c *gin.Context, inboundType llm.APIFormat, inAdapter transformer.Inbound) (*relayRun, error) {
-	internalRequest, err := parseRequest(c, inboundType, inAdapter)
-	if err != nil {
-		return nil, err
+func newRelayRun(c *gin.Context, inboundType llm.APIFormat, inAdapter transformer.Inbound, passthrough *PassthroughOptions) (*relayRun, error) {
+	var (
+		internalRequest *llm.Request
+		rawRequest      *httpclient.Request
+		requestModel    string
+		requestParsed   bool
+		err             error
+	)
+
+	if inboundType == llm.APIFormatOpenAIResponse || passthrough != nil {
+		rawRequest, requestModel, err = parseRoutingRequest(c, passthrough == nil || passthrough.ExtractModel)
+		if err != nil {
+			return nil, err
+		}
+		internalRequest = &llm.Request{
+			Model:       requestModel,
+			RequestType: llm.RequestTypeChat,
+			RawRequest:  rawRequest,
+		}
+	} else {
+		internalRequest, err = parseRequest(c, inboundType, inAdapter)
+		if err != nil {
+			return nil, err
+		}
+		rawRequest = internalRequest.RawRequest
+		requestModel = internalRequest.Model
+		requestParsed = true
 	}
 
 	if supportedModels := c.GetString("supported_models"); supportedModels != "" {
-		if !slices.Contains(strings.Split(supportedModels, ","), internalRequest.Model) {
+		if !slices.Contains(strings.Split(supportedModels, ","), requestModel) {
 			err := errors.New("model not supported")
 			resp.Error(c, http.StatusBadRequest, err.Error())
 			return nil, err
 		}
 	}
 
-	group, err := op.GroupGetEnabledMap(internalRequest.Model, c.Request.Context())
+	group, err := op.GroupGetEnabledMap(requestModel, c.Request.Context())
 	if err != nil {
 		resp.Error(c, http.StatusNotFound, "model not found")
 		return nil, err
 	}
 
 	apiKeyID := c.GetInt("api_key_id")
-	iter := balancer.NewIterator(group, apiKeyID, internalRequest.Model)
+	iter := balancer.NewIterator(group, apiKeyID, requestModel)
 	if iter.Len() == 0 {
 		err := errors.New("no available channel")
 		resp.Error(c, http.StatusServiceUnavailable, err.Error())
 		return nil, err
 	}
 
+	var rawRequestBody []byte
+	if inboundType == llm.APIFormatOpenAIResponse || passthrough != nil {
+		rawRequestBody = append([]byte(nil), rawRequest.Body...)
+	}
+
 	return &relayRun{
 		c:               c,
+		inboundType:     inboundType,
 		inAdapter:       inAdapter,
 		internalRequest: internalRequest,
+		requestParsed:   requestParsed,
+		rawRequest:      rawRequest,
+		requestModel:    requestModel,
+		passthrough:     passthrough,
 		metrics: &RelayMetrics{
 			APIKeyID:        apiKeyID,
-			RequestModel:    internalRequest.Model,
-			ActualModel:     internalRequest.Model,
+			RequestModel:    requestModel,
+			ActualModel:     requestModel,
 			StartTime:       time.Now(),
 			InternalRequest: internalRequest,
+			RawRequestBody:  rawRequestBody,
 		},
 		iter:  iter,
 		group: group,
@@ -98,6 +132,10 @@ func (r *relayRun) run() {
 		attempt, err := r.prepareAttempt()
 		if err != nil {
 			lastErr = err
+			if r.c.Writer.Written() {
+				r.metrics.Save(ctx, false, err, r.iter.Attempts())
+				return
+			}
 			continue
 		}
 		if attempt == nil {
@@ -145,26 +183,73 @@ func (r *relayRun) prepareAttempt() (*relayAttempt, error) {
 		return nil, nil
 	}
 
-	outAdapter, err := newOutbound(channel.Type, r.internalRequest, channel.GetBaseUrl(), usedKey.ChannelKey)
-	if err != nil {
-		r.iter.Skip(channel.ID, usedKey.ID, channel.Name, err.Error())
+	native := r.nativePassthroughEnabled(channel)
+	if r.passthrough != nil && !native {
+		r.iter.Skip(channel.ID, usedKey.ID, channel.Name, "channel does not support OpenAI native passthrough")
 		return nil, nil
 	}
 
-	// 每次尝试都把客户端模型改成本次候选的实际上游模型；重试时会被下一候选覆盖。
-	r.internalRequest.Model = item.ModelName
+	var outAdapter transformer.Outbound
+	if !native {
+		internalRequest, parseErr := r.ensureInternalRequest()
+		if parseErr != nil {
+			r.iter.Skip(channel.ID, usedKey.ID, channel.Name, parseErr.Error())
+			statusCode := http.StatusInternalServerError
+			if errors.Is(parseErr, transformer.ErrInvalidRequest) {
+				statusCode = http.StatusBadRequest
+			}
+			resp.Error(r.c, statusCode, parseErr.Error())
+			return nil, parseErr
+		}
+		outAdapter, err = newOutbound(channel.Type, internalRequest, channel.GetBaseUrl(), usedKey.ChannelKey)
+		if err != nil {
+			r.iter.Skip(channel.ID, usedKey.ID, channel.Name, err.Error())
+			return nil, nil
+		}
+		internalRequest.Model = item.ModelName
+	}
+
 	r.metrics.ActualModel = item.ModelName
 	r.metrics.ParamOverride = ""
-	log.Infof("request model %s, mode: %d, forwarding to channel: %s model: %s (attempt %d/%d, sticky=%t)",
+	log.Infof("request model %s, mode: %d, forwarding to channel: %s model: %s (attempt %d/%d, sticky=%t, native=%t)",
 		r.metrics.RequestModel, r.group.Mode, channel.Name, item.ModelName,
-		r.iter.Index()+1, r.iter.Len(), r.iter.IsSticky())
+		r.iter.Index()+1, r.iter.Len(), r.iter.IsSticky(), native)
 
 	return &relayAttempt{
-		relayRun:   r,
-		outAdapter: outAdapter,
-		channel:    channel,
-		usedKey:    usedKey,
+		relayRun:      r,
+		outAdapter:    outAdapter,
+		channel:       channel,
+		usedKey:       usedKey,
+		native:        native,
+		upstreamModel: item.ModelName,
 	}, nil
+}
+
+func (r *relayRun) nativePassthroughEnabled(channel *dbmodel.Channel) bool {
+	if channel == nil || !channel.NativePassthrough || channel.Type != llm.APIFormatOpenAIResponse {
+		return false
+	}
+	return r.inboundType == llm.APIFormatOpenAIResponse || r.passthrough != nil
+}
+
+func (r *relayRun) ensureInternalRequest() (*llm.Request, error) {
+	if r.requestParsed {
+		return r.internalRequest, nil
+	}
+	if r.inAdapter == nil {
+		return nil, fmt.Errorf("unsupported inbound type: %s", r.inboundType)
+	}
+	request, err := r.inAdapter.TransformRequest(r.c.Request.Context(), r.rawRequest)
+	if err != nil {
+		return nil, err
+	}
+	if request.RawRequest == nil {
+		request.RawRequest = r.rawRequest
+	}
+	r.internalRequest = request
+	r.metrics.InternalRequest = request
+	r.requestParsed = true
+	return request, nil
 }
 
 // run 统一管理一次通道尝试的完整生命周期。
@@ -179,26 +264,26 @@ func (ra *relayAttempt) run() (bool, error) {
 	ra.usedKey.LastUseTimeStamp = time.Now().Unix()
 
 	if fwdErr == nil {
-		ra.usedKey.TotalCost += ra.metrics.Stats.InputCost + ra.metrics.Stats.OutputCost
-		op.ChannelKeyUpdate(ra.usedKey)
+		costDelta := ra.metrics.Stats.InputCost + ra.metrics.Stats.OutputCost
+		op.ChannelKeyUpdate(ra.usedKey, costDelta)
 
 		span.End(dbmodel.AttemptSuccess, "")
 		op.StatsChannelUpdate(ra.channel.ID, dbmodel.StatsMetrics{
 			WaitTime:       span.Duration().Milliseconds(),
 			RequestSuccess: 1,
 		})
-		balancer.RecordSuccess(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
+		balancer.RecordSuccess(ra.channel.ID, ra.usedKey.ID, ra.upstreamModel)
 		balancer.SetSticky(ra.metrics.APIKeyID, ra.metrics.RequestModel, ra.channel.ID, ra.usedKey.ID)
 		return false, nil
 	}
 
-	op.ChannelKeyUpdate(ra.usedKey)
+	op.ChannelKeyUpdate(ra.usedKey, 0)
 	span.End(dbmodel.AttemptFailed, fwdErr.Error())
 	op.StatsChannelUpdate(ra.channel.ID, dbmodel.StatsMetrics{
 		WaitTime:      span.Duration().Milliseconds(),
 		RequestFailed: 1,
 	})
-	balancer.RecordFailure(ra.channel.ID, ra.usedKey.ID, ra.internalRequest.Model)
+	balancer.RecordFailure(ra.channel.ID, ra.usedKey.ID, ra.upstreamModel)
 
 	return ra.c.Writer.Written(), fmt.Errorf("channel %s failed: %v", ra.channel.Name, fwdErr)
 }
@@ -235,6 +320,9 @@ func parseRequest(c *gin.Context, inboundType llm.APIFormat, inAdapter transform
 
 // forward 转发请求到上游服务
 func (ra *relayAttempt) forward() (int, error) {
+	if ra.native {
+		return ra.forwardPassthrough()
+	}
 	ctx := ra.c.Request.Context()
 	if ra.internalRequest.RawRequest == nil {
 		return 0, fmt.Errorf("missing raw request")

--- a/internal/relay/type.go
+++ b/internal/relay/type.go
@@ -5,14 +5,20 @@ import (
 	"github.com/bestruirui/octopus/internal/relay/balancer"
 	"github.com/gin-gonic/gin"
 	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
 	"github.com/looplj/axonhub/llm/transformer"
 )
 
 // relayRun 保存一次客户端请求在负载均衡循环中共享的状态。
 type relayRun struct {
 	c               *gin.Context
+	inboundType     llm.APIFormat
 	inAdapter       transformer.Inbound
 	internalRequest *llm.Request
+	requestParsed   bool
+	rawRequest      *httpclient.Request
+	requestModel    string
+	passthrough     *PassthroughOptions
 	metrics         *RelayMetrics
 	iter            *balancer.Iterator
 	group           dbmodel.Group
@@ -22,7 +28,9 @@ type relayRun struct {
 type relayAttempt struct {
 	*relayRun
 
-	outAdapter transformer.Outbound
-	channel    *dbmodel.Channel
-	usedKey    dbmodel.ChannelKey
+	outAdapter    transformer.Outbound
+	channel       *dbmodel.Channel
+	usedKey       dbmodel.ChannelKey
+	native        bool
+	upstreamModel string
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -58,6 +58,16 @@ func registerRelayRoutes(r *gin.Engine) {
 	v1 := r.Group("/v1", middleware.APIKeyAuth())
 	v1.POST("/chat/completions", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIChatCompletion))
 	v1.POST("/responses", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIResponse))
+	v1.POST("/responses/compact", middleware.RequireJSON(), relay.PassthroughHandler(relay.PassthroughOptions{
+		UpstreamPath: "/responses/compact",
+		ExtractModel: true,
+		RewriteModel: true,
+	}))
+	v1.POST("/alpha/search", middleware.RequireJSON(), relay.PassthroughHandler(relay.PassthroughOptions{
+		UpstreamPath: "/alpha/search",
+		ExtractModel: true,
+		RewriteModel: true,
+	}))
 	v1.POST("/messages", middleware.RequireJSON(), relay.Handler(llm.APIFormatAnthropicMessage))
 	v1.POST("/embeddings", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIEmbedding))
 	v1.POST("/images/generations", middleware.RequireJSON(), relay.Handler(llm.APIFormatOpenAIImageGeneration))

--- a/web/src/api/endpoints/channel.ts
+++ b/web/src/api/endpoints/channel.ts
@@ -63,6 +63,7 @@ export type Channel = {
     auto_group: AutoGroupType;
     custom_header: CustomHeader[];
     param_override?: string | null;
+    native_passthrough: boolean;
     channel_proxy?: string | null;
     match_regex?: string | null;
     stats: StatsChannel;
@@ -92,6 +93,7 @@ export type CreateChannelRequest = {
     custom_header?: CustomHeader[];
     channel_proxy?: string | null;
     param_override?: string | null;
+    native_passthrough?: boolean;
     match_regex?: string | null;
 };
 
@@ -112,6 +114,7 @@ export type UpdateChannelRequest = {
     custom_header?: CustomHeader[];
     channel_proxy?: string | null;
     param_override?: string | null;
+    native_passthrough?: boolean;
     match_regex?: string | null;
     // keys diff
     keys_to_add?: Array<Pick<ChannelKey, 'enabled' | 'channel_key' | 'remark'>>;

--- a/web/src/components/modules/channel/CardContent.tsx
+++ b/web/src/components/modules/channel/CardContent.tsx
@@ -41,6 +41,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         custom_header: channel.custom_header ?? [],
         channel_proxy: channel.channel_proxy ?? '',
         param_override: channel.param_override ?? '',
+        native_passthrough: channel.native_passthrough ?? false,
         keys: channel.keys.length > 0
             ? channel.keys.map((k) => ({
                 id: k.id,
@@ -87,6 +88,7 @@ export function CardContent({ channel, stats }: { channel: Channel; stats: Stats
         if (formData.proxy !== channel.proxy) req.proxy = formData.proxy;
         if (formData.auto_sync !== channel.auto_sync) req.auto_sync = formData.auto_sync;
         if (formData.auto_group !== channel.auto_group) req.auto_group = formData.auto_group;
+        if (formData.native_passthrough !== channel.native_passthrough) req.native_passthrough = formData.native_passthrough;
 
         if (!headersEqual(formData.custom_header, channel.custom_header)) {
             req.custom_header = (formData.custom_header ?? [])

--- a/web/src/components/modules/channel/Create.tsx
+++ b/web/src/components/modules/channel/Create.tsx
@@ -19,6 +19,7 @@ export function CreateDialogContent() {
         custom_header: [],
         channel_proxy: '',
         param_override: '',
+        native_passthrough: false,
         keys: [{ enabled: true, channel_key: '', remark: '' }],
         model: '',
         custom_model: '',
@@ -60,6 +61,7 @@ export function CreateDialogContent() {
                 custom_header: normalizedHeaders,
                 channel_proxy: channelProxy,
                 param_override: paramOverride,
+                native_passthrough: formData.native_passthrough,
                 match_regex: formData.match_regex.trim(),
             },
             {
@@ -71,6 +73,7 @@ export function CreateDialogContent() {
                         custom_header: [],
                         channel_proxy: '',
                         param_override: '',
+                        native_passthrough: false,
                         keys: [{ enabled: true, channel_key: '', remark: '' }],
                         model: '',
                         custom_model: '',

--- a/web/src/components/modules/channel/Form.tsx
+++ b/web/src/components/modules/channel/Form.tsx
@@ -32,6 +32,7 @@ export interface ChannelFormData {
     custom_header: Channel['custom_header'];
     channel_proxy: string;
     param_override: string;
+    native_passthrough: boolean;
     keys: ChannelKeyFormItem[];
     model: string;
     custom_model: string;
@@ -587,6 +588,17 @@ export function ChannelForm({
                     <span className="text-sm font-medium text-card-foreground">{t('enabled')}</span>
                 </label>
                 <div className="flex items-center gap-6">
+                    {formData.type === ChannelType.OpenAIResponse && (
+                        <label className="flex items-center gap-2 cursor-pointer">
+                            <Switch
+                                checked={formData.native_passthrough}
+                                onCheckedChange={(checked) => onFormDataChange({ ...formData, native_passthrough: checked })}
+                            />
+                            <span className="text-sm text-card-foreground" title={t('nativePassthroughHint')}>
+                                {t('nativePassthrough')}
+                            </span>
+                        </label>
+                    )}
                     <label className="flex items-center gap-2 cursor-pointer">
                         <Switch
                             checked={formData.proxy}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -515,6 +515,8 @@
             "channelProxyPlaceholder": "Optional: proxy for this channel (overrides global proxy)",
             "paramOverride": "Param Override",
             "paramOverridePlaceholder": "Optional: JSON string to override request params",
+            "nativePassthrough": "OpenAI/Codex native passthrough",
+            "nativePassthroughHint": "Preserves raw OpenAI Responses fields and SSE events while retaining Octopus routing, failover, logging, and usage accounting.",
             "model": "Model",
             "enabled": "Enabled",
             "proxy": "Use Proxy",

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -515,6 +515,8 @@
             "channelProxyPlaceholder": "可选：仅对该渠道生效（覆盖全局代理）",
             "paramOverride": "参数覆盖",
             "paramOverridePlaceholder": "可选：JSON 字符串，用于覆盖请求参数",
+            "nativePassthrough": "OpenAI/Codex 原生透传",
+            "nativePassthroughHint": "保留 OpenAI Responses 原始字段和 SSE 事件，同时继续使用 Octopus 路由、故障转移、日志与用量统计。",
             "model": "模型",
             "enabled": "启用",
             "proxy": "使用代理",

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -515,6 +515,8 @@
             "channelProxyPlaceholder": "可選：僅對該供應源生效（覆蓋全域代理）",
             "paramOverride": "參數覆蓋",
             "paramOverridePlaceholder": "可選：JSON 字串，用於覆蓋請求參數",
+            "nativePassthrough": "OpenAI/Codex 原生透傳",
+            "nativePassthroughHint": "保留 OpenAI Responses 原始欄位和 SSE 事件，同時繼續使用 Octopus 路由、故障轉移、日誌與用量統計。",
             "model": "模型",
             "enabled": "啟用",
             "proxy": "使用代理",


### PR DESCRIPTION
## 背景

Octopus 当前使用 AxonHub `llm` transformer 处理 OpenAI Responses 请求：

```text
OpenAI Responses JSON
→ InboundTransformer
→ llm.Request
→ OutboundTransformer
→ 上游协议
```

这套流程适合 OpenAI Responses 与 Anthropic 等协议之间的转换，但在客户端和上游都使用 OpenAI Responses/Codex 协议时，会完整解析并重新构造请求和响应。

Codex 当前使用了一些 Responses 协议扩展能力，包括：

* Remote Compaction V2
* `compaction_trigger`
* `compaction`
* `encrypted_content`
* Standalone Web Search
* `/v1/alpha/search`
* Codex 专用 Responses item
* 未来可能增加的未知 Responses 字段和 SSE event

Remote Compaction V2 会在普通 `POST /v1/responses` 请求的 `input` 末尾加入：

```json
{
  "type": "compaction_trigger"
}
```

上游随后通过 Responses SSE 返回包含以下内容的 item：

```json
{
  "type": "compaction",
  "encrypted_content": "..."
}
```

在现有 transformer 流程中，`compaction_trigger`、`compaction`、`encrypted_content` 或未知 SSE event 可能无法完整保留。实际表现可能是请求返回 HTTP 200，但最终得到普通 assistant 文本回复，Codex 无法获得所需的 Compaction item。

Octopus 此前也没有注册：

```text
POST /v1/alpha/search
POST /v1/responses/compact
```

因此 Codex 的 standalone web search 和旧版 remote compact endpoint 无法通过 Octopus 调用。

## 目标

当客户端使用 OpenAI Responses/Codex 协议，并且最终选中的上游 Channel 同样使用 OpenAI Responses 协议时，允许 Channel 启用原生透传。

原生透传保留 Octopus 的以下能力：

* API Key 鉴权
* 模型识别
* 模型映射
* Group 和 Channel 路由
* Channel 优先级
* Failover
* Channel 隔离
* 请求日志
* Token 用量统计
* 计费

该改动不会在 Octopus 内实现远程压缩或搜索算法。Octopus 负责将客户端请求透明转发给支持这些能力的上游，并将上游响应透明返回给 Codex。

跨协议调用继续使用现有 AxonHub transformer，例如：

```text
Responses → Anthropic
Anthropic → Responses
```

## 实现内容

### 1. 通用 Native Passthrough Relay

新增通用原生透传实现：

```text
internal/relay/passthrough.go
```

透传处理器只进行路由所需的最低限度解析：

1. 读取原始 JSON body
2. 提取 `model`
3. 使用现有 Group、Balancer 和 Channel 逻辑选择上游
4. 应用模型映射
5. 只修改 JSON 顶层的 `model`
6. 保留其余未知字段和嵌套结构
7. 将请求发送到上游
8. 将上游 JSON 或 SSE 响应透明返回客户端

需要保留的内容包括：

* 未知顶层 JSON 字段
* 未知 `input` item
* `compaction_trigger`
* `compaction`
* `encrypted_content`
* `metadata`
* `tools`
* `reasoning`
* `prompt_cache_key`
* 未来新增的 Responses 字段

### 2. Responses 到 Responses 自动进入透传路径

当以下条件同时满足时进入 Native Passthrough：

* 客户端 API Format 为 OpenAI Responses
* 上游 Channel API Format 为 OpenAI Responses
* Channel 已开启 OpenAI/Codex 原生透传

其他情况继续进入现有 transformer 流程。

该能力使用 Channel 级显式开关，现有 Channel 默认行为保持不变。

### 3. Responses SSE 透明转发

Native Passthrough 不会把 SSE 解析为 `llm.Response` 后重新生成。

上游 SSE 数据会直接转发给客户端，以保留：

* `response.created`
* `response.in_progress`
* `response.output_item.added`
* `response.output_item.done`
* `response.completed`
* `sequence_number`
* response id
* item id
* `created_at`
* `metadata`
* `compaction`
* `encrypted_content`
* 未知 SSE event
* 未来新增的 SSE 字段

### 4. Usage 旁路观察

透明转发期间增加只读 Usage Observer。

Observer 监听：

```text
response.completed.response.usage
```

并提取：

* `input_tokens`
* `output_tokens`
* `cached_tokens`
* `reasoning_tokens`

Observer 只读取 SSE frame，不修改发送给客户端的数据。

普通 JSON 响应也会在不改变响应内容的情况下旁路读取 usage。

### 5. Failover 边界

原生透传继续支持现有 Channel Failover，但遵循流式响应边界：

* 上游尚未向客户端发送响应 body 时，允许切换到下一个 Channel
* 已经向客户端发送任何 SSE 数据后，禁止切换 Channel

该限制用于避免将两个上游的 Responses SSE 拼接到同一个客户端响应中。

### 6. Codex Standalone Web Search

新增：

```text
POST /v1/alpha/search
```

该 endpoint 使用相同的 Native Passthrough Relay：

1. 从原始 JSON 提取 `model`
2. 使用 Octopus 现有路由选择 Channel
3. 应用模型映射
4. 转发到上游 `/v1/alpha/search`
5. 原样返回上游 JSON 响应

Octopus 不解析 standalone search 的 `commands`、`settings`、`results` 或未来新增字段。

### 7. 旧版 Remote Compact 兼容

新增：

```text
POST /v1/responses/compact
```

该 endpoint 同样使用 Native Passthrough。

Codex 当前 Remote Compaction V2 仍通过：

```text
POST /v1/responses
input: [..., {"type":"compaction_trigger"}]
```

完成远程压缩。`/v1/responses/compact` 主要用于旧 Codex 和其他兼容客户端，不会改变 Remote Compaction V2 的处理逻辑。

### 8. Headers

原生透传尽可能保留客户端请求 headers，包括：

* `x-openai-*`
* `openai-*`
* `user-agent`
* trace headers
* metadata headers
* 其他端到端 headers

同时过滤 Hop-by-Hop headers，并重新设置上游鉴权及请求传输相关字段。

## Channel 配置

Channel 设置中新增：

```text
OpenAI/Codex 原生透传
```

建议仅为确认支持 OpenAI Responses/Codex 原生能力的上游开启。

开启后，在客户端和上游均使用 OpenAI Responses 协议时，将保留原始请求字段和 SSE event，只执行鉴权、模型映射、路由、Failover、日志、用量统计和计费。

适用能力包括：

* Remote Compaction V2
* Standalone Web Search
* `encrypted_content`
* Codex 专用 Responses item
* 未来 OpenAI Responses 扩展

## 自动化测试

新增测试文件：

```text
internal/relay/passthrough_test.go
```

覆盖以下场景：

* `TestNativePassthroughOrdinaryResponsesPreservesUnknownFieldsAndMapsModel`
* `TestNativePassthroughRemoteCompactionV2AndUnknownSSEEvent`
* `TestNativePassthroughAlphaSearch`
* `TestNativePassthroughLegacyResponsesCompact`
* `TestNativePassthroughFailoverBeforeStreamStarts`
* `TestNativePassthroughDoesNotFailoverAfterStreamStarts`
* `TestNativePassthroughRequiresResponsesChannelOptIn`
* `TestNativePassthroughUnknownResponseItemIsPreserved`
* `TestNativePassthroughUnknownSSEEventIsByteTransparent`
* `TestNativePassthroughUsageObserverRecordsCachedAndReasoningTokens`

后端测试结果：

```bash
go test -modfile=.codex-test.mod -mod=mod ./...
```

结果：

```text
PASS
```

前端构建结果：

```bash
pnpm build
```

结果：

```text
PASS
```

当前 `pnpm lint` 会报告上游已有的 24 个全量 ESLint 错误，报错文件没有出现在本 PR 的修改文件中。本 PR 没有混入无关的 lint 修复。

## 手动测试前提

测试 Channel 需要满足：

1. API Format 设置为 OpenAI Responses
2. 开启“OpenAI/Codex 原生透传”
3. 上游真实支持对应 Codex 能力
4. Octopus API Key 有权访问测试模型
5. 根据实际配置替换模型名和 API Key

## 手动测试 1：Remote Compaction V2

```bash
curl -N -i http://127.0.0.1:8080/v1/responses \
  -H 'Authorization: Bearer sk-octopus-XXXX' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "gpt-5.6-luna",
    "store": false,
    "stream": true,
    "input": [
      {
        "role": "user",
        "content": "今天的天气不怎么好，有点要下雨的可能。"
      },
      {
        "type": "compaction_trigger"
      }
    ]
  }'
```

预期结果：

1. HTTP 状态码为 `200`
2. Content-Type 为 `text/event-stream`
3. 上游收到完整的 `compaction_trigger`
4. 客户端收到包含 Compaction item 的 SSE
5. Compaction item 中包含非空 `encrypted_content`
6. Octopus 不生成普通 assistant 文本代替 Compaction item

响应中应能观察到类似内容：

```json
{
  "type": "compaction",
  "encrypted_content": "..."
}
```

## 手动测试 2：Codex Standalone Web Search

该请求格式与当前 Codex `SearchRequest` 保持一致：

```bash
curl -sS -i http://127.0.0.1:8080/v1/alpha/search \
  -H 'Authorization: Bearer sk-octopus-XXXX' \
  -H 'Content-Type: application/json' \
  -d '{
    "id": "manual-search-test",
    "model": "gpt-5.6-luna",
    "commands": {
      "search_query": [
        {
          "q": "OpenAI Codex remote compaction"
        }
      ]
    },
    "settings": {
      "allowed_callers": [
        "direct"
      ],
      "external_web_access": true
    }
  }'
```

预期结果：

1. HTTP 状态码为 `200`
2. 请求被转发到上游 `/v1/alpha/search`
3. 上游收到相同的 `id`、`commands` 和 `settings`
4. 如果发生模型映射，上游收到映射后的 `model`
5. 客户端收到上游原始 JSON 响应
6. 响应中的未知 `results` 类型和字段不会被 Octopus 删除

响应格式由上游决定，当前 Codex 支持的结构包括：

```json
{
  "encrypted_output": "...",
  "output": "...",
  "results": []
}
```

其中 `encrypted_output` 和 `results` 可以由上游省略或返回 `null`。

## 手动测试 3：旧版 Remote Compact

```bash
curl -sS -i http://127.0.0.1:8080/v1/responses/compact \
  -H 'Authorization: Bearer sk-octopus-XXXX' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "gpt-5.6-luna",
    "input": [
      {
        "role": "user",
        "content": "请记住代号 A17。"
      },
      {
        "role": "assistant",
        "content": "好的，我记住了代号 A17。"
      },
      {
        "role": "user",
        "content": "继续对话。"
      }
    ]
  }'
```

预期结果：

1. endpoint 不再返回 `404`
2. 请求转发到上游 `/v1/responses/compact`
3. 请求 body 中除模型映射外的字段保持不变
4. 客户端收到上游原始 JSON 响应

## 安全与兼容性

* 原生透传需要在 Channel 上显式开启
* 现有 Channel 默认行为保持不变
* 跨协议转换继续使用 AxonHub transformer
* 模型映射只修改顶层 `model`
* 上游 Authorization 会使用 Channel 配置替换
* Hop-by-Hop headers 不会转发
* SSE 开始后不会进行跨 Channel Failover
* Usage Observer 不修改客户端收到的响应

## 贡献检查

* [x] 本 PR 仅包含 OpenAI Responses/Codex 原生透传一个变更主题
* [x] Remote Compaction V2 已通过自动化测试和手动测试
* [x] `/v1/alpha/search` 已通过自动化测试和手动测试
* [x] 普通 Responses 已完成回归测试
* [x] Failover 边界已通过自动化测试
* [x] AI 参与内容已经完成人工审查
