### PR TITLE
feat: 在请求日志中显示 API Key 名称

### DIFF
--- a/internal/relay/execution.go
+++ b/internal/relay/execution.go
@@ -19,7 +19,7 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
 )
 
-var requestIDs atomic.Uint64 // requestIDs 分配进程内严格递增的请求 ID。
+var requestIDs atomic.Uint64                             // requestIDs 分配进程内严格递增的请求 ID。
 var errNoActiveChannel = errors.New("no active channel") // errNoActiveChannel 表示分组尚未选择活动渠道。
 
 // execution 保存单个客户端请求的全部可变执行状态。
@@ -49,7 +49,7 @@ func HandleMessages(c *gin.Context) {
 
 // execute 初始化请求，并在渠道未选择时等待、失败时重试，直至提交响应或客户端取消。
 func (e *execution) execute() {
-	e.log = LogRecord{LogOverview: LogOverview{ID: requestIDs.Add(1), State: RequestStateRunning, StartedAt: time.Now(), ClientProtocol: e.protocol.format}}
+	e.log = LogRecord{LogOverview: LogOverview{ID: requestIDs.Add(1), State: RequestStateRunning, StartedAt: time.Now(), ClientProtocol: e.protocol.format, RequestAPIKeyName: e.ctx.GetString("api_key_name")}}
 	ctx := e.ctx.Request.Context()
 	raw, err := httpclient.ReadHTTPRequest(e.ctx.Request)
 	if err != nil {

--- a/internal/relay/log.go
+++ b/internal/relay/log.go
@@ -42,22 +42,23 @@ type LogAttempt struct {
 
 // LogOverview 表示概览流中一条可持续更新的请求日志。
 type LogOverview struct {
-	ID               uint64        `json:"id"`                 // 请求在当前进程内的唯一标识。
-	State            RequestState  `json:"state"`              // 请求当前状态。
-	StartedAt        time.Time     `json:"started_at"`         // 请求到达时间。
-	CompletedAt      time.Time     `json:"completed_at"`       // 请求完成时间。
-	Duration         time.Duration `json:"duration"`           // 请求总耗时。
-	RequestModel     string        `json:"request_model"`      // 客户端请求的模型名称。
-	ActualModel      string        `json:"actual_model"`       // 最终实际请求的模型名称。
-	ClientProtocol   llm.APIFormat `json:"client_protocol"`    // 客户端使用的请求协议。
-	Stream           bool          `json:"stream"`             // 是否为流式请求。
-	FinalChannelName string        `json:"final_channel_name"` // 成功渠道或最后尝试渠道的名称。
-	InputTokens      int64         `json:"input_tokens"`       // 请求完成后补充的输入 Token 数量。
-	OutputTokens     int64         `json:"output_tokens"`      // 请求完成后补充的输出 Token 数量。
-	CacheReadTokens  int64         `json:"cache_read_tokens"`  // 请求完成后补充的缓存读取 Token 数量。
-	CacheWriteTokens int64         `json:"cache_write_tokens"` // 请求完成后补充的缓存写入 Token 数量。
-	TotalCost        float64       `json:"total_cost"`         // 请求完成后补充的总费用。
-	Error            string        `json:"error,omitempty"`    // 请求当前或最终错误。
+	ID                uint64        `json:"id"`                             // 请求在当前进程内的唯一标识。
+	State             RequestState  `json:"state"`                          // 请求当前状态。
+	StartedAt         time.Time     `json:"started_at"`                     // 请求到达时间。
+	CompletedAt       time.Time     `json:"completed_at"`                   // 请求完成时间。
+	Duration          time.Duration `json:"duration"`                       // 请求总耗时。
+	RequestModel      string        `json:"request_model"`                  // 客户端请求的模型名称。
+	RequestAPIKeyName string        `json:"request_api_key_name,omitempty"` // 请求使用的 API Key 名称。
+	ActualModel       string        `json:"actual_model"`                   // 最终实际请求的模型名称。
+	ClientProtocol    llm.APIFormat `json:"client_protocol"`                // 客户端使用的请求协议。
+	Stream            bool          `json:"stream"`                         // 是否为流式请求。
+	FinalChannelName  string        `json:"final_channel_name"`             // 成功渠道或最后尝试渠道的名称。
+	InputTokens       int64         `json:"input_tokens"`                   // 请求完成后补充的输入 Token 数量。
+	OutputTokens      int64         `json:"output_tokens"`                  // 请求完成后补充的输出 Token 数量。
+	CacheReadTokens   int64         `json:"cache_read_tokens"`              // 请求完成后补充的缓存读取 Token 数量。
+	CacheWriteTokens  int64         `json:"cache_write_tokens"`             // 请求完成后补充的缓存写入 Token 数量。
+	TotalCost         float64       `json:"total_cost"`                     // 请求完成后补充的总费用。
+	Error             string        `json:"error,omitempty"`                // 请求当前或最终错误。
 }
 
 // LogRecord 保存一个请求的概览和正文快照。

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -75,6 +75,7 @@ func APIKeyAuth() gin.HandlerFunc {
 		}
 		c.Set("supported_models", apiKeyObj.SupportedModels)
 		c.Set("api_key_id", apiKeyObj.ID)
+		c.Set("api_key_name", apiKeyObj.Name)
 		c.Next()
 	}
 }

--- a/web/src/api/log.ts
+++ b/web/src/api/log.ts
@@ -21,6 +21,7 @@ export interface RelayLogOverview {
     completed_at: string;
     duration: number;
     request_model: string;
+    request_api_key_name?: string;
     actual_model: string;
     client_protocol: string;
     stream: boolean;

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { AlertCircle, ArrowDownToLine, ArrowRight, ArrowUpFromLine, Circle, CircleCheck, Clock, Cpu, Database, DollarSign, Loader2, Square } from 'lucide-react';
+import { AlertCircle, ArrowDownToLine, ArrowRight, ArrowUpFromLine, Circle, CircleCheck, Clock, Cpu, Database, DollarSign, KeyRound, Loader2, Square } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import { AnimatePresence, motion } from 'motion/react';
 import JsonView from '@uiw/react-json-view';
@@ -186,6 +186,7 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
         () => getModelIcon(actualModel),
         [actualModel]
     );
+    const requestAPIKeyName = log.request_api_key_name?.trim() ?? '';
 
     useEffect(() => {
         if (!isOpen) setLeftTab('group');
@@ -218,11 +219,17 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
                                 {actualModel}
                             </span>
                         </div>
-                        <div className="grid grid-cols-2 md:grid-cols-7 gap-x-4 gap-y-2 text-xs tabular-nums text-muted-foreground">
-                            <div className="flex items-center gap-1.5">
-                                <Clock className="size-3.5 shrink-0" style={{ color: brandColor }} />
-                                <span>{formatTime(log.started_at)}</span>
-                            </div>
+                                <div className="grid grid-cols-2 md:grid-cols-7 gap-x-4 gap-y-2 text-xs tabular-nums text-muted-foreground">
+                                    <div className="flex items-center gap-1.5">
+                                        <Clock className="size-3.5 shrink-0" style={{ color: brandColor }} />
+                                        <span>{formatTime(log.started_at)}</span>
+                                    </div>
+                                    {requestAPIKeyName && (
+                                        <div className="flex min-w-0 items-center gap-1.5">
+                                            <KeyRound className="size-3.5 shrink-0 text-orange-500" />
+                                            <span className="truncate" title={requestAPIKeyName}>{requestAPIKeyName}</span>
+                                        </div>
+                                    )}
                             <div className="flex items-center gap-1.5">
                                 <Cpu className="size-3.5 shrink-0 text-blue-500" />
                                 <span>{duration}</span>
@@ -471,10 +478,16 @@ function LogCardContent({ log }: { log: RelayLogOverview }) {
                     </MorphingDialogDescription>
 
                     <div className="flex flex-wrap items-center gap-3 md:gap-4 pt-4 mt-auto text-xs text-muted-foreground shrink-0">
-                        <div className="flex items-center gap-1.5">
-                            <Clock className="size-3.5" style={{ color: brandColor }} />
-                            <span className="tabular-nums">{formatTime(log.started_at)}</span>
-                        </div>
+                            <div className="flex items-center gap-1.5">
+                                <Clock className="size-3.5" style={{ color: brandColor }} />
+                                <span className="tabular-nums">{formatTime(log.started_at)}</span>
+                            </div>
+                            {requestAPIKeyName && (
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                    <KeyRound className="size-3.5 shrink-0 text-orange-500" />
+                                    <span className="truncate" title={requestAPIKeyName}>{requestAPIKeyName}</span>
+                                </div>
+                            )}
                         <div className="flex items-center gap-1.5">
                             <Cpu className="size-3.5 text-blue-500" />
                             <span>{activeState !== 'running' && activeState !== 'committed' ? formatDuration(log.duration) : duration}</span>


### PR DESCRIPTION
## 变更内容

在请求日志中显示调用方 API Key 名称，方便多 Key 环境下定位请求来源：

- API Key 认证成功后将名称写入请求上下文
- Relay 日志概览记录 API Key 名称
- 桌面端和移动端日志卡片展示 API Key 名称
- 未通过 API Key 认证的内部请求保持兼容，不显示额外字段
- 使用截断和 tooltip 处理较长的 API Key 名称，避免卡片布局溢出

## 实现说明

名称从认证阶段传递到日志对象，不在每条日志落盘或渲染时额外查询数据库。

## 验证

- `go test ./...`
- `pnpm build`
- `git diff --check`
