### PR TITLE
fix: :bug: 数据库导入分批写入规避绑定参数上限

### DIFF
--- a/internal/op/backup.go
+++ b/internal/op/backup.go
@@ -151,11 +151,15 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 	return res, nil
 }
 
+// batchSize 控制每次 INSERT 的最大行数。
+// 单行字段数较多（如 stats_hourly 含 9 个字段），若一次插入过多行会超过数据库绑定参数上限（SQLite/PostgreSQL 为 65535），按行数分批写入可规避该限制。
+const batchSize = 2000
+
 func createDoNothing[T any](tx *gorm.DB, rows []T) (int64, error) {
 	if len(rows) == 0 {
 		return 0, nil
 	}
-	result := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows)
+	result := tx.Clauses(clause.OnConflict{DoNothing: true}).CreateInBatches(&rows, batchSize)
 	return result.RowsAffected, result.Error
 }
 
@@ -166,7 +170,7 @@ func createUpsertAll[T any](tx *gorm.DB, rows []T, columns []clause.Column) (int
 	result := tx.Clauses(clause.OnConflict{
 		Columns:   columns,
 		UpdateAll: true,
-	}).Create(&rows)
+	}).CreateInBatches(&rows, batchSize)
 	return result.RowsAffected, result.Error
 }
 


### PR DESCRIPTION
- createDoNothing/createUpsertAll 改用 CreateInBatches 分批写入
- 单批 2000 行，避免 stats_hourly 等大数据量表单条 INSERT 超出 数据库 65535 绑定参数上限（SQLite/PostgreSQL）

## 提交前检查 | Pre-submission Checklist

- [x] 本次 PR 仅包含一个变更主题 | This PR contains only one change topic
- [x] 本次 PR 不包含测试文件 | This PR contains no test files
- [x] AI 参与的内容已完成人工审查 | AI-assisted content has been manually reviewed
