### PR TITLE
fix: :bug: 导入前过滤孤儿统计行规避外键约束错误

### DIFF
--- a/internal/op/backup.go
+++ b/internal/op/backup.go
@@ -78,7 +78,7 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 	res := &model.DBImportResult{RowsAffected: map[string]int64{}}
 
 	err := conn.Transaction(func(tx *gorm.DB) error {
-		// base tables
+		// 先导入无外键依赖的基础表：channels、groups、api_keys，只有这些表就位后才可查询有效主键集合来过滤孤儿引用。
 		if n, err := createDoNothing(tx, dump.Channels); err != nil {
 			return fmt.Errorf("import channels: %w", err)
 		} else {
@@ -89,6 +89,17 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 		} else {
 			res.RowsAffected["groups"] = n
 		}
+		if n, err := createDoNothing(tx, dump.APIKeys); err != nil {
+			return fmt.Errorf("import api_keys: %w", err)
+		} else {
+			res.RowsAffected["api_keys"] = n
+		}
+
+		// 过滤掉引用已不存在主键的孤儿记录（如渠道被删除后残留的 stats_channel / stats_model，导入时会触发外键约束错误）。
+		if err := sanitizeOrphanRows(tx, dump); err != nil {
+			return err
+		}
+
 		if n, err := createDoNothing(tx, dump.GroupItems); err != nil {
 			return fmt.Errorf("import group_items: %w", err)
 		} else {
@@ -98,11 +109,6 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 			return fmt.Errorf("import llm_infos: %w", err)
 		} else {
 			res.RowsAffected["llm_infos"] = n
-		}
-		if n, err := createDoNothing(tx, dump.APIKeys); err != nil {
-			return fmt.Errorf("import api_keys: %w", err)
-		} else {
-			res.RowsAffected["api_keys"] = n
 		}
 		if n, err := createUpsertSettings(tx, dump.Settings); err != nil {
 			return fmt.Errorf("import settings: %w", err)
@@ -149,6 +155,85 @@ func DBImportIncremental(ctx context.Context, dump *model.DBDump) (*model.DBImpo
 		return nil, err
 	}
 	return res, nil
+}
+
+// sanitizeOrphanRows 过滤 dump 中引用已不存在主键的孤儿记录。
+// stats_channel / stats_model 引用 channels.id，stats_api_key 引用 api_keys.id。
+// 若源库中这些渠道/密钥已被删除，导出文件会残留对应统计行，导入时触发外键约束错误（如 PostgreSQL 的 fk_channels_stats / SQLSTATE 23503）。
+// 过滤在事务内、基础表写入后进行，此时已能查询到有效主键集合。
+func sanitizeOrphanRows(tx *gorm.DB, dump *model.DBDump) error {
+	// 渠道主键集合（来自导入数据 + 数据库中已存在的渠道）。
+	channelIDs := make(map[int]struct{}, len(dump.Channels))
+	for _, c := range dump.Channels {
+		if c.ID != 0 {
+			channelIDs[c.ID] = struct{}{}
+		}
+	}
+	// 合并数据库中已有的渠道 id（增量导入时 dump 可能只含部分渠道）。
+	var dbChannelIDs []int
+	if err := tx.Model(&model.Channel{}).Pluck("id", &dbChannelIDs).Error; err != nil {
+		return fmt.Errorf("query channels for orphan filtering: %w", err)
+	}
+	for _, id := range dbChannelIDs {
+		channelIDs[id] = struct{}{}
+	}
+
+	if len(dump.StatsChannel) > 0 {
+		kept := dump.StatsChannel[:0]
+		for _, s := range dump.StatsChannel {
+			if _, ok := channelIDs[s.ChannelID]; ok {
+				kept = append(kept, s)
+			}
+		}
+		dropped := len(dump.StatsChannel) - len(kept)
+		dump.StatsChannel = kept
+		if dropped > 0 {
+			fmt.Printf("[import] dropped %d orphaned stats_channel row(s)\n", dropped)
+		}
+	}
+	if len(dump.StatsModel) > 0 {
+		kept := dump.StatsModel[:0]
+		for _, s := range dump.StatsModel {
+			if _, ok := channelIDs[s.ChannelID]; ok {
+				kept = append(kept, s)
+			}
+		}
+		dropped := len(dump.StatsModel) - len(kept)
+		dump.StatsModel = kept
+		if dropped > 0 {
+			fmt.Printf("[import] dropped %d orphaned stats_model row(s)\n", dropped)
+		}
+	}
+
+	// API key 主键集合（来自导入数据 + 数据库中已存在的密钥）。
+	apiKeyIDs := make(map[int]struct{}, len(dump.APIKeys))
+	for _, k := range dump.APIKeys {
+		if k.ID != 0 {
+			apiKeyIDs[k.ID] = struct{}{}
+		}
+	}
+	var dbAPIKeyIDs []int
+	if err := tx.Model(&model.APIKey{}).Pluck("id", &dbAPIKeyIDs).Error; err != nil {
+		return fmt.Errorf("query api_keys for orphan filtering: %w", err)
+	}
+	for _, id := range dbAPIKeyIDs {
+		apiKeyIDs[id] = struct{}{}
+	}
+	if len(dump.StatsAPIKey) > 0 {
+		kept := dump.StatsAPIKey[:0]
+		for _, s := range dump.StatsAPIKey {
+			if _, ok := apiKeyIDs[s.APIKeyID]; ok {
+				kept = append(kept, s)
+			}
+		}
+		dropped := len(dump.StatsAPIKey) - len(kept)
+		dump.StatsAPIKey = kept
+		if dropped > 0 {
+			fmt.Printf("[import] dropped %d orphaned stats_api_key row(s)\n", dropped)
+		}
+	}
+
+	return nil
 }
 
 func createDoNothing[T any](tx *gorm.DB, rows []T) (int64, error) {


### PR DESCRIPTION
- 新增 sanitizeOrphanRows，导入前过滤引用已删除渠道/密钥的孤儿统计行， 避免触发 PostgreSQL fk_channels_stats 外键约束错误（SQLSTATE 23503）
- 调整导入顺序：先写入 channels/groups/api_keys 等基础表，再过滤孤儿引用

## 提交前检查 | Pre-submission Checklist

- [x] 本次 PR 仅包含一个变更主题 | This PR contains only one change topic
- [x] 本次 PR 不包含测试文件 | This PR contains no test files
- [x] AI 参与的内容已完成人工审查 | AI-assisted content has been manually reviewed
