### PR TITLE
fix: 立即刷新空日志 SSE 流

### DIFF
--- a/internal/server/handlers/log.go
+++ b/internal/server/handlers/log.go
@@ -87,6 +87,13 @@ func streamOverview(c *gin.Context) {
 	prepareSSE(c)
 	snapshot, updates := relay.OpenRequestStream()
 	defer relay.CloseRequestStream(updates)
+	if len(snapshot) == 0 {
+		// Flush a real SSE comment so proxies forward the empty-state response immediately.
+		if _, err := c.Writer.Write([]byte(": connected\n\n")); err != nil {
+			return
+		}
+		c.Writer.Flush()
+	}
 	for _, request := range snapshot {
 		if err := sse.Encode(c.Writer, sse.Event{Event: "log", Data: request}); err != nil {
 			return


### PR DESCRIPTION
## 提交前检查 | Pre-submission Checklist

- [x] 本次 PR 仅包含一个变更主题 | This PR contains only one change topic
- [x] 本次 PR 不包含测试文件 | This PR contains no test files
- [x] AI 参与的内容已完成人工审查 | AI-assisted content has been manually reviewed
## 问题
- 空日志场景下，SSE 响应虽然已经建立，但服务端没有立即写入并刷新任何数据。
- 由于响应缺少首个可刷新的数据块，前端的连接状态更新会延迟到下一次心跳或真实日志到达，表现为日志页面长时间加载后才显示“暂无日志”。

## 修复方案

- 当初始日志快照为空时，服务端立即写入一个 SSE comment : connected\n\n，并调用 Flush() 将响应发送给客户端。

- 该 comment 仅用于及时刷新 SSE 连接，不会触发前端的 log 事件，也不会生成虚假的日志记录。连接仍然保持打开，后续新增日志继续通过原有SSE 流推送。

## 行为变化

- 无日志时，日志页面可以立即结束加载状态并显示“暂无日志”。
  
## 验证

- 已运行 go test ./...，测试通过。
- 已在 Docker 环境验证空日志卡顿修复，以及一次日志模拟。