### PR TITLE
fix: 上游请求增加超时并透传不可重试错误

### DIFF
--- a/internal/client/http.go
+++ b/internal/client/http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/bestruirui/octopus/internal/model"
 	"github.com/bestruirui/octopus/internal/op"
@@ -103,12 +104,26 @@ func GetHTTPClientCustomProxy(proxyURL string) (*http.Client, error) {
 	return actual.(*http.Client), nil
 }
 
+// 上游请求超时配置。
+// 不使用 http.Client.Timeout：它覆盖从发请求到读完 body 的全程，
+// 会砍断正常的长时间流式响应。改为在 Transport 层分别限制建连
+// 和等待响应头两个阶段，body 读取（含 SSE 流）不受总时长限制。
+const (
+	upstreamDialTimeout         = 30 * time.Second // 建立 TCP/TLS 连接的超时。
+	upstreamResponseHeaderLimit = 10 * time.Minute // 从请求发出到收到响应头的超时。
+)
+
 func clonedDefaultTransport() (*http.Transport, error) {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
 		return nil, fmt.Errorf("default transport is not *http.Transport")
 	}
-	return transport.Clone(), nil
+	clone := transport.Clone()
+	clone.ResponseHeaderTimeout = upstreamResponseHeaderLimit
+	if clone.DialContext == nil {
+		clone.DialContext = (&net.Dialer{Timeout: upstreamDialTimeout, KeepAlive: 30 * time.Second}).DialContext
+	}
+	return clone, nil
 }
 
 func newHTTPClientNoProxy() (*http.Client, error) {
@@ -141,6 +156,12 @@ func newHTTPClientCustomProxy(proxyURLStr string) (*http.Client, error) {
 		}
 		cloned.Proxy = nil
 		cloned.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// 建连受 ctx 超时和取消控制，并补上与直连一致的建连超时。
+			ctx, cancel := context.WithTimeout(ctx, upstreamDialTimeout)
+			defer cancel()
+			if dialer, ok := socksDialer.(proxy.ContextDialer); ok {
+				return dialer.DialContext(ctx, network, addr)
+			}
 			return socksDialer.Dial(network, addr)
 		}
 	default:

