### PR TITLE
feat: 支持 API Key 每分钟请求数限制

### DIFF
--- a/internal/model/apikey.go
+++ b/internal/model/apikey.go
@@ -7,5 +7,6 @@ type APIKey struct {
 	Enabled         bool    `json:"enabled" gorm:"default:true"`
 	ExpireAt        int64   `json:"expire_at,omitempty"`
 	MaxCost         float64 `json:"max_cost,omitempty"`
+	MaxRPM          int     `json:"max_rpm,omitempty"`
 	SupportedModels string  `json:"supported_models,omitempty"`
 }

--- a/internal/op/apikey.go
+++ b/internal/op/apikey.go
@@ -72,6 +72,7 @@ func APIKeyDelete(id int, ctx context.Context) error {
 	if result.Error != nil {
 		return fmt.Errorf("failed to delete API key: %w", result.Error)
 	}
+	RateLimitDel(id)
 	apiKeyCache.Del(k.ID)
 	apiKeyIDMap.Del(k.APIKey)
 	return nil

--- a/internal/op/ratelimit.go
+++ b/internal/op/ratelimit.go
@@ -1,0 +1,57 @@
+package op
+
+import (
+	"sync"
+	"time"
+)
+
+type rateLimitEntry struct {
+	mu     sync.Mutex
+	minute int64
+	count  int64
+}
+
+var rateLimitEntries = struct {
+	sync.Mutex
+	items map[int]*rateLimitEntry
+}{items: make(map[int]*rateLimitEntry)}
+
+// RateLimitCheck applies a fixed one-minute request window to one API key.
+// A non-positive limit means unlimited.
+func RateLimitCheck(apiKeyID int, maxRPM int) (bool, int) {
+	if maxRPM <= 0 {
+		return true, 0
+	}
+
+	rateLimitEntries.Lock()
+	entry := rateLimitEntries.items[apiKeyID]
+	if entry == nil {
+		entry = &rateLimitEntry{}
+		rateLimitEntries.items[apiKeyID] = entry
+	}
+	rateLimitEntries.Unlock()
+
+	now := time.Now()
+	currentMinute := now.Unix() / 60
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.minute != currentMinute {
+		entry.minute = currentMinute
+		entry.count = 0
+	}
+	entry.count++
+	if entry.count <= int64(maxRPM) {
+		return true, 0
+	}
+	retryAfter := 60 - int(now.Unix()%60)
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	return false, retryAfter
+}
+
+func RateLimitDel(apiKeyID int) {
+	rateLimitEntries.Lock()
+	delete(rateLimitEntries.items, apiKeyID)
+	rateLimitEntries.Unlock()
+}

--- a/internal/op/ratelimit_test.go
+++ b/internal/op/ratelimit_test.go
@@ -1,0 +1,22 @@
+package op
+
+import "testing"
+
+func TestRateLimitCheck(t *testing.T) {
+	const keyID = 987654321
+	RateLimitDel(keyID)
+	t.Cleanup(func() { RateLimitDel(keyID) })
+
+	if allowed, retryAfter := RateLimitCheck(keyID, 2); !allowed || retryAfter != 0 {
+		t.Fatalf("first request: allowed=%v retryAfter=%d", allowed, retryAfter)
+	}
+	if allowed, retryAfter := RateLimitCheck(keyID, 2); !allowed || retryAfter != 0 {
+		t.Fatalf("second request: allowed=%v retryAfter=%d", allowed, retryAfter)
+	}
+	if allowed, retryAfter := RateLimitCheck(keyID, 2); allowed || retryAfter < 1 || retryAfter > 60 {
+		t.Fatalf("third request: allowed=%v retryAfter=%d", allowed, retryAfter)
+	}
+	if allowed, retryAfter := RateLimitCheck(keyID, 0); !allowed || retryAfter != 0 {
+		t.Fatalf("unlimited request: allowed=%v retryAfter=%d", allowed, retryAfter)
+	}
+}

--- a/internal/server/handlers/apikey.go
+++ b/internal/server/handlers/apikey.go
@@ -53,6 +53,10 @@ func createAPIKey(c *gin.Context) {
 		resp.Error(c, http.StatusBadRequest, resp.ErrInvalidJSON)
 		return
 	}
+	if req.MaxRPM < 0 {
+		resp.Error(c, http.StatusBadRequest, "max_rpm must be non-negative")
+		return
+	}
 	req.APIKey = auth.GenerateAPIKey()
 	if err := op.APIKeyCreate(&req, c.Request.Context()); err != nil {
 		resp.Error(c, http.StatusInternalServerError, err.Error())
@@ -74,6 +78,10 @@ func updateAPIKey(c *gin.Context) {
 	var req model.APIKey
 	if err := c.ShouldBindJSON(&req); err != nil {
 		resp.Error(c, http.StatusBadRequest, resp.ErrInvalidJSON)
+		return
+	}
+	if req.MaxRPM < 0 {
+		resp.Error(c, http.StatusBadRequest, "max_rpm must be non-negative")
 		return
 	}
 	if err := op.APIKeyUpdate(&req, c.Request.Context()); err != nil {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -66,6 +67,15 @@ func APIKeyAuth() gin.HandlerFunc {
 			resp.Error(c, http.StatusUnauthorized, "API key has expired")
 			c.Abort()
 			return
+		}
+		if apiKeyObj.MaxRPM > 0 {
+			allowed, retryAfter := op.RateLimitCheck(apiKeyObj.ID, apiKeyObj.MaxRPM)
+			if !allowed {
+				c.Header("Retry-After", strconv.Itoa(retryAfter))
+				resp.Error(c, http.StatusTooManyRequests, "API key has exceeded the rate limit")
+				c.Abort()
+				return
+			}
 		}
 		statsAPIKey := op.StatsAPIKeyGet(apiKeyObj.ID)
 		if apiKeyObj.MaxCost > 0 && apiKeyObj.MaxCost < statsAPIKey.StatsMetrics.OutputCost+statsAPIKey.StatsMetrics.InputCost {

--- a/web/src/api/apikey.ts
+++ b/web/src/api/apikey.ts
@@ -15,6 +15,7 @@ export interface APIKey {
     enabled: boolean;
     expire_at?: number; // Unix 时间戳（秒），不传表示永不过期
     max_cost?: number; // 不传表示无限制
+    max_rpm?: number; // 不传表示不限流
     supported_models?: string; // 不传表示支持所有模型
 }
 

--- a/web/src/components/modules/setting/APIKey.tsx
+++ b/web/src/components/modules/setting/APIKey.tsx
@@ -85,10 +85,14 @@ function APIKeyForm({ apiKey, isPending, submitLabel, onSubmit, onClose }: APIKe
         enabled: apiKey?.enabled ?? true,
         expire_at: apiKey?.expire_at,
         max_cost: apiKey?.max_cost,
+        max_rpm: apiKey?.max_rpm,
         supported_models: apiKey?.supported_models,
     }));
     const [maxCostInput, setMaxCostInput] = useState(() =>
         apiKey?.max_cost != null ? String(apiKey.max_cost) : ''
+    );
+    const [maxRPMInput, setMaxRPMInput] = useState(() =>
+        apiKey?.max_rpm != null ? String(apiKey.max_rpm) : ''
     );
     const [expireTime, setExpireTime] = useState(() => {
         if (apiKey?.expire_at) {
@@ -109,6 +113,7 @@ function APIKeyForm({ apiKey, isPending, submitLabel, onSubmit, onClose }: APIKe
     const expireDate = parseExpireDate(form.expire_at);
     const neverExpire = !form.expire_at;
     const isUnlimitedCost = maxCostInput.trim() === '';
+    const isUnlimitedRPM = maxRPMInput.trim() === '';
 
     const expireLabel = neverExpire
         ? t('apiKey.form.neverExpire')
@@ -157,6 +162,23 @@ function APIKeyForm({ apiKey, isPending, submitLabel, onSubmit, onClose }: APIKe
         updateForm({ max_cost: undefined });
     }, [updateForm]);
 
+    const handleMaxRPMChange = useCallback((value: string) => {
+        const cleaned = value.replace(/[^\d]/g, '');
+        const number = Number.parseInt(cleaned, 10);
+        if (Number.isFinite(number) && number > 0) {
+            setMaxRPMInput(cleaned);
+            updateForm({ max_rpm: number });
+        } else {
+            setMaxRPMInput('');
+            updateForm({ max_rpm: undefined });
+        }
+    }, [updateForm]);
+
+    const handleClearMaxRPM = useCallback(() => {
+        setMaxRPMInput('');
+        updateForm({ max_rpm: undefined });
+    }, [updateForm]);
+
     const handleSubmit = useCallback((e: React.FormEvent) => {
         e.preventDefault();
         if (!form.name.trim()) return;
@@ -203,6 +225,36 @@ function APIKeyForm({ apiKey, isPending, submitLabel, onSubmit, onClose }: APIKe
                                 ? 'bg-primary text-primary-foreground border-primary/30'
                                 : 'border-border bg-muted/20 text-foreground hover:bg-muted/30',
                             isPending && 'opacity-50 cursor-not-allowed'
+                        )}
+                    >
+                        {t('apiKey.form.unlimited')}
+                    </button>
+                </div>
+            </div>
+
+            <div className="grid gap-1 text-xs text-muted-foreground">
+                {t('apiKey.form.maxRPM')}
+                <div className="flex items-center gap-2">
+                    <Input
+                        type="text"
+                        inputMode="numeric"
+                        placeholder={t('apiKey.form.maxRPMPlaceholder')}
+                        value={maxRPMInput}
+                        onChange={(e) => handleMaxRPMChange(e.target.value)}
+                        className="h-9 flex-1 rounded-xl text-sm"
+                        disabled={isPending}
+                    />
+                    <button
+                        type="button"
+                        onClick={handleClearMaxRPM}
+                        disabled={isPending}
+                        aria-pressed={isUnlimitedRPM}
+                        className={cn(
+                            'h-9 shrink-0 rounded-xl border px-3 text-sm transition-colors',
+                            isUnlimitedRPM
+                                ? 'border-primary/30 bg-primary text-primary-foreground'
+                                : 'border-border bg-muted/20 text-foreground hover:bg-muted/30',
+                            isPending && 'cursor-not-allowed opacity-50'
                         )}
                     >
                         {t('apiKey.form.unlimited')}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -187,6 +187,8 @@
                 "name": "Name",
                 "maxCost": "Max Cost",
                 "maxCostPlaceholder": "Enter amount",
+                "maxRPM": "Requests per minute",
+                "maxRPMPlaceholder": "Enter maximum requests per minute",
                 "unlimited": "Unlimited",
                 "expireAt": "Expire Date",
                 "selectDate": "Select date",

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -187,6 +187,8 @@
                 "name": "名称",
                 "maxCost": "最大金额",
                 "maxCostPlaceholder": "请输入金额",
+                "maxRPM": "每分钟请求数",
+                "maxRPMPlaceholder": "请输入每分钟最大请求数",
                 "unlimited": "无限制",
                 "expireAt": "过期日期",
                 "selectDate": "选择日期",

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -187,6 +187,8 @@
                 "name": "名稱",
                 "maxCost": "最大金額",
                 "maxCostPlaceholder": "請輸入金額",
+                "maxRPM": "每分鐘請求數",
+                "maxRPMPlaceholder": "請輸入每分鐘最大請求數",
                 "unlimited": "無限制",
                 "expireAt": "過期日期",
                 "selectDate": "選擇日期",


### PR DESCRIPTION
## 变更内容

为 API Key 增加可选的 RPM（Requests Per Minute）限流配置：

- API Key 新增 `max_rpm` 字段，`0` 或未设置表示不限流
- 在 API Key 认证中间件统一执行限流，覆盖所有需要 API Key 的代理接口
- 超过限制时返回 HTTP `429 Too Many Requests`
- 返回 `Retry-After` 响应头，提示客户端等待到下一个窗口
- 删除 API Key 时同步清理对应的内存计数
- 设置页面增加“每分钟请求数”输入和“无限制”选项
- 增加固定窗口计数及超限行为单元测试

## 实现说明

使用进程内固定一分钟窗口计数，不增加请求日志或数据库写放大；限制只在单实例内生效，适合单实例部署。多实例部署需要在网关或共享存储层配置全局限流。

## 验证

- `go test ./...`
- `pnpm build`
- `git diff --check`
