### PR TITLE
fix(update): retire the running executable before extracting the update on Windows

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bestruirui/octopus/internal/op"
 	"github.com/bestruirui/octopus/internal/server"
 	"github.com/bestruirui/octopus/internal/task"
+	"github.com/bestruirui/octopus/internal/update"
 	"github.com/bestruirui/octopus/internal/utils/shutdown"
 	"github.com/charmbracelet/log"
 	"github.com/spf13/cobra"
@@ -24,6 +25,7 @@ var startCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
+		update.CleanupRetiredExecutable()
 		shutdown.Init(log.Default())
 		if err := db.InitDB(conf.AppConfig.Database.Type, conf.AppConfig.Database.Path, conf.IsDebug()); err != nil {
 			log.Errorf("database init error: %v", err)

--- a/internal/update/core.go
+++ b/internal/update/core.go
@@ -35,14 +35,65 @@ func UpdateCore() error {
 		return err
 	}
 
+	retired := ""
+	if runtime.GOOS == "windows" {
+		// Windows holds the image file of a running process open without
+		// sharing write access, so extracting the new binary over it fails
+		// with "Access is denied". Renaming the image aside is allowed.
+		retired, err = retireExecutable(execPath)
+		if err != nil {
+			log.Warnf("retire old executable failed: %v", err)
+			return err
+		}
+	}
+
 	if err := unzip(data, filepath.Dir(execPath)); err != nil {
 		log.Warnf("unzip failed: %v", err)
+		// put the retired binary back so the running one stays usable
+		if retired != "" {
+			if rbErr := os.Rename(retired, execPath); rbErr != nil {
+				log.Warnf("restore retired executable failed: %v", rbErr)
+			}
+		}
 		return err
 	}
 
 	log.Infof("update core success")
 	go restartExecutable(execPath)
 	return nil
+}
+
+// retiredExecutableSuffix is appended to the running executable's path when a
+// self-update moves it aside so the new binary can take its place.
+const retiredExecutableSuffix = ".old"
+
+// retireExecutable renames the running executable aside so an update archive
+// can place the new binary at the original path. Windows opens the image file
+// of a running process without sharing write or delete access, so extracting
+// over it fails with "Access is denied", while renaming the image is allowed.
+func retireExecutable(execPath string) (string, error) {
+	retired := execPath + retiredExecutableSuffix
+	if err := os.Remove(retired); err != nil && !os.IsNotExist(err) {
+		// surface real errors (locked files will fail the rename below anyway)
+		return "", fmt.Errorf("remove stale %s failed: %w", retired, err)
+	}
+	if err := os.Rename(execPath, retired); err != nil {
+		return "", err
+	}
+	return retired, nil
+}
+
+// CleanupRetiredExecutable removes the leftover binary from a previous
+// self-update. Best effort: if the previous instance has not fully exited yet
+// the file is still locked and will be cleaned up on the following start.
+func CleanupRetiredExecutable() {
+	execPath, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if err := os.Remove(execPath + retiredExecutableSuffix); err != nil && !os.IsNotExist(err) {
+		log.Debugf("cleanup retired executable failed: %v", err)
+	}
 }
 
 // getDownloadFilename 返回当前平台对应的发布归档名称。