--- a/internal/helper/price.go
+++ b/internal/helper/price.go
@@ -1,0 +1,51 @@
+package helper
+
+import (
+	"context"
+
+	"github.com/bestruirui/octopus/internal/model"
+	"github.com/bestruirui/octopus/internal/op"
+	"github.com/bestruirui/octopus/internal/price"
+)
+
+// LLMPriceAddToDB 为模型名批量补写价格记录，API 无校准价格时写入零价格占位。
+func LLMPriceAddToDB(modelNames []string, ctx context.Context) error {
+	newLLMInfos := make([]model.LLMInfo, 0, len(modelNames))
+	for _, modelName := range modelNames {
+		if modelName == "" {
+			continue
+		}
+		llmInfo := model.LLMInfo{Name: modelName}
+		if modelPrice := price.GetLLMPrice(modelName); modelPrice != nil {
+			llmInfo.LLMPrice = *modelPrice
+		}
+		newLLMInfos = append(newLLMInfos, llmInfo)
+	}
+	if len(newLLMInfos) > 0 {
+		return op.LLMBatchCreate(newLLMInfos, ctx)
+	}
+	return nil
+}
+
+// LLMPriceDeleteFromDBWithNoPrice 删除价格全部为零（从未校准）的模型价格记录。
+func LLMPriceDeleteFromDBWithNoPrice(modelNames []string, ctx context.Context) error {
+	if len(modelNames) == 0 {
+		return nil
+	}
+	for _, modelName := range modelNames {
+		if modelName == "" {
+			continue
+		}
+		modelPrice, err := op.LLMGet(modelName)
+		if err != nil {
+			return err
+		}
+		if modelPrice.Input != 0 || modelPrice.Output != 0 || modelPrice.CacheRead != 0 || modelPrice.CacheWrite != 0 {
+			continue
+		}
+		if err := op.LLMDelete(modelName, ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/op/llm.go
+++ b/internal/op/llm.go
@@ -8,10 +8,21 @@ import (
 	"github.com/bestruirui/octopus/internal/db"
 	"github.com/bestruirui/octopus/internal/model"
 	"github.com/bestruirui/octopus/internal/utils/cache"
+	"github.com/charmbracelet/log"
 	"gorm.io/gorm/clause"
 )
 
 var llmModelCache = cache.New[string, model.LLMPrice](16) // llmModelCache 保存数据库中的模型价格。
+
+// channelModels 读取渠道模型列表，数据库读取失败时返回空列表以继续清理流程。
+func channelModels(ctx context.Context) []model.LLMChannel {
+	channelLLMs, err := ChannelLLMList(ctx)
+	if err != nil {
+		log.Warnf("failed to list channel models: %v", err)
+		return nil
+	}
+	return channelLLMs
+}
 
 // LLMList 返回缓存中的全部模型价格。
 func LLMList() []model.LLMInfo {
@@ -44,7 +55,7 @@ func LLMDelete(modelName string, ctx context.Context) error {
 	if !ok {
 		return fmt.Errorf("model not found")
 	}
-	for _, channelModel := range ChannelLLMList() {
+	for _, channelModel := range channelModels(ctx) {
 		if strings.ToLower(channelModel.Name) == modelName {
 			return fmt.Errorf("model is referenced by channel")
 		}
@@ -58,7 +69,7 @@ func LLMDelete(modelName string, ctx context.Context) error {
 
 // LLMCleanupGhosts 删除已经不被任何渠道引用的模型价格。
 func LLMCleanupGhosts(ctx context.Context) error {
-	channelModels := ChannelLLMList()
+	channelModels := channelModels(ctx)
 	referencedModelNames := make(map[string]struct{}, len(channelModels))
 	// 价格表使用小写模型名作为键，渠道模型名转换为相同键后再判断引用关系。
 	for _, channelModel := range channelModels {

--- a/internal/relay/execution.go
+++ b/internal/relay/execution.go
@@ -22,6 +22,34 @@ import (
 var requestIDs atomic.Uint64 // requestIDs 分配进程内严格递增的请求 ID。
 var errNoActiveChannel = errors.New("no active channel") // errNoActiveChannel 表示分组尚未选择活动渠道。
 
+// nonRetryableStatusCodes 表示客户端侧请求错误的 HTTP 状态码。
+// 这些错误源于请求本身不合法，等待渠道恢复或人工切换渠道都无法改变结果，
+// 重试只会空耗配额并持续占用请求，应立即透传给客户端。
+// 401/403/404/429 等其余 4xx 不在此列：换渠道或等渠道恢复后仍可能成功。
+var nonRetryableStatusCodes = map[int]bool{
+	http.StatusBadRequest:            true, // 400 请求体格式或语义错误。
+	http.StatusMethodNotAllowed:      true, // 405 方法不支持。
+	http.StatusNotAcceptable:         true, // 406 Accept 头不被接受。
+	http.StatusRequestEntityTooLarge: true, // 413 请求体超限。
+	http.StatusRequestURITooLong:     true, // 414 URI 超长。
+	http.StatusUnsupportedMediaType:  true, // 415 Content-Type 不支持。
+	http.StatusUnprocessableEntity:   true, // 422 请求体语义无法处理。
+	http.StatusNotImplemented:        true, // 501 上游确实不支持该功能。
+}
+
+// upstreamErrorStatusCode 从错误链中提取上游 HTTP 状态码，非上游 HTTP 错误返回 false。
+func upstreamErrorStatusCode(err error) (int, bool) {
+	var llmErr *llm.ResponseError
+	var httpErr *httpclient.Error
+	if errors.As(err, &llmErr) && llmErr.StatusCode != 0 {
+		return llmErr.StatusCode, true
+	}
+	if errors.As(err, &httpErr) && httpErr.StatusCode != 0 {
+		return httpErr.StatusCode, true
+	}
+	return 0, false
+}
+
 // execution 保存单个客户端请求的全部可变执行状态。
 type execution struct {
 	ctx            *gin.Context       // 当前客户端请求上下文。
@@ -220,6 +248,12 @@ func (e *execution) handleAttemptFailure(ctx context.Context, item model.GroupIt
 	}
 	e.log.Error = attempt.Error
 	e.emit(LogEventAttemptFinished, attempt)
+	// 客户端侧请求错误立即透传给客户端并结束请求，不再回到重试循环。
+	if statusCode, ok := upstreamErrorStatusCode(result.err); ok && nonRetryableStatusCodes[statusCode] {
+		e.finish(RequestStateFailed, result.err, result.responseBody, result.usage)
+		e.protocol.writeError(e.ctx, statusCode, result.err)
+		return true, nil
+	}
 	return false, result.err
 }
 

--- a/internal/relay/execution.go
+++ b/internal/relay/execution.go
@@ -22,12 +22,15 @@ import (
 var requestIDs atomic.Uint64 // requestIDs 分配进程内严格递增的请求 ID。
 var errNoActiveChannel = errors.New("no active channel") // errNoActiveChannel 表示分组尚未选择活动渠道。
 
-// nonRetryableStatusCodes 表示客户端侧请求错误的 HTTP 状态码。
-// 这些错误源于请求本身不合法，等待渠道恢复或人工切换渠道都无法改变结果，
-// 重试只会空耗配额并持续占用请求，应立即透传给客户端。
-// 401/403/404/429 等其余 4xx 不在此列：换渠道或等渠道恢复后仍可能成功。
+// nonRetryableStatusCodes 表示重试无法改变结果的上游 HTTP 状态码。
+// 一类是客户端侧请求错误（400/405/406/413/414/415/422/501），请求本身不合法，
+// 等待或换渠道都无济于事；另一类是渠道凭证失效（401/403），只能通过修正渠道
+// key 解决，重试同样无效。命中后立即透传给客户端，由客户端在修复后重发。
+// 404/429/5xx 保持可重试：换渠道或渠道恢复后仍可能成功。
 var nonRetryableStatusCodes = map[int]bool{
 	http.StatusBadRequest:            true, // 400 请求体格式或语义错误。
+	http.StatusUnauthorized:          true, // 401 渠道 key 无效。
+	http.StatusForbidden:             true, // 403 渠道 key 无权限或被封禁。
 	http.StatusMethodNotAllowed:      true, // 405 方法不支持。
 	http.StatusNotAcceptable:         true, // 406 Accept 头不被接受。
 	http.StatusRequestEntityTooLarge: true, // 413 请求体超限。

--- a/internal/relay/execution_test.go
+++ b/internal/relay/execution_test.go
@@ -59,14 +59,14 @@ func TestUpstreamErrorStatusCode(t *testing.T) {
 
 // TestNonRetryableStatusCodes 验证不可重试状态码集合的边界。
 func TestNonRetryableStatusCodes(t *testing.T) {
-	nonRetryable := []int{400, 405, 406, 413, 414, 415, 422, 501}
+	nonRetryable := []int{400, 401, 403, 405, 406, 413, 414, 415, 422, 501}
 	for _, code := range nonRetryable {
 		if !nonRetryableStatusCodes[code] {
 			t.Errorf("status %d should be non-retryable", code)
 		}
 	}
-	// 可重试：网络类无状态码、429 限流、401/403 换渠道可能恢复、5xx 服务端故障。
-	retryable := []int{401, 403, 404, 408, 429, 500, 502, 503, 504}
+	// 可重试：网络类无状态码、429 限流、404 渠道可能未部署该模型、5xx 服务端故障。
+	retryable := []int{404, 408, 429, 500, 502, 503, 504}
 	for _, code := range retryable {
 		if nonRetryableStatusCodes[code] {
 			t.Errorf("status %d should stay retryable", code)

--- a/internal/relay/execution_test.go
+++ b/internal/relay/execution_test.go
@@ -1,0 +1,88 @@
+package relay
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/looplj/axonhub/llm"
+	"github.com/looplj/axonhub/llm/httpclient"
+)
+
+// TestUpstreamErrorStatusCode 验证从不同错误链形态中提取上游 HTTP 状态码。
+func TestUpstreamErrorStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		statusCode int
+		ok         bool
+	}{
+		{
+			name:       "裸 httpclient.Error",
+			err:        &httpclient.Error{StatusCode: http.StatusBadRequest},
+			statusCode: http.StatusBadRequest,
+			ok:         true,
+		},
+		{
+			name:       "裸 llm.ResponseError",
+			err:        &llm.ResponseError{StatusCode: http.StatusUnprocessableEntity},
+			statusCode: http.StatusUnprocessableEntity,
+			ok:         true,
+		},
+		{
+			name:       "UpstreamError 包装的 llm.ResponseError",
+			err:        wrapUpstreamErrorForTest(&llm.ResponseError{StatusCode: http.StatusNotFound}),
+			statusCode: http.StatusNotFound,
+			ok:         true,
+		},
+		{
+			name: "普通错误",
+			err:  errors.New("connection refused"),
+		},
+		{
+			name: "无状态码的 httpclient.Error",
+			err:  &httpclient.Error{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, ok := upstreamErrorStatusCode(tt.err)
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if code != tt.statusCode {
+				t.Fatalf("statusCode = %d, want %d", code, tt.statusCode)
+			}
+		})
+	}
+}
+
+// TestNonRetryableStatusCodes 验证不可重试状态码集合的边界。
+func TestNonRetryableStatusCodes(t *testing.T) {
+	nonRetryable := []int{400, 405, 406, 413, 414, 415, 422, 501}
+	for _, code := range nonRetryable {
+		if !nonRetryableStatusCodes[code] {
+			t.Errorf("status %d should be non-retryable", code)
+		}
+	}
+	// 可重试：网络类无状态码、429 限流、401/403 换渠道可能恢复、5xx 服务端故障。
+	retryable := []int{401, 403, 404, 408, 429, 500, 502, 503, 504}
+	for _, code := range retryable {
+		if nonRetryableStatusCodes[code] {
+			t.Errorf("status %d should stay retryable", code)
+		}
+	}
+}
+
+// wrapUpstreamErrorForTest 复刻 pipeline.UpstreamError 的包装形态：
+// 该类型实现 Unwrap，errors.As 应能穿透提取内部错误的状态码。
+type testUpstreamError struct {
+	err error
+}
+
+func (e *testUpstreamError) Error() string { return e.err.Error() }
+func (e *testUpstreamError) Unwrap() error { return e.err }
+
+func wrapUpstreamErrorForTest(err error) error {
+	return &testUpstreamError{err: err}
+}

--- a/internal/server/handlers/model.go
+++ b/internal/server/handlers/model.go
@@ -59,7 +59,11 @@ func init() {
 }
 
 func getModelList(c *gin.Context) {
-	models := op.GroupListModel()
+	models, err := op.GroupListModel(c.Request.Context())
+	if err != nil {
+		resp.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if supportedModelsValue := c.GetString("supported_models"); supportedModelsValue != "" {
 		supportedModels := lo.Map(strings.Split(supportedModelsValue, ","), func(s string, _ int) string {
 			return strings.TrimSpace(s)
@@ -111,7 +115,12 @@ func listLLM(c *gin.Context) {
 }
 
 func listLLMByChannel(c *gin.Context) {
-	resp.Success(c, op.ChannelLLMList())
+	channelLLMs, err := op.ChannelLLMList(c.Request.Context())
+	if err != nil {
+		resp.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resp.Success(c, channelLLMs)
 }
 
 // createLLM 校验并创建自定义模型价格。

--- a/internal/task/sync.go
+++ b/internal/task/sync.go
@@ -77,11 +77,7 @@ func SyncModelsTask() {
 			}
 		}
 	}
-	llmPrice, err := op.LLMList(ctx)
-	if err != nil {
-		log.Errorf("failed to list models price: %v", err)
-		return
-	}
+	llmPrice := op.LLMList()
 	llmPriceNames := make([]string, 0, len(llmPrice))
 	for _, price := range llmPrice {
 		llmPriceNames = append(llmPriceNames, price.Name)


### PR DESCRIPTION
## Summary

- 修复 #338：上游渠道报错或挂起时，octopus 无限重试且 HTTP 客户端无超时，导致客户端先超时报错、后台仍持续空转
- 给上游 HTTP 客户端补上超时；请求格式错误和渠道凭证错误立即透传给客户端，不再空转重试

## 修改点

- `internal/client/http.go`：Transport 增加建连超时 30s 和响应头超时 10min（`ResponseHeaderTimeout` 只限制响应头等待，不影响流式 body 读取）；SOCKS5 代理建连改为 `DialContext` 并补超时，受 ctx 取消控制
- `internal/relay/execution.go`：新增 `nonRetryableStatusCodes` 与 `upstreamErrorStatusCode`，对 400/401/403/405/406/413/414/415/422/501 立即透传给客户端并结束请求；404/429/5xx/网络错误/超时仍保留重试
- `internal/relay/execution_test.go`：覆盖状态码提取（含 pipeline UpstreamError 包装穿透）和不可重试集合边界
- `internal/op/llm.go` / `internal/helper/price.go` / `internal/task/sync.go` / `internal/server/handlers/model.go`：修复 27a29a3 价格重构后遗留的编译错误（`ChannelLLMList`/`GroupListModel`/`LLMList` 签名变更及被删除的 `helper/price.go`），master 当前无法编译，需一并修复

## Test plan

- [x] `go build ./...` 通过
- [x] `go vet ./...` 通过
- [x] `go test ./...` 通过
- [x] 本地起服务（端口 7892，数据从 7891 复制）：上游返回 401「API Key 无效」时，curl 0.7s 内收到原样错误并结束请求（修复前无限重试挂住 60s+）

Closes #338