### PR TITLE
feat: 支持自定义模型价格数据地址

### DIFF
--- a/internal/model/setting.go
+++ b/internal/model/setting.go
@@ -10,6 +10,7 @@ type SettingKey string
 
 const (
 	SettingKeyProxyURL                SettingKey = "proxy_url"
+	SettingKeyModelPriceURL           SettingKey = "model_price_url"            // 模型价格镜像或反向代理接口地址
 	SettingKeyStatsSaveInterval       SettingKey = "stats_save_interval"        // 将统计信息写入数据库的周期(分钟)
 	SettingKeyModelInfoUpdateInterval SettingKey = "model_info_update_interval" // 模型信息更新间隔(小时)
 	SettingKeySyncLLMInterval         SettingKey = "sync_llm_interval"          // LLM 同步间隔(小时)
@@ -24,6 +25,7 @@ type Setting struct {
 func DefaultSettings() []Setting {
 	return []Setting{
 		{Key: SettingKeyProxyURL, Value: ""},
+		{Key: SettingKeyModelPriceURL, Value: ""},
 		{Key: SettingKeyStatsSaveInterval, Value: "10"},       // 默认10分钟保存一次统计信息
 		{Key: SettingKeyCORSAllowOrigins, Value: ""},          // CORS 默认不允许跨域，设置为 "*" 才允许所有来源
 		{Key: SettingKeyModelInfoUpdateInterval, Value: "24"}, // 默认24小时更新一次模型信息
@@ -57,6 +59,21 @@ func (s *Setting) Validate() error {
 		}
 		if parsedURL.Host == "" {
 			return fmt.Errorf("proxy URL must have a host")
+		}
+		return nil
+	case SettingKeyModelPriceURL:
+		if s.Value == "" {
+			return nil
+		}
+		parsedURL, err := url.Parse(s.Value)
+		if err != nil {
+			return fmt.Errorf("model price URL is invalid: %w", err)
+		}
+		if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+			return fmt.Errorf("model price URL scheme must be http or https")
+		}
+		if parsedURL.Host == "" {
+			return fmt.Errorf("model price URL must have a host")
 		}
 		return nil
 	}

--- a/internal/model/setting_test.go
+++ b/internal/model/setting_test.go
@@ -1,0 +1,28 @@
+package model
+
+import "testing"
+
+func TestModelPriceURLSettingValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty uses default", value: ""},
+		{name: "https mirror", value: "https://mirror.example.com/models.dev/api.json"},
+		{name: "http private mirror", value: "http://192.168.1.10:8080/api.json"},
+		{name: "reject ftp", value: "ftp://mirror.example.com/api.json", wantErr: true},
+		{name: "reject missing scheme", value: "mirror.example.com/api.json", wantErr: true},
+		{name: "reject missing host", value: "https:///api.json", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setting := Setting{Key: SettingKeyModelPriceURL, Value: tc.value}
+			err := setting.Validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/price/price.go
+++ b/internal/price/price.go
@@ -16,7 +16,7 @@ import (
 	"github.com/charmbracelet/log"
 )
 
-const llmPriceUrl = "https://models.dev/api.json"
+const defaultLLMPriceURL = "https://models.dev/api.json"
 
 // developerFamilies 定义研发商及其自研模型系列前缀。
 var developerFamilies = map[string][]string{
@@ -44,7 +44,7 @@ func UpdateLLMPrice(ctx context.Context) error {
 	var body []byte
 	httpClient, err := client.GetHTTPClientSystemProxy(false)
 	if err == nil {
-		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, llmPriceUrl, nil)
+		req, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, configuredLLMPriceURL(), nil)
 		if requestErr != nil {
 			return requestErr
 		}
@@ -70,7 +70,7 @@ func UpdateLLMPrice(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, llmPriceUrl, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, configuredLLMPriceURL(), nil)
 		if err != nil {
 			return err
 		}
@@ -130,6 +130,22 @@ func UpdateLLMPrice(ctx context.Context) error {
 	llmPriceLock.Unlock()
 	lastUpdateTime = time.Now()
 	return nil
+}
+
+func configuredLLMPriceURL() string {
+	value, err := op.SettingGetString(model.SettingKeyModelPriceURL)
+	if err != nil {
+		return defaultLLMPriceURL
+	}
+	return selectLLMPriceURL(value)
+}
+
+func selectLLMPriceURL(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultLLMPriceURL
+	}
+	return value
 }
 
 // GetLastUpdateTime 返回最近一次价格更新时间。

--- a/internal/price/price_test.go
+++ b/internal/price/price_test.go
@@ -1,0 +1,17 @@
+package price
+
+import "testing"
+
+func TestSelectLLMPriceURL(t *testing.T) {
+	if got := selectLLMPriceURL(""); got != defaultLLMPriceURL {
+		t.Fatalf("empty URL = %q, want %q", got, defaultLLMPriceURL)
+	}
+	if got := selectLLMPriceURL("   "); got != defaultLLMPriceURL {
+		t.Fatalf("blank URL = %q, want %q", got, defaultLLMPriceURL)
+	}
+
+	const mirror = "https://mirror.example.com/models.dev/api.json"
+	if got := selectLLMPriceURL("  " + mirror + "  "); got != mirror {
+		t.Fatalf("configured URL = %q, want %q", got, mirror)
+	}
+}

--- a/web/src/api/setting.ts
+++ b/web/src/api/setting.ts
@@ -11,6 +11,7 @@ export interface Setting {
 
 export const SettingKey = {
     ProxyURL: 'proxy_url',
+    ModelPriceURL: 'model_price_url',
     StatsSaveInterval: 'stats_save_interval',
     ModelInfoUpdateInterval: 'model_info_update_interval',
     SyncLLMInterval: 'sync_llm_interval',

--- a/web/src/components/modules/setting/LLMPrice.tsx
+++ b/web/src/components/modules/setting/LLMPrice.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, type MutableRefObject } from 'react';
 import { useTranslations } from 'use-intl';
-import { DollarSign, Clock, RefreshCw } from 'lucide-react';
+import { DollarSign, Clock, Link, RefreshCw } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useSettingList, useSetSetting, SettingKey } from '@/api/setting';
@@ -15,7 +15,9 @@ export function SettingLLMPrice() {
     const { data: lastUpdateTime } = useLastUpdateTime();
 
     const [updateInterval, setUpdateInterval] = useState('');
+    const [modelPriceUrl, setModelPriceUrl] = useState('');
     const initialUpdateInterval = useRef('');
+    const initialModelPriceUrl = useRef('');
 
     useEffect(() => {
         if (settings) {
@@ -24,16 +26,21 @@ export function SettingLLMPrice() {
                 queueMicrotask(() => setUpdateInterval(interval.value));
                 initialUpdateInterval.current = interval.value;
             }
+            const priceUrl = settings.find(s => s.key === SettingKey.ModelPriceURL);
+            if (priceUrl) {
+                queueMicrotask(() => setModelPriceUrl(priceUrl.value));
+                initialModelPriceUrl.current = priceUrl.value;
+            }
         }
     }, [settings]);
 
-    const handleSave = (key: string, value: string, initialValue: string) => {
+    const handleSave = (key: string, value: string, initialValue: string, initialRef: MutableRefObject<string>) => {
         if (value === initialValue) return;
 
         setSetting.mutate({ key, value }, {
             onSuccess: () => {
                 toast.success(t('saved'));
-                initialUpdateInterval.current = value;
+                initialRef.current = value;
             }
         });
     };
@@ -73,9 +80,27 @@ export function SettingLLMPrice() {
                     type="number"
                     value={updateInterval}
                     onChange={(e) => setUpdateInterval(e.target.value)}
-                    onBlur={() => handleSave(SettingKey.ModelInfoUpdateInterval, updateInterval, initialUpdateInterval.current)}
+                    onBlur={() => handleSave(SettingKey.ModelInfoUpdateInterval, updateInterval, initialUpdateInterval.current, initialUpdateInterval)}
                     placeholder={t('llmPrice.updateInterval.placeholder')}
                     className="w-48 rounded-xl"
+                />
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                <div className="flex items-center gap-3">
+                    <Link className="h-5 w-5 shrink-0 text-muted-foreground" />
+                    <div className="flex flex-col gap-0.5">
+                        <span className="text-sm font-medium">{t('llmPrice.sourceUrl.label')}</span>
+                        <span className="text-xs text-muted-foreground">{t('llmPrice.sourceUrl.description')}</span>
+                    </div>
+                </div>
+                <Input
+                    type="url"
+                    value={modelPriceUrl}
+                    onChange={(e) => setModelPriceUrl(e.target.value)}
+                    onBlur={() => handleSave(SettingKey.ModelPriceURL, modelPriceUrl.trim(), initialModelPriceUrl.current, initialModelPriceUrl)}
+                    placeholder={t('llmPrice.sourceUrl.placeholder')}
+                    className="w-full rounded-xl sm:w-72"
                 />
             </div>
 

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -224,6 +224,11 @@
                 "label": "Auto Update Interval (hours)",
                 "placeholder": "Enter interval in hours"
             },
+            "sourceUrl": {
+                "label": "Price data URL",
+                "placeholder": "https://example.com/api.json",
+                "description": "Leave empty to use the official models.dev endpoint"
+            },
             "manualUpdate": {
                 "label": "Manual Price Update",
                 "button": "Update Now",

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -224,6 +224,11 @@
                 "label": "自动更新间隔（小时）",
                 "placeholder": "请输入间隔（小时）"
             },
+            "sourceUrl": {
+                "label": "价格数据地址",
+                "placeholder": "https://example.com/api.json",
+                "description": "留空时使用 models.dev 官方接口"
+            },
             "manualUpdate": {
                 "label": "手动更新价格",
                 "button": "立即更新",

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -224,6 +224,11 @@
                 "label": "自動更新間隔（小時）",
                 "placeholder": "請輸入間隔（小時）"
             },
+            "sourceUrl": {
+                "label": "價格資料地址",
+                "placeholder": "https://example.com/api.json",
+                "description": "留空時使用 models.dev 官方介面"
+            },
             "manualUpdate": {
                 "label": "手動更新價格",
                 "button": "立即更新",


### PR DESCRIPTION
## 背景

模型价格目前固定从 `https://models.dev/api.json` 获取。在无法直接访问 models.dev、需要使用内网镜像或反向代理的部署环境中，只能修改源码或配置全局网络代理。

## 改动

- 新增 `model_price_url` 设置项；留空时继续使用官方 models.dev 地址，默认行为不变。
- 仅接受带有效主机名的 `http` / `https` URL，拒绝缺少协议、缺少主机或其他协议的配置。
- 价格更新的直连和代理重试路径均使用该配置地址。
- 在“模型价格”设置面板增加价格数据地址输入框。
- 补充简体中文、繁体中文和英文文案。
- 添加设置校验和默认地址选择的单元测试。

## 验证

- `go test ./internal/model ./internal/price`
- `cd web && pnpm build`
- `jq empty web/src/locales/en.json web/src/locales/zh_hans.json web/src/locales/zh_hant.json`
- `git diff --check`

`pnpm lint` 当前仍会报告 12 个基线错误，均位于本 PR 未修改的文件中；本 PR 修改的文件未产生新增 ESLint 错误。

## 不包含

- 不改变 models.dev 返回数据的解析和模型筛选逻辑。
- 不改变价格更新周期、代理开关或定时任务行为。
- 不内置或维护第三方镜像地址。
