### PR TITLE
fix: :bug: 恢复 developer -> system 角色转换 (regression of #19)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/samber/lo v1.53.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
+	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
@@ -94,7 +95,6 @@ require (
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tidwall/gjson v1.19.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tmaxmax/go-sse v0.11.0 // indirect

--- a/internal/relay/upstream.go
+++ b/internal/relay/upstream.go
@@ -18,6 +18,8 @@ import (
 	"github.com/looplj/axonhub/llm/transformer/anthropic"
 	"github.com/looplj/axonhub/llm/transformer/openai"
 	"github.com/looplj/axonhub/llm/transformer/openai/responses"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // upstreamResponse 是已验证但尚未写给客户端的上游成功响应; events 为 nil 表示非流式响应。
@@ -119,7 +121,34 @@ type conversionMiddleware struct {
 
 // OnOutboundRawRequest 在转换后的上游请求上应用渠道参数和自定义 Header。
 func (m *conversionMiddleware) OnOutboundRawRequest(_ context.Context, request *httpclient.Request) (*httpclient.Request, error) {
+	normalizeDeveloperRole(m.format, request)
 	return request, applyChannelConfig(m.channel, request)
+}
+
+// normalizeDeveloperRole 把转换后 chat completions 请求里 messages 的 developer 角色归一化为 system。
+// developer 是 OpenAI Responses 协议对 system 的替代角色, 客户端 (如 Codex) 会用它携带指令;
+// 部分 OpenAI 兼容上游不接受该角色而直接报错, 归一化后语义等价且兼容性更好。
+func normalizeDeveloperRole(format llm.APIFormat, request *httpclient.Request) {
+	if format != llm.APIFormatOpenAIChatCompletion {
+		return
+	}
+	messages := gjson.GetBytes(request.Body, "messages")
+	if !messages.IsArray() {
+		return
+	}
+	for i, message := range messages.Array() {
+		if message.Get("role").String() != "developer" {
+			continue
+		}
+		body, err := sjson.SetBytes(request.Body, fmt.Sprintf("messages.%d.role", i), "system")
+		if err != nil {
+			return
+		}
+		request.Body = body
+	}
+	if len(request.JSONBody) > 0 {
+		request.JSONBody = slices.Clone(request.Body)
+	}
 }
 
 // OnOutboundRawError 保留上游错误状态码携带的原始正文。


### PR DESCRIPTION
## 提交前检查 | Pre-submission Checklist

- [x] 本次 PR 仅包含一个变更主题 | This PR contains only one change topic
- [x] 本次 PR 不包含测试文件 | This PR contains no test files
- [x] AI 参与的内容已完成人工审查 | AI-assisted content has been manually reviewed

## 变更说明

这是 #19 的回归修复。

- d98f2ce 曾在旧转换层 (`internal/transformer/outbound/openai/chat.go`) 把 chat 出站请求里的 `developer` 角色统一转为 `system` (fix #19)。
- 97d6a04 (API 转换迁移到 axonhub/llm) 删除旧转换层时，该修复被一并移除；替代实现 axonhub responses inbound 以 `Role: item.Role` 原样透传，`developer` 角色重新直达上游。

部分 OpenAI 兼容上游 (仅接受 `system/user/assistant`，例如部分 new-api 中转) 会直接拒绝该角色，导致跨协议 (Responses -> Chat Completions) 请求持续失败；在 manual 分组下配合错误屏蔽表现为无限重试，客户端 (Codex) 长时间停留在 working 状态。此前反馈的"中断 Codex 后日志仍在重试"是同一现象的延续：中断操作不会立即关闭 HTTP 连接，重试会一直持续到 Codex 自身的 HTTP 超时 (实测单请求约 600s / 55 轮)。

复现提示：手工构造的简单 Responses 请求不会触发；需要 input 中实际包含 `developer` 角色消息 (新版 Codex 启用 skills 时会发送)，且上游拒绝该角色。

本 PR 在 `conversionMiddleware` 的 `OnOutboundRawRequest` 出站钩子把转换后 chat completions 请求中 `messages` 的 `developer` 角色归一化为 `system`，与 `applyChannelConfig` 位于同一位置，语义与 d98f2ce 一致。

## 验证

- 同一请求体直接请求上游：`developer` 消息被拒绝；仅把角色改为 `system` 后同内容成功。
- 重放真实 Codex 请求 (约 75KB，含 skills 注入的 developer 消息)：补丁前每轮失败；补丁后同一请求获得 `response.completed`。
- `go build ./...` 与 `go vet ./internal/relay/` 通过。

Fixes #19
