### PR TITLE
feat: 增加请求首字耗时与输出速度指标

### DIFF
--- a/internal/relay/handler.go
+++ b/internal/relay/handler.go
@@ -234,7 +234,7 @@ func Forward(format llm.APIFormat) gin.HandlerFunc {
 				metrics.RequestSuccess = 1
 				_ = op.ChannelStatsUpdate(channel.ID, metrics)
 				_ = op.ChannelModelStatsUpdate(channelModel.ID, metrics)
-				request.markCommitted()
+				request.markCommitted(false)
 				n, err := c.Writer.Write(result.body)
 				if err == nil && n != len(result.body) {
 					err = io.ErrShortWrite
@@ -270,7 +270,7 @@ func Forward(format llm.APIFormat) gin.HandlerFunc {
 						break
 					}
 					if !committed {
-						request.markCommitted()
+						request.markCommitted(true)
 						committed = true
 					}
 					n, writeErr := c.Writer.Write(encoded.Bytes())
@@ -282,6 +282,9 @@ func Forward(format llm.APIFormat) gin.HandlerFunc {
 						break
 					}
 					c.Writer.Flush()
+					if streamEventHasText(format, event) {
+						request.markFirstToken()
+					}
 				}
 				if last {
 					break

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -157,6 +157,48 @@ func inspectStreamEvent(format llm.APIFormat, event *httpclient.StreamEvent) (bo
 	}
 }
 
+// streamEventHasText 判断客户端协议事件是否携带实际可见文本; 角色、ID、用量和结束事件不算首字。
+func streamEventHasText(format llm.APIFormat, event *httpclient.StreamEvent) bool {
+	if event == nil || len(event.Data) == 0 {
+		return false
+	}
+
+	switch format {
+	case llm.APIFormatOpenAIChatCompletion:
+		var parsed struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if json.Unmarshal(event.Data, &parsed) != nil {
+			return false
+		}
+		for _, choice := range parsed.Choices {
+			if choice.Delta.Content != "" {
+				return true
+			}
+		}
+	case llm.APIFormatOpenAIResponse:
+		var parsed struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		}
+		return json.Unmarshal(event.Data, &parsed) == nil && parsed.Type == "response.output_text.delta" && parsed.Delta != ""
+	case llm.APIFormatAnthropicMessage:
+		var parsed struct {
+			Type  string `json:"type"`
+			Delta struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"delta"`
+		}
+		return json.Unmarshal(event.Data, &parsed) == nil && parsed.Type == "content_block_delta" && parsed.Delta.Type == "text_delta" && parsed.Delta.Text != ""
+	}
+	return false
+}
+
 // validateResponse 检查统一响应中需要在提交前判定为失败的终止原因; 仅 Responses 协议会以正常响应下发这类终态。
 func validateResponse(format llm.APIFormat, response *llm.Response) error {
 	if response == nil {

--- a/internal/relay/state.go
+++ b/internal/relay/state.go
@@ -25,13 +25,15 @@ const (
 
 // 客户端请求的完整进程内状态, 同时作为状态流的消息形状; 上半部分在请求到达时写入并在结束时定稿, 下半部分每轮循环覆盖。
 type RequestState struct {
-	ID        uint64        `json:"id"`         // 请求在当前进程内的唯一标识。
-	Status    Status        `json:"status"`     // 请求当前状态。
-	StartedAt time.Time     `json:"started_at"` // 请求到达时间。
-	Duration  time.Duration `json:"duration"`   // 请求总耗时, 未结束时为零。
-	Model     string        `json:"model"`      // 客户端请求的模型名称, 即分组名称。
-	Usage     llm.Usage     `json:"usage"`      // 请求结束时写入的展示用量。
-	Cost      float64       `json:"cost"`       // 请求结束时写入的累计费用。
+	ID                    uint64        `json:"id"`                       // 请求在当前进程内的唯一标识。
+	Status                Status        `json:"status"`                   // 请求当前状态。
+	StartedAt             time.Time     `json:"started_at"`               // 请求到达时间。
+	Duration              time.Duration `json:"duration"`                 // 请求总耗时, 未结束时为零。
+	FirstTokenDuration    time.Duration `json:"first_token_duration"`     // 首次向客户端写出有效文本的耗时。
+	OutputTokensPerSecond float64       `json:"output_tokens_per_second"` // 首字后按完成 Token 计算的输出速度。
+	Model                 string        `json:"model"`                    // 客户端请求的模型名称, 即分组名称。
+	Usage                 llm.Usage     `json:"usage"`                    // 请求结束时写入的展示用量。
+	Cost                  float64       `json:"cost"`                     // 请求结束时写入的累计费用。
 
 	Round         int    `json:"round"`           // 最新一轮循环的递增序号, 人工中止按此匹配以免误杀下一轮。
 	TargetChannel string `json:"target_channel"`  // 最新一轮选中的渠道名称。
@@ -42,6 +44,7 @@ type RequestState struct {
 	body         string             // 客户端原始请求体, 体积大故不进状态流, 由独立接口按需拉取。
 	responseBody string             // 聚合后的完整最终响应体, 同样按需拉取。
 	apiKeyID     int                // 发起请求的 API Key ID, 用于请求完成后的归属统计。
+	streaming    bool               // 是否为流式响应, 非流式响应不计算生成速度。
 	cancel       context.CancelFunc // 中止最新一轮上游请求, 仅在该轮等待响应期间非空。
 }
 
@@ -49,8 +52,8 @@ const streamBuffer = 16 // 单个状态流连接的非阻塞消息缓冲容量�
 const maxFinished = 50  // 进程内最多保留的已结束请求数量。
 
 var (
-	idSeq    atomic.Uint64                     // 进程内严格递增的请求 ID。
-	mu       sync.Mutex                        // 全部共享状态的互斥锁。
+	idSeq    atomic.Uint64                          // 进程内严格递增的请求 ID。
+	mu       sync.Mutex                             // 全部共享状态的互斥锁。
 	requests = make(map[uint64]*RequestState)       // 按请求 ID 保存的全部请求状态。
 	watchers = make(map[chan RequestState]struct{}) // 全部状态流 SSE 连接。
 )
@@ -126,11 +129,24 @@ func (r *RequestState) wait(ctx context.Context, seconds int) bool {
 }
 
 // markCommitted 标记响应已提交; 流式响应在此之后仍会持续转发, 故必须先于提交动作调用。
-func (r *RequestState) markCommitted() {
+func (r *RequestState) markCommitted(streaming bool) {
 	mu.Lock()
 	defer mu.Unlock()
 
 	r.Status = StatusCommitted
+	r.streaming = streaming
+	publishRequestLocked(r)
+}
+
+// markFirstToken 记录首个有效文本已经刷新给客户端; 元数据事件不算首字。
+func (r *RequestState) markFirstToken() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if r.FirstTokenDuration != 0 {
+		return
+	}
+	r.FirstTokenDuration = time.Since(r.StartedAt)
 	publishRequestLocked(r)
 }
 
@@ -181,6 +197,12 @@ func (r *RequestState) finishLocked(usage *llm.Usage) {
 	metrics := usageMetrics(r.TargetModel, usage)
 	r.Cost = metrics.InputCost + metrics.OutputCost
 	r.Duration = time.Since(r.StartedAt)
+	if r.streaming && r.FirstTokenDuration > 0 && usage != nil && usage.CompletionTokens > 0 {
+		generationDuration := r.Duration - r.FirstTokenDuration
+		if generationDuration > 0 {
+			r.OutputTokensPerSecond = float64(usage.CompletionTokens) / generationDuration.Seconds()
+		}
+	}
 	metrics.WaitTime = r.Duration.Milliseconds()
 	if r.Status == StatusSuccess {
 		metrics.RequestSuccess = 1

--- a/web/src/api/log.ts
+++ b/web/src/api/log.ts
@@ -22,6 +22,8 @@ export interface RelayLogOverview {
     status: RequestState;
     started_at: string;
     duration: number;
+    first_token_duration: number;
+    output_tokens_per_second: number;
     model: string;
     usage: RelayUsage;
     cost: number;

--- a/web/src/components/modules/log/Item.tsx
+++ b/web/src/components/modules/log/Item.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useMemo, useState, type CSSProperties } from 'react';
-import { AlertCircle, ArrowDownToLine, ArrowRight, ArrowUpFromLine, Clock, Cpu, Database, DollarSign, Loader2, Square } from 'lucide-react';
+import { AlertCircle, ArrowDownToLine, ArrowRight, ArrowUpFromLine, Clock, Cpu, Database, DollarSign, Gauge, Loader2, Square, Timer } from 'lucide-react';
 import { useTranslations } from 'use-intl';
 import JsonView from '@uiw/react-json-view';
 import { githubDarkTheme } from '@uiw/react-json-view/githubDark';
@@ -47,14 +47,23 @@ function formatMilliseconds(value: number) {
 
 // LogMetrics 渲染耗时, 费用和 Token 指标; card 变体用于卡片栅格, footer 变体用于弹窗底部。
 function LogMetrics({ log, now, brandColor, variant }: { log: RelayLogOverview; now: number; brandColor: string; variant: 'card' | 'footer' }) {
+    const t = useTranslations('log.card');
     const cachedTokens = log.usage.prompt_tokens_details?.cached_tokens ?? 0;
     // 进行中的请求按共享时钟推算耗时, 结束后改用后端记录的最终耗时。
     const duration = log.status === 'running' || log.status === 'committed'
         ? formatMilliseconds(now - new Date(log.started_at).getTime())
         : formatMilliseconds(log.duration / 1_000_000);
+    const firstTokenDuration = log.first_token_duration > 0
+        ? formatMilliseconds(log.first_token_duration / 1_000_000)
+        : '--';
+    const outputSpeed = log.output_tokens_per_second > 0
+        ? `${log.output_tokens_per_second.toFixed(1)} t/s`
+        : '--';
     const metrics = [
         { key: 'time', Icon: Clock, iconClassName: 'size-3.5 shrink-0', iconStyle: { color: brandColor } as CSSProperties, value: formatTime(log.started_at), valueClassName: 'tabular-nums', cellClassName: 'col-span-4 whitespace-nowrap md:col-span-1' },
         { key: 'duration', Icon: Cpu, iconClassName: 'size-3.5 shrink-0 text-blue-500', value: duration, cellClassName: 'col-span-4 md:col-span-1' },
+        { key: 'firstToken', Icon: Timer, iconClassName: 'size-3.5 shrink-0 text-amber-500', value: firstTokenDuration, cellClassName: 'col-span-4 md:col-span-1' },
+        { key: 'outputSpeed', Icon: Gauge, iconClassName: 'size-3.5 shrink-0 text-violet-500', value: outputSpeed, cellClassName: 'col-span-4 md:col-span-1' },
         { key: 'cost', Icon: DollarSign, iconClassName: 'size-3.5 shrink-0 text-emerald-500', value: log.cost.toFixed(6), valueClassName: 'font-medium text-emerald-600 dark:text-emerald-400', cellClassName: 'col-span-4 md:col-span-1' },
         { key: 'prompt', Icon: ArrowDownToLine, iconClassName: 'size-3.5 shrink-0 text-green-500', value: (log.usage.prompt_tokens - cachedTokens).toLocaleString(), cellClassName: 'col-span-3 md:col-span-1' },
         { key: 'cached', Icon: Database, iconClassName: 'size-3.5 shrink-0 text-cyan-500', value: cachedTokens.toLocaleString(), cellClassName: 'col-span-3 md:col-span-1' },
@@ -63,7 +72,7 @@ function LogMetrics({ log, now, brandColor, variant }: { log: RelayLogOverview; 
     ];
 
     return metrics.map((metric) => (
-        <div key={metric.key} className={cn('flex items-center gap-1.5', variant === 'card' && metric.cellClassName)}>
+        <div key={metric.key} title={metric.key === 'firstToken' ? t('firstToken') : metric.key === 'outputSpeed' ? t('outputSpeed') : undefined} className={cn('flex items-center gap-1.5', variant === 'card' && metric.cellClassName)}>
             <metric.Icon className={metric.iconClassName} style={metric.iconStyle} />
             <span className={metric.valueClassName}>{metric.value}</span>
         </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -425,6 +425,8 @@
             "noRequestContent": "(No request content)",
             "noResponseContent": "(No response content)",
             "tokens": "tokens",
+            "firstToken": "First token",
+            "outputSpeed": "Output speed",
             "retryIndex": "Retry {index}",
             "retryDetails": "Retry Details",
             "stopRound": "Stop Current Round",

--- a/web/src/locales/zh_hans.json
+++ b/web/src/locales/zh_hans.json
@@ -425,6 +425,8 @@
             "noRequestContent": "(无请求内容)",
             "noResponseContent": "(无响应内容)",
             "tokens": "词元",
+            "firstToken": "首字耗时",
+            "outputSpeed": "输出速度",
             "retryIndex": "重试 {index}",
             "retryDetails": "重试详情",
             "stopRound": "停止当前轮次",

--- a/web/src/locales/zh_hant.json
+++ b/web/src/locales/zh_hant.json
@@ -425,6 +425,8 @@
             "noRequestContent": "(無請求內容)",
             "noResponseContent": "(無回應內容)",
             "tokens": "詞元",
+            "firstToken": "首字耗時",
+            "outputSpeed": "輸出速度",
             "retryIndex": "重試 {index}",
             "retryDetails": "重試詳情",
             "stopRound": "停止目前輪次",


### PR DESCRIPTION
## 功能

- 在实时请求日志中记录端到端首字耗时
- 首字仅识别实际文本增量，排除角色、ID、用量和结束事件
- 按完成 Token /（总耗时 - 首字耗时）计算流式输出速度
- 支持 OpenAI Chat Completions、Responses 与 Anthropic Messages
- 日志卡片和详情展示首字耗时及输出速度，并补充三种语言文案
- 非流式请求或缺少用量时不生成误导性的输出速度

## 兼容性

仅向进程内日志 SSE 状态追加字段，不涉及数据库迁移，也不改变现有请求转发协议。

## 验证

- `go test ./...`
- `go build -trimpath -tags=jsoniter .`
- `cd web && pnpm build`

`pnpm lint` 仍被仓库现有 ESLint 问题阻挡，本次改动未新增相关诊断。