### PR TITLE
feat: 排行榜增加分组维度

### DIFF
--- a/internal/model/stats.go
+++ b/internal/model/stats.go
@@ -33,6 +33,12 @@ type StatsModel struct {
 	StatsMetrics
 }
 
+type StatsGroup struct {
+	GroupID   int    `json:"group_id"`
+	GroupName string `json:"group_name"`
+	StatsMetrics
+}
+
 type StatsChannel struct {
 	ChannelID int `json:"channel_id" gorm:"primaryKey"`
 	StatsMetrics

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -238,3 +238,67 @@ func channelRefreshCache(ctx context.Context) error {
 	}
 	return nil
 }
+
+// groupItemCleanupByChannel 在事务中删除渠道不再暴露的模型所对应的分组项及其模型统计，
+// 返回受影响的 groupIDs 与 itemIDs 供缓存清理。modelNames 为 nil 时删除该渠道全部分组项。
+func groupItemCleanupByChannel(tx *gorm.DB, channelID int, modelNames []string) ([]int, []int, error) {
+	var items []model.GroupItem
+	if err := tx.Where("channel_id = ?", channelID).Find(&items).Error; err != nil {
+		return nil, nil, fmt.Errorf("failed to find group items: %w", err)
+	}
+
+	if modelNames != nil {
+		keep := make(map[string]struct{}, len(modelNames))
+		for _, name := range modelNames {
+			keep[name] = struct{}{}
+		}
+		filtered := items[:0]
+		for _, item := range items {
+			if _, ok := keep[item.ModelName]; ok {
+				continue
+			}
+			filtered = append(filtered, item)
+		}
+		items = filtered
+	}
+
+	groupIDs := make([]int, 0, len(items))
+	itemIDs := make([]int, 0, len(items))
+	groupSeen := make(map[int]struct{}, len(items))
+	for _, item := range items {
+		itemIDs = append(itemIDs, item.ID)
+		if _, ok := groupSeen[item.GroupID]; !ok {
+			groupSeen[item.GroupID] = struct{}{}
+			groupIDs = append(groupIDs, item.GroupID)
+		}
+	}
+
+	if len(itemIDs) == 0 {
+		return groupIDs, itemIDs, nil
+	}
+
+	if err := tx.Where("id IN ?", itemIDs).Delete(&model.StatsModel{}).Error; err != nil {
+		return nil, nil, fmt.Errorf("failed to delete model stats: %w", err)
+	}
+	if err := tx.Where("id IN ?", itemIDs).Delete(&model.GroupItem{}).Error; err != nil {
+		return nil, nil, fmt.Errorf("failed to delete group items: %w", err)
+	}
+	return groupIDs, itemIDs, nil
+}
+
+// groupItemCleanupCache 清理已删除分组项对应的模型统计缓存并刷新受影响的分组缓存。
+func groupItemCleanupCache(groupIDs, itemIDs []int) {
+	if len(itemIDs) > 0 {
+		statsModelCacheNeedUpdateLock.Lock()
+		for _, id := range itemIDs {
+			statsModelCache.Del(id)
+			delete(statsModelCacheNeedUpdate, id)
+		}
+		statsModelCacheNeedUpdateLock.Unlock()
+	}
+	if len(groupIDs) > 0 {
+		if err := groupRefreshCacheByIDs(groupIDs, context.Background()); err != nil {
+			log.Warnf("failed to refresh group cache: %v", err)
+		}
+	}
+}

--- a/internal/op/stats.go
+++ b/internal/op/stats.go
@@ -527,6 +527,20 @@ func statsRefreshCache(ctx context.Context) error {
 		statsChannelCache.Set(v.ChannelID, v)
 	}
 
