### PR TITLE
fix: 修复最后一行模型卡片编辑弹层被视口底部截断

### DIFF
--- a/web/src/components/modules/model/Item.tsx
+++ b/web/src/components/modules/model/Item.tsx
@@ -15,6 +15,9 @@ interface ModelItemProps {
     layout?: 'grid' | 'list';
 }
 
+// 缓存编辑弹层实测高度，首次打开即可正确判断是否需要向上弹出
+let cachedEditOverlayHeight = 0;
+
 export const ModelItem = memo(function ModelItem({ model, layout = 'grid' }: ModelItemProps) {
     const t = useTranslations('model');
     const isListLayout = layout === 'list';
@@ -43,17 +46,29 @@ export const ModelItem = memo(function ModelItem({ model, layout = 'grid' }: Mod
         const card = cardRef.current;
         if (!card) return;
         const rect = card.getBoundingClientRect();
+        const height = cachedEditOverlayHeight;
+        // 下方空间不足时改为向上弹出，避免最后一行弹层被视口底部截断
+        const flipUp = height > 0 && rect.top + height > window.innerHeight;
+        const top = flipUp
+            ? Math.min(Math.max(rect.bottom - height, 0), Math.max(window.innerHeight - height, 0))
+            : rect.top;
         setOverlayRect((prev) => {
-            if (prev && prev.top === rect.top && prev.left === rect.left && prev.width === rect.width) {
+            if (prev && prev.top === top && prev.left === rect.left && prev.width === rect.width) {
                 return prev;
             }
-            return { top: rect.top, left: rect.left, width: rect.width };
+            return { top, left: rect.left, width: rect.width };
         });
     }, []);
 
     const closeEdit = useCallback(() => {
         setIsEditOpen(false);
     }, []);
+
+    const handleOverlayHeightChange = useCallback((height: number) => {
+        if (height === cachedEditOverlayHeight) return;
+        cachedEditOverlayHeight = height;
+        updateOverlayRect();
+    }, [updateOverlayRect]);
 
     const handleEditClick = () => {
         setConfirmDelete(false);
@@ -248,18 +263,17 @@ export const ModelItem = memo(function ModelItem({ model, layout = 'grid' }: Mod
                                     width: `${overlayRect.width}px`,
                                 }}
                             >
-                                <div className="relative">
-                                    <ModelEditOverlay
-                                        layoutId={editLayoutId}
-                                        modelName={model.name}
-                                        brandColor={brandColor}
-                                        editValues={editValues}
-                                        isPending={updateModel.isPending}
-                                        onChange={setEditValues}
-                                        onCancel={handleCancelEdit}
-                                        onSave={handleSaveEdit}
-                                    />
-                                </div>
+                                <ModelEditOverlay
+                                    layoutId={editLayoutId}
+                                    onHeightChange={handleOverlayHeightChange}
+                                    modelName={model.name}
+                                    brandColor={brandColor}
+                                    editValues={editValues}
+                                    isPending={updateModel.isPending}
+                                    onChange={setEditValues}
+                                    onCancel={handleCancelEdit}
+                                    onSave={handleSaveEdit}
+                                />
                             </div>
                         )}
                     </AnimatePresence>,

--- a/web/src/components/modules/model/ItemOverlays.tsx
+++ b/web/src/components/modules/model/ItemOverlays.tsx
@@ -57,6 +57,7 @@ export function ModelDeleteOverlay({
 
 type ModelEditOverlayProps = {
     layoutId: string;
+    onHeightChange?: (height: number) => void;
     modelName: string;
     brandColor: string;
     editValues: EditValues;
@@ -68,6 +69,7 @@ type ModelEditOverlayProps = {
 
 export function ModelEditOverlay({
     layoutId,
+    onHeightChange,
     modelName,
     brandColor,
     editValues,
@@ -80,7 +82,12 @@ export function ModelEditOverlay({
     return (
         <motion.div
             layoutId={layoutId}
-            className="absolute inset-x-0 top-0 z-20 flex flex-col bg-card p-5 rounded-3xl border border-border"
+            ref={(node) => {
+                if (node && onHeightChange) {
+                    onHeightChange(node.offsetHeight);
+                }
+            }}
+            className="flex flex-col bg-card p-5 rounded-3xl border border-border"
             transition={{ type: 'spring', stiffness: 400, damping: 30 }}
         >
             <h3 className="text-sm font-semibold text-card-foreground line-clamp-1 mb-3">


### PR DESCRIPTION
## Summary

- 修复 #335：模型价格页最后一行卡片点编辑时，弹层固定在卡片顶部向下展开，被视口底部截断只能看到一半
- 测量弹层实际高度，当卡片下方剩余空间不足时改为向上弹出，并做视口钳制兜底（卡片自身被截断时也能完整显示）

## 修改点

- `Item.tsx`：`updateOverlayRect` 根据弹层缓存高度判断是否翻转向上弹出；弹层高度变化时通过回调重新计算定位
- `ItemOverlays.tsx`：`ModelEditOverlay` 改为文档流内布局（原 `absolute` 脱离文档流导致父容器高度为 0 无法测量），并通过 `onHeightChange` 上报实测高度

## Test plan

- [x] 滚动到列表最后一行，点击编辑按钮，弹层向上弹出且完整可见
- [x] 列表顶部/中部卡片编辑弹层仍向下弹出，展开动画正常
- [x] 删除确认弹层行为不受影响
- [x] 窗口 resize / 滚动时弹层跟随卡片重新定位
- [x] `tsc --noEmit` 与 `pnpm build` 通过

Closes #335