### PR TITLE
feat: 分组编辑器支持复制模型名称

### DIFF
--- a/web/src/components/modules/group/Editor.tsx
+++ b/web/src/components/modules/group/Editor.tsx
@@ -7,6 +7,8 @@ import { Button } from '@/components/ui/button';
 import { Field, FieldGroup, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Accordion, AccordionContent, AccordionItem } from '@/components/ui/accordion';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { CopyIconButton } from '@/components/common/CopyButton';
 import { cn } from '@/lib/utils';
 import { getModelIcon } from '@/lib/model-icons';
 import type { SelectedMember } from './ItemList';
@@ -126,29 +128,52 @@ function ModelPickerSection({
                                             const isSelected = selectedKeys.has(memberKey(m));
                                             const { Icon, className: iconClassName } = getModelIcon(m.name);
                                             return (
-                                                <button
+                                                <div
                                                     key={memberKey(m)}
-                                                    type="button"
-                                                    onClick={() => !isSelected && onAdd(m)}
-                                                    disabled={isSelected}
                                                     className={cn(
-                                                        'w-full flex items-center justify-between gap-2 rounded-lg border border-border/50 bg-background px-2.5 py-2 text-left transition-colors',
-                                                        isSelected ? 'opacity-60 cursor-not-allowed' : 'hover:bg-muted'
+                                                        'flex w-full items-center gap-1 rounded-lg border border-border/50 bg-background transition-colors',
+                                                        isSelected ? 'opacity-60' : 'hover:bg-muted'
                                                     )}
                                                 >
-                                                    <span className="flex items-center gap-2 min-w-0">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => onAdd(m)}
+                                                        disabled={isSelected}
+                                                        className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2 text-left disabled:cursor-not-allowed"
+                                                    >
                                                         <Icon aria-hidden="true" className={iconClassName} width={16} height={16} />
                                                         <span className="text-sm font-medium truncate">{m.name}</span>
-                                                    </span>
+                                                    </button>
 
-                                                    <span className="shrink-0 text-muted-foreground">
+                                                    <div className="flex shrink-0 items-center gap-0.5 pr-1.5 text-muted-foreground">
+                                                        <Tooltip>
+                                                            <TooltipTrigger asChild>
+                                                                <span className="inline-flex">
+                                                                    <CopyIconButton
+                                                                        text={m.name}
+                                                                        className="rounded-md p-1.5 transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                                                        copyIconClassName="size-4"
+                                                                        checkIconClassName="size-4 text-primary"
+                                                                    />
+                                                                </span>
+                                                            </TooltipTrigger>
+                                                            <TooltipContent>{t('form.copyModelName')}</TooltipContent>
+                                                        </Tooltip>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => onAdd(m)}
+                                                            disabled={isSelected}
+                                                            className="rounded-md p-1.5 disabled:cursor-not-allowed"
+                                                            title={isSelected ? undefined : t('form.addItem')}
+                                                        >
                                                         {isSelected ? (
                                                             <Check className="size-4 text-primary" />
                                                         ) : (
                                                             <Plus className="size-4" />
                                                         )}
-                                                    </span>
-                                                </button>
+                                                        </button>
+                                                    </div>
+                                                </div>
                                             );
                                         })}
                                     </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -334,6 +334,7 @@
             "retryInterval": "Retry Interval",
             "items": "Selected Models",
             "addItem": "Add Model",
+            "copyModelName": "Copy model name",
             "autoAdd": "Auto Add",
             "clear": "Clear"
         }

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -334,6 +334,7 @@
             "retryInterval": "重试间隔",
             "items": "已选模型",
             "addItem": "添加模型",
+            "copyModelName": "复制模型名称",
             "autoAdd": "自动添加",
             "clear": "清空"
         }

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -334,6 +334,7 @@
             "retryInterval": "重試間隔",
             "items": "已選模型",
             "addItem": "新增模型",
+            "copyModelName": "複製模型名稱",
             "autoAdd": "自動新增",
             "clear": "清空"
         }


### PR DESCRIPTION
## 背景

在分组中配置模型时，模型名称只能查看或添加，无法直接复制。对名称较长、包含版本后缀的模型，用户需要手动选中文本，操作不稳定，尤其不利于后续粘贴到客户端配置或排查请求。

## 改动

- 在分组编辑器的可选模型列表中增加独立复制按钮。
- 复用项目现有 `CopyIconButton`，保持复制成功、失败提示和短暂完成状态一致。
- 将原整行按钮拆为语义正确的添加按钮与复制按钮，避免嵌套交互元素。
- 已选模型仍可复制名称，但添加操作保持禁用。
- 添加简体中文、繁体中文和英文 Tooltip 文案。

## 验证

- `cd web && pnpm build`
- `cd web && pnpm exec eslint src/components/modules/group/Editor.tsx`
- `jq empty web/src/locales/en.json web/src/locales/zh_hans.json web/src/locales/zh_hant.json`
- `git diff --check`

## 不包含

- 不改变模型筛选、自动添加、排序或分组保存逻辑。
- 不修改通用复制组件的行为。
- 不调整分组卡片已有的“复制分组名称”功能。
