### PR TITLE
fix: 备份导入后同步 PostgreSQL 自增序列

### DIFF
--- a/internal/op/backup.go
+++ b/internal/op/backup.go
@@ -143,12 +143,45 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 			}
 		}
 
+		if err := resetPostgresImportSequences(tx); err != nil {
+			return fmt.Errorf("reset postgres import sequences: %w", err)
+		}
+
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 	return res, nil
+}
+
+var postgresImportSequenceTables = []string{
+	"channels",
+	"groups",
+	"group_items",
+	"api_keys",
+	"stats_models",
+}
+
+func resetPostgresImportSequences(tx *gorm.DB) error {
+	if tx.Dialector == nil || tx.Dialector.Name() != "postgres" {
+		return nil
+	}
+	for _, table := range postgresImportSequenceTables {
+		statement := postgresSequenceResetStatement(table)
+		if err := tx.Exec(statement).Error; err != nil {
+			return fmt.Errorf("reset %s id sequence: %w", table, err)
+		}
+	}
+	return nil
+}
+
+func postgresSequenceResetStatement(table string) string {
+	return fmt.Sprintf(
+		`SELECT setval(pg_get_serial_sequence('%s', 'id'), COALESCE(MAX("id"), 1), MAX("id") IS NOT NULL) FROM "%s"`,
+		table,
+		table,
+	)
 }
 
 func createDoNothing[T any](tx *gorm.DB, rows []T) (int64, error) {

--- a/internal/op/backup_sequence_test.go
+++ b/internal/op/backup_sequence_test.go
@@ -1,0 +1,10 @@
+package op
+
+import "testing"
+
+func TestPostgresSequenceResetStatement(t *testing.T) {
+	const want = `SELECT setval(pg_get_serial_sequence('groups', 'id'), COALESCE(MAX("id"), 1), MAX("id") IS NOT NULL) FROM "groups"`
+	if got := postgresSequenceResetStatement("groups"); got != want {
+		t.Fatalf("postgresSequenceResetStatement() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## 背景

PostgreSQL 导入备份时会显式插入原始主键，但序列值不会随显式 ID 自动推进。导入包含 `groups.id = 1` 的备份后再创建分组，序列仍可能返回 1，最终触发 `groups_pkey` 冲突。

Fixes #263

## 改动

- 在增量导入事务末尾，仅对 PostgreSQL 重置相关自增序列。
- 覆盖备份会导入显式 ID 且后续可能新增记录的表：
  - `channels`
  - `groups`
  - `group_items`
  - `api_keys`
  - `stats_models`
- 序列值同步到表中当前最大 ID。
- 空表使用 `setval(..., 1, false)`，保证下一条记录仍从 1 开始。
- 任一序列同步失败会让导入事务返回错误，不静默留下不一致状态。
- SQLite 和 MySQL 路径不执行任何额外 SQL。

## 验证

- `go test ./internal/op`
- `git diff --check`

当前机器没有运行 PostgreSQL 或 Docker 守护进程，因此未执行真实 PostgreSQL 集成测试；单元测试覆盖了生成的 PostgreSQL `setval` 语句，代码路径受 Dialector 限制。

## 不包含

- 不改变备份格式、冲突处理策略或导入顺序。
- 不重编号现有记录。
- 不修改 SQLite/MySQL 的自增行为。
