### PR TITLE
fix: 防止移动端日志卡片被长名称撑宽

### DIFF
--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -195,28 +195,32 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
         <>
             <MorphingDialogTrigger
                 className={cn(
-                    "rounded-3xl border bg-card w-full text-left",
+                    "w-full overflow-hidden rounded-3xl border bg-card text-left",
                     requestFailed ? "border-destructive/40" : "border-border",
                 )}
             >
                 <div className={cn("p-4 grid grid-cols-[auto_1fr] gap-4", requestFailed ? "items-start" : "items-center")}>
                     <Icon aria-hidden="true" className={iconClassName} width={40} height={40} />
                     <div className="min-w-0 flex flex-col gap-3">
-                        <div className="flex items-center gap-2 min-w-0 text-sm">
-                            <span className="font-semibold text-card-foreground truncate" title={log.request_model}>
-                                {log.request_model || t('unknownModel')}
-                            </span>
-                            <ArrowRight className="size-3.5 shrink-0 text-muted-foreground/50" />
-                            <Badge
-                                variant="secondary"
-                                className="shrink-0 text-xs px-1.5 py-0"
-                                style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
-                            >
-                                {channelName}
-                            </Badge>
-                            <span className="text-muted-foreground truncate" title={actualModel}>
-                                {actualModel}
-                            </span>
+                        <div className="flex min-w-0 flex-col gap-1 text-sm md:flex-row md:items-center md:gap-2">
+                            <div className="flex min-w-0 items-center gap-2 md:contents">
+                                <span className="min-w-0 flex-1 truncate font-semibold text-card-foreground" title={log.request_model}>
+                                    {log.request_model || t('unknownModel')}
+                                </span>
+                                <ArrowRight className="size-3.5 shrink-0 text-muted-foreground/50" />
+                            </div>
+                            <div className="flex min-w-0 items-center gap-2 md:contents">
+                                <Badge
+                                    variant="secondary"
+                                    className="max-w-[45%] min-w-0 shrink-0 px-1.5 py-0 text-xs md:max-w-[30%]"
+                                    style={{ backgroundColor: `${brandColor}15`, color: brandColor }}
+                                >
+                                    <span className="truncate">{channelName}</span>
+                                </Badge>
+                                <span className="min-w-0 flex-1 truncate text-muted-foreground" title={actualModel}>
+                                    {actualModel}
+                                </span>
+                            </div>
                         </div>
                         <div className="grid grid-cols-2 md:grid-cols-7 gap-x-4 gap-y-2 text-xs tabular-nums text-muted-foreground">
                             <div className="flex items-center gap-1.5">
@@ -252,7 +256,7 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
                         </div>
                         {requestFailed && errorText && (
                             <div className="p-2.5 rounded-xl bg-destructive/10 border border-destructive/20 overflow-hidden">
-                                <p className="text-xs text-destructive line-clamp-2 whitespace-pre-line">{errorText}</p>
+                                <p className="line-clamp-2 break-words whitespace-pre-line text-xs text-destructive">{errorText}</p>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## 背景

日志概览卡片将请求模型、渠道和实际模型固定放在同一行。渠道 Badge 不允许收缩，当模型名或渠道名较长时，窄屏下会撑宽卡片并导致页面横向溢出；错误文本中的长连续字符串也可能产生同类问题。

## 改动

- 日志卡片增加 `overflow-hidden`，限制动态内容不能突破卡片边界。
- 移动端将模型路由信息拆为两行，桌面端继续保持同一行和原有信息顺序。
- 请求模型、渠道名和实际模型分别增加正确的 `min-w-0`、最大宽度和截断规则。
- 错误摘要允许长字符串断行，同时继续保留两行截断。

## 验证

- `cd web && pnpm build`
- `git diff --check`

对修改文件执行 ESLint 时仍有 3 个基线错误，位于本 PR 未修改的第 59、89 和 191 行（React purity / effect setState 规则）；本次修改未新增 ESLint 报错。

## 不包含

- 不改变日志数据、筛选、刷新或详情弹窗逻辑。
- 不改变桌面端指标布局和日志字段。
- 不处理上述既有 ESLint 基线问题。