--- a/internal/update/core_test.go
+++ b/internal/update/core_test.go
@@ -1,0 +1,151 @@
+package update
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// buildZipWithEntry builds an in-memory archive containing a single file with
+// the given name and content.
+func buildZipWithEntry(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	f, err := w.Create(name)
+	if err != nil {
+		t.Fatalf("create zip entry: %v", err)
+	}
+	if _, err := f.Write([]byte(content)); err != nil {
+		t.Fatalf("write zip entry: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestUnzipCannotOverwriteRunningExecutable documents why UpdateCore retires
+// the executable before unzipping on Windows: the image file of a running
+// process is held open without write sharing, so extracting the update
+// archive over it fails with "Access is denied" (issue #347).
+func TestUnzipCannotOverwriteRunningExecutable(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only behavior")
+	}
+	execPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	data := buildZipWithEntry(t, filepath.Base(execPath), "replacement")
+	if err := unzip(data, filepath.Dir(execPath)); err == nil {
+		// If overwriting the running binary suddenly works, the retire step
+		// is no longer needed; fail so this can be revisited.
+		t.Fatal("unzip over the running executable unexpectedly succeeded")
+	}
+}
+
+// TestRetireThenUnzipSucceeds verifies the fix for issue #347: the running
+// executable is renamed aside first, the archive then extracts cleanly onto
+// the original path, and restoring works.
+func TestRetireThenUnzipSucceeds(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only behavior")
+	}
+	execPath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	orig, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatalf("read executable: %v", err)
+	}
+	if len(orig) == 0 {
+		t.Fatal("empty executable")
+	}
+
+	retired, err := retireExecutable(execPath)
+	if err != nil {
+		t.Fatalf("retire executable: %v", err)
+	}
+	if _, err := os.Stat(retired); err != nil {
+		t.Fatalf("retired binary missing: %v", err)
+	}
+
+	restore := func() {
+		os.Remove(execPath)
+		if err := os.Rename(retired, execPath); err != nil {
+			t.Fatalf("restore executable: %v", err)
+		}
+	}
+	defer restore()
+
+	data := buildZipWithEntry(t, filepath.Base(execPath), "replacement")
+	if err := unzip(data, filepath.Dir(execPath)); err != nil {
+		t.Fatalf("unzip after retire: %v", err)
+	}
+	got, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatalf("read new executable: %v", err)
+	}
+	if string(got) != "replacement" {
+		t.Fatalf("unexpected content %q", got)
+	}
+}
+
+// TestRetireExecutableReplacesStaleCopy ensures a leftover .old file from an
+// interrupted update does not block the next self-update.
+func TestRetireExecutableReplacesStaleCopy(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "octopus.exe")
+	if err := os.WriteFile(execPath, []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := execPath + retiredExecutableSuffix
+	if err := os.WriteFile(stale, []byte("stale"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	retired, err := retireExecutable(execPath)
+	if err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if retired != stale {
+		t.Fatalf("expected retired path %q, got %q", stale, retired)
+	}
+	got, err := os.ReadFile(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("stale copy not replaced, content %q", got)
+	}
+}
+
+// TestCleanupRetiredExecutable covers the startup cleanup path.
+func TestCleanupRetiredExecutable(t *testing.T) {
+	dir := t.TempDir()
+	execPath := filepath.Join(dir, "octopus.exe")
+	if err := os.WriteFile(execPath, []byte("current"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// point the cleanup at our temp copy via a saved cwd switch: os.Executable
+	// returns the test binary, so exercise the remove-only path instead.
+	retired, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	retired += retiredExecutableSuffix
+	if err := os.WriteFile(retired, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	CleanupRetiredExecutable()
+	if _, err := os.Stat(retired); !os.IsNotExist(err) {
+		t.Fatalf("retired executable not cleaned up: %v", err)
+	}
+	// second run must be a no-op when nothing is left over
+	CleanupRetiredExecutable()
+	_ = execPath
+}


### PR DESCRIPTION
## 问题

在 Windows 上通过 WebUI 自更新时，解压更新包失败（#347）：

```
WARN unzip failed: remove ...\octopus.exe: Access is denied
```

Windows 会以不共享写权限的方式持有运行中进程的镜像文件，因此 `extractFile` 在 `os.OpenFile`/`os.Remove` 覆盖正在运行的 `octopus.exe` 时被拒绝，更新流程在解压阶段即中断。

## 修复

- 解压前先把运行中的可执行文件重命名为 `octopus.exe.old`（Windows 允许重命名正在运行的镜像，但不允许覆盖写入）；
- 若解压失败，把 `.old` 改回原路径，保证旧版本仍可运行；
- 下次启动时（`cmd/start.go`）清理残留的 `.old` 文件，若上个进程尚未完全退出则留待下次清理。

非 Windows 平台行为不变。

## 测试

以运行中的测试二进制本身模拟被锁定的 exe：

- `TestUnzipCannotOverwriteRunningExecutable`：直接对运行中的二进制解压必然失败（Access is denied），固化问题根因；
- `TestRetireThenUnzipSucceeds`：先 retire 再解压成功，新文件落到原路径 —— 在未修复代码上该路径必然失败；
- `TestRetireExecutableReplacesStaleCopy`：残留 `.old` 不会阻塞下次更新；
- `TestCleanupRetiredExecutable`：启动清理幂等。

`go build ./...` 与 `go test ./internal/update/` 在 Windows 上全部通过。

Fixes #347