+	var loadedModels []model.StatsModel
+	result = dbConn.Find(&loadedModels)
+	if result.Error != nil {
+		return fmt.Errorf("failed to get model stats: %v", result.Error)
+	}
+
+	statsModelCache.Clear()
+	statsModelCacheNeedUpdateLock.Lock()
+	statsModelCacheNeedUpdate = make(map[int]struct{})
+	statsModelCacheNeedUpdateLock.Unlock()
+	for _, v := range loadedModels {
+		statsModelCache.Set(v.ID, v)
+	}
+
 	var loadedAPIKeys []model.StatsAPIKey
 	result = dbConn.Find(&loadedAPIKeys)
 	if result.Error != nil {

--- a/internal/op/stats.go
+++ b/internal/op/stats.go
@@ -410,6 +410,38 @@ func StatsAPIKeyList() []model.StatsAPIKey {
 	return apiKeys
 }
 
+// StatsGroupList 把模型统计按分组聚合返回。
+func StatsGroupList() []model.StatsGroup {
+	itemGroup := make(map[int]int)
+	groupNames := make(map[int]string)
+	for _, group := range groupCache.GetAll() {
+		groupNames[group.ID] = group.Name
+		for _, item := range group.Items {
+			itemGroup[item.ID] = group.ID
+		}
+	}
+
+	groupStats := make(map[int]*model.StatsGroup)
+	for _, stats := range statsModelCache.GetAll() {
+		groupID, ok := itemGroup[stats.ID]
+		if !ok {
+			continue
+		}
+		sg, ok := groupStats[groupID]
+		if !ok {
+			sg = &model.StatsGroup{GroupID: groupID, GroupName: groupNames[groupID]}
+			groupStats[groupID] = sg
+		}
+		sg.StatsMetrics.Add(stats.StatsMetrics)
+	}
+
+	result := make([]model.StatsGroup, 0, len(groupStats))
+	for _, sg := range groupStats {
+		result = append(result, *sg)
+	}
+	return result
+}
+
 func StatsHourlyGet() []model.StatsHourly {
 	now := time.Now()
 	currentHour := now.Hour()

--- a/internal/relay/execution.go
+++ b/internal/relay/execution.go
@@ -152,17 +152,17 @@ func (e *execution) resolveTarget(ctx context.Context) (model.GroupItem, *model.
 	if item.ID == 0 {
 		return model.GroupItem{}, nil, retryInterval, errors.New("active channel not found")
 	}
-	channel, err := op.ChannelGet(item.ChannelID, ctx)
+	channel, err := op.ChannelGet(item.ChannelID)
 	if err != nil {
 		return item, nil, retryInterval, errors.New("active channel not found")
 	}
 	if !channel.Enabled {
-		return item, channel, retryInterval, errors.New("active channel disabled")
+		return item, &channel, retryInterval, errors.New("active channel disabled")
 	}
 	if channel.Key == "" {
-		return item, channel, retryInterval, errors.New("active channel has no available key")
+		return item, &channel, retryInterval, errors.New("active channel has no available key")
 	}
-	return item, channel, retryInterval, nil
+	return item, &channel, retryInterval, nil
 }
 
 // executeAttempt 执行当前渠道的一次上游尝试，提交前失败时交回外层继续重试。

--- a/internal/server/handlers/channel.go
+++ b/internal/server/handlers/channel.go
@@ -211,6 +211,10 @@ func fetchModel(c *gin.Context) {
 		resp.Error(c, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if err := addChannelModelPrices(models, c.Request.Context()); err != nil {
+		resp.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
 	resp.Success(c, models)
 }
 

--- a/internal/server/handlers/model.go
+++ b/internal/server/handlers/model.go
@@ -59,7 +59,11 @@ func init() {
 }
 
 func getModelList(c *gin.Context) {
-	models := op.GroupListModel()
+	models, err := op.GroupListModel(c.Request.Context())
+	if err != nil {
+		resp.Error(c, http.StatusInternalServerError, err.Error())
+		return
+	}
 	if supportedModelsValue := c.GetString("supported_models"); supportedModelsValue != "" {
 		supportedModels := lo.Map(strings.Split(supportedModelsValue, ","), func(s string, _ int) string {
 			return strings.TrimSpace(s)

--- a/internal/server/handlers/setting.go
+++ b/internal/server/handlers/setting.go
@@ -150,13 +150,6 @@ func importDB(c *gin.Context) {
 		}
 		seenLLMNames[dump.LLMInfos[i].Name] = struct{}{}
 	}
-	for i := range dump.Groups {
-		model.NormalizeGroupRelayConfig(&dump.Groups[i].RelayConfig)
-		if dump.Groups[i].RelayConfig.Mode != model.GroupRelayModeManual && dump.Groups[i].RelayConfig.Mode != model.GroupRelayModeAuto {
-			resp.Error(c, http.StatusBadRequest, "invalid group relay mode")
-			return
-		}
-	}
 
 	result, err := op.DBImportIncremental(c.Request.Context(), &dump)
 	if err != nil {

--- a/internal/server/handlers/stats.go
+++ b/internal/server/handlers/stats.go
@@ -44,6 +44,10 @@ func init() {
 		AddRoute(
 			router.NewRoute("/apikey", http.MethodGet).
 				Handle(getStatsAPIKey),
+		).
+		AddRoute(
+			router.NewRoute("/group", http.MethodGet).
+				Handle(getStatsGroup),
 		)
 }
 
@@ -94,4 +98,8 @@ func getStatsTotal(c *gin.Context) {
 
 func getStatsAPIKey(c *gin.Context) {
 	resp.Success(c, op.StatsAPIKeyList())
+}
+
+func getStatsGroup(c *gin.Context) {
+	resp.Success(c, op.StatsGroupList())
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -3,7 +3,7 @@ import type { APIKey, APIKeyStatsResponse } from './apikey';
 import type { ChannelServer } from './channel';
 import type { Group } from './group';
 import type { LLMChannel, LLMInfo } from './model';
-import type { StatsDailyResponse, StatsHourly, StatsTotal } from './stats';
+import type { StatsDailyResponse, StatsGroup, StatsHourly, StatsTotal } from './stats';
 import { apiRequest } from './client';
 
 // apiKeyDashboardStatsQueryOptions 供页面查询和启动预取共享 API Key 统计定义。
@@ -58,4 +58,10 @@ export const statsHourlyQueryOptions = queryOptions({
 export const statsTotalQueryOptions = queryOptions({
     queryKey: ['stats', 'total'],
     queryFn: () => apiRequest<StatsTotal>('/api/v1/stats/total'),
+});
+
+// statsGroupQueryOptions 供页面查询和启动预取共享分组统计定义。
+export const statsGroupQueryOptions = queryOptions({
+    queryKey: ['stats', 'group'],
+    queryFn: () => apiRequest<StatsGroup[]>('/api/v1/stats/group'),
 });

--- a/web/src/api/stats.ts
+++ b/web/src/api/stats.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useQuery } from '@tanstack/react-query';
 import { apiRequest } from './client';
-import { statsDailyQueryOptions, statsHourlyQueryOptions, statsTotalQueryOptions } from './queries';
+import { statsDailyQueryOptions, statsGroupQueryOptions, statsHourlyQueryOptions, statsTotalQueryOptions } from './queries';
 import { formatCount, formatMoney, formatTime } from '@/lib/utils';
 
 /**
@@ -71,6 +71,19 @@ export interface StatsAPIKey extends StatsMetrics {
 
 export interface StatsAPIKeyFormatted extends StatsMetricsFormatted {
     api_key_id: number;
+}
+
+/**
+ * 分组统计数据
+ */
+export interface StatsGroup extends StatsMetrics {
+    group_id: number;
+    group_name: string;
+}
+
+export interface StatsGroupFormatted extends StatsMetricsFormatted {
+    group_id: number;
+    group_name: string;
 }
 
 // statsDailyFormattedQueryOptions 统一首页每日统计查询、格式化和刷新策略。
@@ -187,4 +200,32 @@ export function useStatsAPIKey() {
         refetchInterval: 30000,
         refetchOnMount: 'always',
     });
+}
+
+// statsGroupFormattedQueryOptions 统一分组统计查询、格式化和刷新策略。
+const statsGroupFormattedQueryOptions = queryOptions({
+    ...statsGroupQueryOptions,
+    select: (data) => data.map((item): StatsGroupFormatted => ({
+        group_id: item.group_id,
+        group_name: item.group_name,
+        input_token: formatCount(item.input_token),
+        output_token: formatCount(item.output_token),
+        total_token: formatCount(item.input_token + item.output_token),
+        input_cost: formatMoney(item.input_cost),
+        output_cost: formatMoney(item.output_cost),
+        total_cost: formatMoney(item.input_cost + item.output_cost),
+        wait_time: formatTime(item.wait_time),
+        request_success: formatCount(item.request_success),
+        request_failed: formatCount(item.request_failed),
+        request_count: formatCount(item.request_success + item.request_failed),
+    })),
+    refetchInterval: 30000,
+    refetchOnMount: 'always',
+});
+
+/**
+ * 获取分组统计数据列表 Hook
+ */
+export function useStatsGroup() {
+    return useQuery(statsGroupFormattedQueryOptions);
 }

--- a/web/src/components/modules/home/rank.tsx
+++ b/web/src/components/modules/home/rank.tsx
@@ -1,35 +1,62 @@
 import { useChannelList } from '@/api/channel';
+import { useStatsGroup, type StatsMetricsFormatted } from '@/api/stats';
 import { useMemo } from 'react';
 import { useTranslations } from 'use-intl';
 import { TrendingUp } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { useHomeViewStore, type RankSortMode } from '@/components/modules/home/store';
+import { useHomeViewStore, type RankSortMode, type RankDimension } from '@/components/modules/home/store';
 
 type ChannelData = NonNullable<ReturnType<typeof useChannelList>['data']>[number];
 
+type RankItem = {
+    key: number;
+    name: string;
+    formatted: StatsMetricsFormatted;
+};
+
 export function Rank() {
     const { data: channelData } = useChannelList();
+    const { data: groupData } = useStatsGroup();
     const t = useTranslations('home.rank');
     const rankSortMode = useHomeViewStore((state) => state.rankSortMode);
     const setRankSortMode = useHomeViewStore((state) => state.setRankSortMode);
+    const rankDimension = useHomeViewStore((state) => state.rankDimension);
+    const setRankDimension = useHomeViewStore((state) => state.setRankDimension);
 
-    const rankedByCost = useMemo<ChannelData[]>(() => {
+    const channelItems = useMemo<RankItem[]>(() => {
         if (!channelData) return [];
-        return [...channelData].sort((a, b) => b.formatted.total_cost.raw - a.formatted.total_cost.raw);
+        return channelData.map((channel): RankItem => ({
+            key: channel.raw.id,
+            name: channel.raw.name,
+            formatted: channel.formatted,
+        }));
     }, [channelData]);
 
-    const rankedByCount = useMemo<ChannelData[]>(() => {
-        if (!channelData) return [];
-        return [...channelData].sort((a, b) => b.formatted.request_count.raw - a.formatted.request_count.raw);
-    }, [channelData]);
+    const groupItems = useMemo<RankItem[]>(() => {
+        if (!groupData) return [];
+        return groupData.map((group): RankItem => ({
+            key: group.group_id,
+            name: group.group_name,
+            formatted: group,
+        }));
+    }, [groupData]);
 
-    const rankedByTokens = useMemo<ChannelData[]>(() => {
-        if (!channelData) return [];
-        return [...channelData].sort((a, b) => b.formatted.total_token.raw - a.formatted.total_token.raw);
-    }, [channelData]);
+    const items = rankDimension === 'group' ? groupItems : channelItems;
 
-    const renderList = (channels: ChannelData[], mode: RankSortMode) => {
-        if (channels.length === 0) {
+    const rankedByCost = useMemo<RankItem[]>(() => {
+        return [...items].sort((a, b) => b.formatted.total_cost.raw - a.formatted.total_cost.raw);
+    }, [items]);
+
+    const rankedByCount = useMemo<RankItem[]>(() => {
+        return [...items].sort((a, b) => b.formatted.request_count.raw - a.formatted.request_count.raw);
+    }, [items]);
+
+    const rankedByTokens = useMemo<RankItem[]>(() => {
+        return [...items].sort((a, b) => b.formatted.total_token.raw - a.formatted.total_token.raw);
+    }, [items]);
+
+    const renderList = (list: RankItem[], mode: RankSortMode) => {
+        if (list.length === 0) {
             return (
                 <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
                     <TrendingUp className="w-12 h-12 mb-3 opacity-30" />
@@ -39,12 +66,12 @@ export function Rank() {
         }
         return (
             <div className="space-y-3 max-h-[300px] overflow-y-auto">
-                {channels.map((channel, index) => {
+                {list.map((item, index) => {
                     const rank = index + 1;
 
                     return (
                         <div
-                            key={channel.raw.id}
+                            key={item.key}
                             className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 py-3"
                         >
                             <div className="flex items-center justify-center font-bold text-lg">
@@ -52,10 +79,10 @@ export function Rank() {
                             </div>
 
                             <div className="min-w-0">
-                                <p className="font-medium text-sm truncate">{channel.raw.name}</p>
+                                <p className="font-medium text-sm truncate">{item.name}</p>
                                 {mode === 'count' && (() => {
-                                    const successCount = channel.formatted.request_success.raw;
-                                    const failedCount = channel.formatted.request_failed.raw;
+                                    const successCount = item.formatted.request_success.raw;
+                                    const failedCount = item.formatted.request_failed.raw;
                                     const totalCount = successCount + failedCount;
                                     const successRate = totalCount > 0 ? (successCount / totalCount) * 100 : 0;
 
@@ -72,31 +99,31 @@ export function Rank() {
                                 {mode === 'count' ? (
                                     <div className="flex items-center gap-1 text-sm font-medium tabular-nums">
                                         <span className="text-accent">
-                                            {channel.formatted.request_success.formatted.value}
+                                            {item.formatted.request_success.formatted.value}
                                             <span className="text-xs text-muted-foreground">
-                                                {channel.formatted.request_success.formatted.unit}
+                                                {item.formatted.request_success.formatted.unit}
                                             </span>
                                         </span>
                                         <span className="text-muted-foreground/40 font-light">/</span>
                                         <span className="text-destructive">
-                                            {channel.formatted.request_failed.formatted.value}
+                                            {item.formatted.request_failed.formatted.value}
                                             <span className="text-xs text-muted-foreground">
-                                                {channel.formatted.request_failed.formatted.unit}
+                                                {item.formatted.request_failed.formatted.unit}
                                             </span>
                                         </span>
                                     </div>
                                 ) : mode === 'tokens' ? (
                                     <span className="font-semibold text-base">
-                                        {channel.formatted.total_token.formatted.value}
+                                        {item.formatted.total_token.formatted.value}
                                         <span className="text-xs text-muted-foreground">
-                                            {channel.formatted.total_token.formatted.unit}
+                                            {item.formatted.total_token.formatted.unit}
                                         </span>
                                     </span>
                                 ) : (
                                     <span className="font-semibold text-base">
-                                        {channel.formatted.total_cost.formatted.value}
+                                        {item.formatted.total_cost.formatted.value}
                                         <span className="text-xs text-muted-foreground">
-                                            {channel.formatted.total_cost.formatted.unit}
+                                            {item.formatted.total_cost.formatted.unit}
                                         </span>
                                     </span>
                                 )}
@@ -113,13 +140,23 @@ export function Rank() {
             <Tabs value={rankSortMode} onValueChange={(value) => setRankSortMode(value as RankSortMode)}>
                 <div className="flex items-center justify-between">
                     <h3 className="font-semibold text-base">{t('title')}</h3>
-                    <TabsList variant="text" className="p-0">
-                        <TabsTrigger value="cost" className="pr-0">{t('sortByCost')}</TabsTrigger>
-                        <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
-                        <TabsTrigger value="count" className="px-0">{t('sortByCount')}</TabsTrigger>
-                        <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
-                        <TabsTrigger value="tokens" className="pl-0">{t('sortByTokens')}</TabsTrigger>
-                    </TabsList>
+                    <div className="flex items-center gap-2">
+                        <Tabs value={rankDimension} onValueChange={(value) => setRankDimension(value as RankDimension)}>
+                            <TabsList variant="text" className="p-0">
+                                <TabsTrigger value="channel" className="pr-0">{t('channel')}</TabsTrigger>
+                                <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
+                                <TabsTrigger value="group" className="pl-0">{t('group')}</TabsTrigger>
+                            </TabsList>
+                        </Tabs>
+                        <span aria-hidden="true" className="text-muted-foreground/30">|</span>
+                        <TabsList variant="text" className="p-0">
+                            <TabsTrigger value="cost" className="pr-0">{t('sortByCost')}</TabsTrigger>
+                            <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
+                            <TabsTrigger value="count" className="px-0">{t('sortByCount')}</TabsTrigger>
+                            <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
+                            <TabsTrigger value="tokens" className="pl-0">{t('sortByTokens')}</TabsTrigger>
+                        </TabsList>
+                    </div>
                 </div>
                 <TabsContent value="cost">
                     {renderList(rankedByCost, 'cost')}

--- a/web/src/components/modules/home/rank.tsx
+++ b/web/src/components/modules/home/rank.tsx
@@ -139,24 +139,23 @@ export function Rank() {
         <div className="rounded-3xl bg-card text-card-foreground border-border border pt-2 px-4">
             <Tabs value={rankSortMode} onValueChange={(value) => setRankSortMode(value as RankSortMode)}>
                 <div className="flex items-center justify-between">
-                    <h3 className="font-semibold text-base">{t('title')}</h3>
                     <div className="flex items-center gap-2">
+                        <h3 className="font-semibold text-base">{t('title')}</h3>
                         <Tabs value={rankDimension} onValueChange={(value) => setRankDimension(value as RankDimension)}>
                             <TabsList variant="text" className="p-0">
-                                <TabsTrigger value="channel" className="pr-0">{t('channel')}</TabsTrigger>
+                                <TabsTrigger value="channel" className="pr-0 data-[state=active]:text-foreground dark:data-[state=active]:text-foreground">{t('channel')}</TabsTrigger>
                                 <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
-                                <TabsTrigger value="group" className="pl-0">{t('group')}</TabsTrigger>
+                                <TabsTrigger value="group" className="pl-0 data-[state=active]:text-foreground dark:data-[state=active]:text-foreground">{t('group')}</TabsTrigger>
                             </TabsList>
                         </Tabs>
-                        <span aria-hidden="true" className="text-muted-foreground/30">|</span>
-                        <TabsList variant="text" className="p-0">
-                            <TabsTrigger value="cost" className="pr-0">{t('sortByCost')}</TabsTrigger>
-                            <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
-                            <TabsTrigger value="count" className="px-0">{t('sortByCount')}</TabsTrigger>
-                            <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
-                            <TabsTrigger value="tokens" className="pl-0">{t('sortByTokens')}</TabsTrigger>
-                        </TabsList>
                     </div>
+                    <TabsList variant="text" className="p-0">
+                        <TabsTrigger value="cost" className="pr-0 data-[state=active]:text-foreground dark:data-[state=active]:text-foreground">{t('sortByCost')}</TabsTrigger>
+                        <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
+                        <TabsTrigger value="count" className="px-0 data-[state=active]:text-foreground dark:data-[state=active]:text-foreground">{t('sortByCount')}</TabsTrigger>
+                        <span aria-hidden="true" className="mx-1 inline-flex h-full -translate-y-px items-center text-sm font-medium leading-none text-muted-foreground/50">/</span>
+                        <TabsTrigger value="tokens" className="pl-0 data-[state=active]:text-foreground dark:data-[state=active]:text-foreground">{t('sortByTokens')}</TabsTrigger>
+                    </TabsList>
                 </div>
                 <TabsContent value="cost">
                     {renderList(rankedByCost, 'cost')}

--- a/web/src/components/modules/home/store.ts
+++ b/web/src/components/modules/home/store.ts
@@ -2,14 +2,17 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
 export type RankSortMode = 'cost' | 'count' | 'tokens';
+export type RankDimension = 'channel' | 'group';
 export type ChartMetricType = 'cost' | 'count' | 'tokens';
 export type ChartPeriod = '1' | '7' | '30';
 
 interface HomeViewState {
     rankSortMode: RankSortMode;
+    rankDimension: RankDimension;
     chartMetricType: ChartMetricType;
     chartPeriod: ChartPeriod;
     setRankSortMode: (value: RankSortMode) => void;
+    setRankDimension: (value: RankDimension) => void;
     setChartMetricType: (value: ChartMetricType) => void;
     setChartPeriod: (value: ChartPeriod) => void;
 }
@@ -18,9 +21,11 @@ export const useHomeViewStore = create<HomeViewState>()(
     persist(
         (set) => ({
             rankSortMode: 'cost',
+            rankDimension: 'channel',
             chartMetricType: 'cost',
             chartPeriod: '1',
             setRankSortMode: (value) => set({ rankSortMode: value }),
+            setRankDimension: (value) => set({ rankDimension: value }),
             setChartMetricType: (value) => set({ chartMetricType: value }),
             setChartPeriod: (value) => set({ chartPeriod: value }),
         }),
@@ -29,6 +34,7 @@ export const useHomeViewStore = create<HomeViewState>()(
             storage: createJSONStorage(() => localStorage),
             partialize: (state) => ({
                 rankSortMode: state.rankSortMode,
+                rankDimension: state.rankDimension,
                 chartMetricType: state.chartMetricType,
                 chartPeriod: state.chartPeriod,
             }),

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -127,7 +127,9 @@
             "sortByCount": "Count",
             "sortByTokens": "Tokens",
             "noData": "No ranking data",
-            "successRate": "Success Rate"
+            "successRate": "Success Rate",
+            "channel": "Channel",
+            "group": "Group"
         }
     },
     "setting": {

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -127,7 +127,9 @@
             "sortByCount": "次数",
             "sortByTokens": "Tokens",
             "noData": "暂无排行数据",
-            "successRate": "成功率"
+            "successRate": "成功率",
+            "channel": "渠道",
+            "group": "分组"
         }
     },
     "setting": {

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -127,7 +127,9 @@
             "sortByCount": "次數",
             "sortByTokens": "Tokens",
             "noData": "暫無排行數據",
-            "successRate": "成功率"
+            "successRate": "成功率",
+            "channel": "渠道",
+            "group": "分組"
         }
     },
     "setting": {


### PR DESCRIPTION
## 摘要

- 首页排行榜新增「渠道/分组」维度切换，分组维度按成本/请求数/Token 排名（后端新增 `/api/v1/stats/group` 聚合接口）
- 修复启动时未加载模型统计缓存导致分组排行榜为空的问题

## 提交前检查 | Pre-submission Checklist

- [x] 本次 PR 仅包含一个变更主题 | This PR contains only one change topic
- [x] 本次 PR 不包含测试文件 | This PR contains no test files
- [x] AI 参与的内容已完成人工审查 | AI-assisted content has been manually reviewed