### PR TITLE
feat: 日志显示缓存命中率

### DIFF
--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -13,6 +13,7 @@ import { useModelChannelList } from '@/api/model';
 import { getModelIcon } from '@/lib/model-icons';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { CopyIconButton } from '@/components/common/CopyButton';
 import { toast } from 'sonner';
@@ -51,6 +52,13 @@ function formatMilliseconds(value: number) {
 // formatDuration 将 Go time.Duration 的纳秒值转换为显示文本。
 function formatDuration(value: number) {
     return formatMilliseconds(value / 1_000_000);
+}
+
+function cacheHitRate(inputTokens: number, cacheReadTokens: number) {
+    const total = Math.max(0, inputTokens);
+    const cached = Math.max(0, cacheReadTokens);
+    if (total === 0) return 0;
+    return Math.min(100, (cached / total) * 100);
 }
 
 // useOverviewDuration 返回运行中请求的实时耗时或完成请求的固定耗时。
@@ -178,6 +186,7 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
     const errorText = log.error ?? '';
     const requestFailed = activeState === 'failed' || activeState === 'canceled';
     const responseCommitted = isCommitted || activeState === 'committed';
+    const cacheRate = cacheHitRate(log.input_tokens, log.cache_read_tokens);
     const isWaiting = activeState === 'running' && !responseCommitted;
     const activeGroup = groups.find((group) => group.name === log.request_model);
     const isWaitingForSelection = isWaiting && activeGroup?.active_item_id === 0; // isWaitingForSelection 表示请求正等待分组选择渠道。
@@ -234,6 +243,20 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
                             <div className="flex items-center gap-1.5">
                                 <Database className="size-3.5 shrink-0 text-cyan-500" />
                                 <span>{log.cache_read_tokens.toLocaleString()}</span>
+                                {log.cache_read_tokens > 0 && (
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Badge
+                                                variant="secondary"
+                                                className="cursor-help px-1.5 py-0 text-[11px] text-emerald-600 dark:text-emerald-400"
+                                                aria-label={`${t('cacheHitRate')} ${cacheRate.toFixed(1)}%`}
+                                            >
+                                                {cacheRate.toFixed(1)}%
+                                            </Badge>
+                                        </TooltipTrigger>
+                                        <TooltipContent>{t('cacheHitRate')}</TooltipContent>
+                                    </Tooltip>
+                                )}
                             </div>
                             <div className="flex items-center gap-1.5">
                                 <ArrowUpFromLine className="size-3.5 shrink-0 text-purple-500" />
@@ -486,6 +509,20 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
                         <div className="flex items-center gap-1.5">
                             <Database className="size-3.5 text-cyan-500" />
                             <span>{log.cache_read_tokens.toLocaleString()}</span>
+                            {log.cache_read_tokens > 0 && (
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Badge
+                                            variant="secondary"
+                                            className="cursor-help px-1.5 py-0 text-[11px] text-emerald-600 dark:text-emerald-400"
+                                            aria-label={`${t('cacheHitRate')} ${cacheRate.toFixed(1)}%`}
+                                        >
+                                            {cacheRate.toFixed(1)}%
+                                        </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent>{t('cacheHitRate')}</TooltipContent>
+                                </Tooltip>
+                            )}
                         </div>
                         <div className="flex items-center gap-1.5">
                             <ArrowUpFromLine className="size-3.5 text-purple-500" />

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -398,6 +398,7 @@
             "noRequestContent": "(No request content)",
             "noResponseContent": "(No response content)",
             "tokens": "tokens",
+            "cacheHitRate": "Cache hit rate",
             "retryDetails": "Retry Details",
             "stopAttempt": "Stop Attempt",
             "stopFailed": "Failed to stop attempt",

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -398,6 +398,7 @@
             "noRequestContent": "(无请求内容)",
             "noResponseContent": "(无响应内容)",
             "tokens": "tokens",
+            "cacheHitRate": "缓存命中率",
             "retryDetails": "重试详情",
             "stopAttempt": "停止本次尝试",
             "stopFailed": "停止失败",

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -398,6 +398,7 @@
             "noRequestContent": "(無請求內容)",
             "noResponseContent": "(無回應內容)",
             "tokens": "tokens",
+            "cacheHitRate": "快取命中率",
             "retryDetails": "重試詳情",
             "stopAttempt": "停止本次嘗試",
             "stopFailed": "停止失敗",


### PR DESCRIPTION
## 背景

Relay 日志已经记录总输入 Token 和缓存读取 Token，但目前只能看到缓存读取数量，无法直接判断一次请求的缓存利用率。

## 改动

- 在日志概览卡片的缓存读取指标旁显示缓存命中率。
- 在日志详情底部的缓存读取指标旁同步显示命中率。
- 计算口径为 `cache_read_tokens / input_tokens * 100`：`input_tokens` 是上游 Usage 报告的总输入，缓存读取是其中的命中部分。
- 对异常数据进行保护：总输入小于等于 0 时显示 0，最终结果限制在 `0–100%`。
- 仅在缓存读取 Token 大于 0 时展示百分比，避免无缓存请求增加视觉噪音。
- 增加简体中文、繁体中文和英文 Tooltip 文案。

## 验证

- `cd web && pnpm build`
- `jq empty web/src/locales/en.json web/src/locales/zh_hans.json web/src/locales/zh_hant.json`
- `git diff --check`

对修改文件执行 ESLint 时仍有 3 个基线错误，位于本 PR 未修改的 React 状态代码；本次修改未新增 ESLint 报错。

## 不包含

- 不改变 Token 采集、费用计算或统计持久化口径。
- 不增加数据库字段或迁移。
- 不修改无缓存请求的现有布局。
